### PR TITLE
fix: disable language support by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,8 @@ FACTORY_DISABLE_ANALYTICS_CONSENT_BANNER=true
 # multivariate flags). Env overrides win over PostHog rollouts.
 # Example — enable the new chatbot experience for everyone on this instance:
 # FEATURE_FLAG_CHATBOT_EXPERIENCE=true
+# Language support is disabled by default until localization is fully wired:
+# FEATURE_FLAG_LANGUAGE_SUPPORT=true
 
 # ─── Optional: OIDC SSO (Keycloak, Authentik, Authelia, Okta, etc.) ──────────
 # Enable Single Sign-On via any OIDC-compliant identity provider.

--- a/app/components/LanguageSwitcher.vue
+++ b/app/components/LanguageSwitcher.vue
@@ -11,10 +11,14 @@ const props = withDefaults(defineProps<{
 
 const route = useRoute()
 const requestURL = useRequestURL()
+const runtimeConfig = useRuntimeConfig()
 const { locale, locales, t } = useI18n()
 
 const isOpen = ref(false)
 const dropdownRef = ref<HTMLElement | null>(null)
+const languageFeatureEnabled = computed(
+  () => runtimeConfig.public.languageFeatureEnabled === true,
+)
 
 function closeDropdown() {
   isOpen.value = false
@@ -195,7 +199,7 @@ async function handleLocaleChange(nextLocale: string) {
 </script>
 
 <template>
-  <div class="flex items-center gap-2">
+  <div v-if="languageFeatureEnabled" class="flex items-center gap-2">
     <span
       v-if="showI18nProbe"
       data-testid="i18n-probe"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,11 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 import tailwindcss from "@tailwindcss/vite";
 import { readEnvFlagOverrides } from "./shared/feature-flags";
+import {
+  getEnabledI18nLocales,
+  I18N_DEFAULT_LOCALE,
+  isLanguageFeatureEnabled,
+} from "./shared/language-feature";
 
 const railwayEnvironmentName =
   process.env.RAILWAY_ENVIRONMENT_NAME?.toLowerCase() ?? "";
@@ -8,42 +13,12 @@ const railwayPublicDomain =
   process.env.RAILWAY_PUBLIC_DOMAIN?.toLowerCase() ?? "";
 const siteUrl =
   process.env.NUXT_PUBLIC_SITE_URL || "https://careers.thefactoryhq.com";
-const i18nDefaultLocale = "en";
-const i18nLocales = [
-  { code: "en", language: "en-US", name: "English", file: "en.json" },
-  {
-    code: "es",
-    language: "es-ES",
-    name: "Español",
-    file: "es.json",
-    partial: true,
-  },
-  {
-    code: "fr",
-    language: "fr-FR",
-    name: "Français",
-    file: "fr.json",
-    partial: true,
-  },
-  {
-    code: "de",
-    language: "de-DE",
-    name: "Deutsch",
-    file: "de.json",
-    partial: true,
-  },
-  { code: "nb", language: "nb-NO", name: "Norsk Bokmål", file: "nb.json" },
-  {
-    code: "vi",
-    language: "vi-VN",
-    name: "Tiếng Việt",
-    file: "vi.json",
-    partial: true,
-  },
-];
+const i18nDefaultLocale = I18N_DEFAULT_LOCALE;
+const languageFeatureEnabled = isLanguageFeatureEnabled();
+const enabledI18nLocales = getEnabledI18nLocales();
 
 const localizedPublicRouteRules = Object.fromEntries(
-  i18nLocales
+  enabledI18nLocales
     .filter((locale) => locale.code !== i18nDefaultLocale)
     .flatMap((locale) => [
       [`/${locale.code}/jobs`, { isr: 3600 }],
@@ -53,7 +28,7 @@ const localizedPublicRouteRules = Object.fromEntries(
 
 // Allow search-engine indexing for localized job board pages
 const localizedJobsRobotsRules = Object.fromEntries(
-  i18nLocales
+  enabledI18nLocales
     .filter((locale) => locale.code !== i18nDefaultLocale)
     .flatMap((locale) => [
       [
@@ -70,7 +45,7 @@ const localizedJobsRobotsRules = Object.fromEntries(
 // Redirect locale roots to their respective job boards
 // (e.g. / → /jobs, /es → /es/jobs, /fr → /fr/jobs)
 const localizedRootRedirectRules = Object.fromEntries(
-  i18nLocales.map((locale) => {
+  enabledI18nLocales.map((locale) => {
     const root = locale.code === i18nDefaultLocale ? "/" : `/${locale.code}`;
     const target =
       locale.code === i18nDefaultLocale ? "/jobs" : `/${locale.code}/jobs`;
@@ -165,13 +140,15 @@ export default defineNuxtConfig({
     baseUrl: siteUrl,
     defaultLocale: i18nDefaultLocale,
     strategy: "prefix_except_default",
-    locales: i18nLocales,
+    locales: enabledI18nLocales,
     langDir: "locales",
-    detectBrowserLanguage: {
-      useCookie: true,
-      cookieKey: "reqcore_i18n_redirected",
-      redirectOn: "root",
-    },
+    detectBrowserLanguage: languageFeatureEnabled
+      ? {
+          useCookie: true,
+          cookieKey: "reqcore_i18n_redirected",
+          redirectOn: "root",
+        }
+      : false,
     vueI18n: "./i18n.config.ts",
   },
 
@@ -270,6 +247,8 @@ export default defineNuxtConfig({
       /** Whether to show the analytics consent banner ("A small ask"). Disabled for Factory (SSO + always cookieless). */
       factoryAnalyticsConsentBannerEnabled:
         process.env.FACTORY_DISABLE_ANALYTICS_CONSENT_BANNER === "false",
+      /** Whether public language switching and localized routes are enabled. */
+      languageFeatureEnabled,
       /**
        * Feature flag overrides forced by env vars (FEATURE_FLAG_*).
        * Self-hosters use these to enable/disable flags without running PostHog.

--- a/shared/feature-flags.ts
+++ b/shared/feature-flags.ts
@@ -53,6 +53,16 @@ export const FEATURE_FLAGS = {
     defaultValue: false,
     description: 'New AI chatbot experience in the dashboard.',
   },
+  /**
+   * Public language switching and localized route generation.
+   *
+   * Off by default until translations are fully piped through the product.
+   * Enable per deployment with `FEATURE_FLAG_LANGUAGE_SUPPORT=true`.
+   */
+  'language-support': {
+    defaultValue: false,
+    description: 'Public language switching and localized routes.',
+  },
 } as const satisfies Record<string, FeatureFlagDefinition>
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS

--- a/shared/language-feature.ts
+++ b/shared/language-feature.ts
@@ -1,0 +1,70 @@
+import type { LocaleObject } from '@nuxtjs/i18n'
+import {
+  FEATURE_FLAGS,
+  flagEnvVarName,
+  parseFlagOverride,
+  type FeatureFlagKey,
+} from './feature-flags'
+
+export const LANGUAGE_FEATURE_FLAG = 'language-support' satisfies FeatureFlagKey
+export const I18N_DEFAULT_LOCALE = 'en'
+
+export type I18nLocale = LocaleObject<string> & {
+  code: string
+  language: string
+  name: string
+  file: string
+  partial?: boolean
+}
+
+export const I18N_LOCALES: readonly I18nLocale[] = [
+  { code: 'en', language: 'en-US', name: 'English', file: 'en.json' },
+  {
+    code: 'es',
+    language: 'es-ES',
+    name: 'Español',
+    file: 'es.json',
+    partial: true,
+  },
+  {
+    code: 'fr',
+    language: 'fr-FR',
+    name: 'Français',
+    file: 'fr.json',
+    partial: true,
+  },
+  {
+    code: 'de',
+    language: 'de-DE',
+    name: 'Deutsch',
+    file: 'de.json',
+    partial: true,
+  },
+  { code: 'nb', language: 'nb-NO', name: 'Norsk Bokmål', file: 'nb.json' },
+  {
+    code: 'vi',
+    language: 'vi-VN',
+    name: 'Tiếng Việt',
+    file: 'vi.json',
+    partial: true,
+  },
+]
+
+export function isLanguageFeatureEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const override = parseFlagOverride(
+    LANGUAGE_FEATURE_FLAG,
+    env[flagEnvVarName(LANGUAGE_FEATURE_FLAG)],
+  )
+  const value = override ?? FEATURE_FLAGS[LANGUAGE_FEATURE_FLAG].defaultValue
+
+  return value === true
+}
+
+export function getEnabledI18nLocales(
+  env: Record<string, string | undefined> = process.env,
+): I18nLocale[] {
+  if (isLanguageFeatureEnabled(env)) return [...I18N_LOCALES]
+  return I18N_LOCALES.filter(locale => locale.code === I18N_DEFAULT_LOCALE)
+}

--- a/tests/unit/language-feature-flag.test.ts
+++ b/tests/unit/language-feature-flag.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { FEATURE_FLAGS } from '../../shared/feature-flags'
+import {
+  getEnabledI18nLocales,
+  isLanguageFeatureEnabled,
+} from '../../shared/language-feature'
+
+const ROOT = resolve(__dirname, '../..')
+const read = (rel: string) => readFileSync(resolve(ROOT, rel), 'utf8')
+
+describe('language feature flag', () => {
+  it('registers language support as off by default', () => {
+    const flags = FEATURE_FLAGS as Record<
+      string,
+      { defaultValue: boolean | string; description: string }
+    >
+
+    expect(flags['language-support']).toMatchObject({
+      defaultValue: false,
+    })
+  })
+
+  it('defaults to English-only locales until the env override enables languages', () => {
+    expect(isLanguageFeatureEnabled({})).toBe(false)
+    expect(getEnabledI18nLocales({}).map(locale => locale.code)).toEqual(['en'])
+
+    const enabledEnv = { FEATURE_FLAG_LANGUAGE_SUPPORT: 'true' }
+    expect(isLanguageFeatureEnabled(enabledEnv)).toBe(true)
+    expect(getEnabledI18nLocales(enabledEnv).map(locale => locale.code)).toEqual([
+      'en',
+      'es',
+      'fr',
+      'de',
+      'nb',
+      'vi',
+    ])
+  })
+
+  it('uses the language flag to limit Nuxt i18n to enabled locales', () => {
+    const config = read('nuxt.config.ts')
+
+    expect(config).toMatch(/const languageFeatureEnabled = isLanguageFeatureEnabled\(\)/)
+    expect(config).toMatch(/locales:\s*enabledI18nLocales/)
+    expect(config).toMatch(/detectBrowserLanguage:\s*languageFeatureEnabled\s*\?\s*\{/)
+    expect(config).toMatch(/languageFeatureEnabled/)
+    expect(config).not.toMatch(/locales:\s*i18nLocales/)
+  })
+
+  it('hides the language switcher when language support is disabled', () => {
+    const switcher = read('app/components/LanguageSwitcher.vue')
+
+    expect(switcher).toMatch(/languageFeatureEnabled/)
+    expect(switcher).toMatch(/v-if="languageFeatureEnabled"/)
+  })
+})


### PR DESCRIPTION
## Summary

- Add a `language-support` feature flag that defaults off and can be enabled with `FEATURE_FLAG_LANGUAGE_SUPPORT=true`.
- Collapse Nuxt i18n to English-only when the flag is off, including localized route rules and browser language detection.
- Hide the public language switcher while language support is disabled.

Refs #32.

## Validation

- `npm run test:unit -- tests/unit/language-feature-flag.test.ts` (red first, then green)
- `npm run test:unit` — 41 files / 469 tests passed
- `npm run typecheck` — passed; existing Vue/Volar package-export warning still prints
- `npm run build` — passed with local dummy env; Tailwind sourcemap warnings still print
- Browser smoke test: `http://127.0.0.1:3010/auth/sign-in` rendered without an error overlay, had 0 `Select language` buttons, and had no console warnings/errors