### PR TITLE
fix: restore auth session middleware and Render npm secret

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ WORKDIR /app
 
 # Install dependencies first (layer-cached unless package.json changes)
 COPY package*.json ./
-RUN --mount=type=secret,id=npm_token,required=false \
+RUN --mount=type=secret,id=npm_token,dst=/etc/secrets/npm_token,required=false \
   set -eu; \
-  if [ -s /run/secrets/npm_token ]; then \
-    printf '@caffeinebounce:registry=https://npm.pkg.github.com/\n//npm.pkg.github.com/:_authToken=%s\n' "$(cat /run/secrets/npm_token)" > .npmrc; \
+  if [ -s /etc/secrets/npm_token ]; then \
+    printf '@caffeinebounce:registry=https://npm.pkg.github.com/\n//npm.pkg.github.com/:_authToken=%s\n' "$(cat /etc/secrets/npm_token)" > .npmrc; \
   fi; \
   npm ci; \
   rm -f .npmrc

--- a/app/composables/useAuthSession.ts
+++ b/app/composables/useAuthSession.ts
@@ -13,30 +13,23 @@
  * - Easy to extend later with stronger SWR / TTL if needed.
  *
  * Usage in middleware (async context):
- *   const { session } = useAuthSession()
+ *   const { session } = await useAuthSession()
  *   if (!session.value) { ... }
- *
- * Usage in pages/composables:
- *   const { session } = useAuthSession()
  */
 import { authClient } from '~/utils/auth-client'
 
-export function useAuthSession() {
+export async function useAuthSession() {
   // The official Better Auth Vue composable already does excellent
   // client-side caching and reactive updates. We pass useFetch so it
   // integrates with Nuxt's SSR + payload transfer.
-  //
-  // We cast to any because vue-tsc / the current @better-auth/vue types
-  // sometimes infer the return as Promise<...> during `nuxi typecheck`,
-  // even though runtime returns the reactive state object.
-  const session = authClient.useSession(useFetch) as any
+  const session = await authClient.useSession(useFetch)
 
   return {
     /** Reactive session data (Ref) */
     session: session.data,
-    /** Force refresh the session (useful after login/org switch) */
-    refresh: session.refresh,
-    /** 'loading' | 'authenticated' | 'unauthenticated' etc. */
-    status: session.status,
+    /** Whether Better Auth is still resolving the Nuxt useFetch session request */
+    isPending: session.isPending,
+    /** Reactive fetch error from the session request */
+    error: session.error,
   }
 }

--- a/app/middleware/auth.ts
+++ b/app/middleware/auth.ts
@@ -4,14 +4,8 @@
  */
 export default defineNuxtRouteMiddleware(async () => {
   // Use the centralized cached session composable (deduped from previous direct calls)
-  const { session, status, refresh } = useAuthSession()
+  const { session } = await useAuthSession()
   const localePath = useLocalePath()
-
-  // Ensure the session has settled before making the redirect decision.
-  // This addresses race conditions where the fetch is still in flight.
-  if (status.value === 'loading') {
-    await refresh()
-  }
 
   if (!session.value) {
     return navigateTo(localePath('/auth/sign-in'))

--- a/app/middleware/require-org.ts
+++ b/app/middleware/require-org.ts
@@ -4,13 +4,8 @@
  */
 export default defineNuxtRouteMiddleware(async () => {
   // Use the centralized cached session composable (deduped)
-  const { session, status, refresh } = useAuthSession()
+  const { session } = await useAuthSession()
   const localePath = useLocalePath()
-
-  // Ensure the session has settled before checking activeOrganizationId.
-  if (status.value === 'loading') {
-    await refresh()
-  }
 
   if (session.value && !session.value.session.activeOrganizationId) {
     return navigateTo(localePath('/onboarding/create-org'))

--- a/tests/unit/auth-session.test.ts
+++ b/tests/unit/auth-session.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { ref } from 'vue'
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+}))
+
+vi.mock('~/utils/auth-client', () => ({
+  authClient: {
+    useSession: mocks.useSession,
+  },
+}))
+
+describe('useAuthSession', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mocks.useSession.mockReset()
+    vi.stubGlobal('useFetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('awaits Better Auth useFetch session promise and exposes the session ref', async () => {
+    const session = ref(null)
+    const error = ref(null)
+
+    mocks.useSession.mockResolvedValue({
+      data: session,
+      isPending: false,
+      error,
+    })
+
+    const { useAuthSession } = await import('../../app/composables/useAuthSession')
+
+    const result = await useAuthSession()
+
+    expect(mocks.useSession).toHaveBeenCalledWith(useFetch)
+    expect(result.session).toBe(session)
+    expect(result.isPending).toBe(false)
+    expect(result.error).toBe(error)
+  })
+})

--- a/tests/unit/dockerfile-npm-auth.test.ts
+++ b/tests/unit/dockerfile-npm-auth.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Dockerfile private package auth', () => {
+  const dockerfile = readFileSync(join(process.cwd(), 'Dockerfile'), 'utf8')
+
+  it('mounts the Render npm_token secret file during npm ci', () => {
+    expect(dockerfile).toContain(
+      '--mount=type=secret,id=npm_token,dst=/etc/secrets/npm_token,required=false',
+    )
+    expect(dockerfile).toContain('/etc/secrets/npm_token')
+    expect(dockerfile).toContain('@caffeinebounce:registry=https://npm.pkg.github.com/')
+    expect(dockerfile).toContain('//npm.pkg.github.com/:_authToken=%s')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,13 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('./app', import.meta.url)),
+      '~~': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
   test: {
     setupFiles: ['./tests/setup.ts'],
     include: ['tests/**/*.test.ts'],


### PR DESCRIPTION
## Summary
- await Better Auth's Nuxt useFetch session promise in the shared auth session composable
- update auth and org middleware to use the resolved session shape instead of missing status/refresh refs
- mount Render's npm_token secret file at /etc/secrets/npm_token during Docker npm ci
- add regression tests for the session shape and Docker private package auth wiring

## Verification
- npm run test:unit (40 files, 465 tests)
- npm run typecheck (exit 0; existing vue-router/volar warning)
- npm run build
- docker build --secret id=npm_token,src=<working npm token file> -t factory-careers:codex-auth-render .
- curl -i http://localhost:3001/dashboard/jobs (302/no 500 before auth, dashboard content when browser session is authenticated)