### PR TITLE
fix: tighten Docker publish timeout

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,17 +21,14 @@ jobs:
   docker:
     name: Build & Push Docker Image
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 12
 
     steps:
       # ── 1. Checkout (needed for path context so .dockerignore is respected) ──
       - name: Checkout
         uses: actions/checkout@v6
 
-      # ── 2. Multi-platform support ───────────────────────────────────────────
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
+      # ── 2. Buildx support ───────────────────────────────────────────────────
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -72,7 +69,9 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          # Keep the main publish path fast. Restore multi-arch once issue #29
+          # is solved without QEMU-heavy builds on every push.
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,8 +69,8 @@ jobs:
         with:
           context: .
           push: true
-          # Keep the main publish path fast. Restore multi-arch once issue #29
-          # is solved without QEMU-heavy builds on every push.
+          # Keep publish runs fast for main and tag events. Restore multi-arch
+          # once issue #29 is solved without QEMU-heavy builds.
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- Tighten `Publish Docker Image` from a 30 minute timeout to 12 minutes.
- Stop running QEMU-backed ARM64 image publishing on publish events for now.
- Keep published images on `linux/amd64` and track fast multi-arch restoration in #29.

## Context

The previous main publish run was cancelled after 17m15s while still inside `docker/build-push-action`. The slow path was a multi-arch Buildx publish (`linux/amd64,linux/arm64`) on GitHub-hosted x64 runners, so ARM64 was likely paying QEMU emulation cost.

## Tracking

- Restore fast multi-arch publishing: https://github.com/theFactoryHQ/factory-careers/issues/29

## Validation

- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker-publish.yml'); puts 'ok .github/workflows/docker-publish.yml'"`
