### PR TITLE
fix: complete Issue 8 theme cleanup

### DIFF
--- a/app/components/AiConfigForm.vue
+++ b/app/components/AiConfigForm.vue
@@ -132,8 +132,8 @@ function pickModelById(modelId: string) {
   form.value.model = modelId
 }
 
-function onModelSelect(event: Event) {
-  pickModelById((event.target as HTMLSelectElement).value)
+function onModelSelect(modelId: string) {
+  pickModelById(modelId)
 }
 
 function pickProvider(key: string) {
@@ -339,25 +339,14 @@ function providerShortName(key: string, name: string) {
           <label class="block text-xs font-medium text-surface-700 dark:text-surface-300">
             Recommended model
           </label>
-          <div class="relative">
-            <select
-              :value="form.model"
-              class="ui-field appearance-none pr-10"
-              @change="onModelSelect"
-            >
-              <option v-if="form.model && !selectedModel" :value="form.model">
-                {{ form.model }} - Custom
-              </option>
-              <option
-                v-for="m in selectedProvider.models"
-                :key="m.id"
-                :value="m.id"
-              >
-                {{ modelOptionLabel(m) }}
-              </option>
-            </select>
-            <ChevronDown class="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-surface-400" />
-          </div>
+          <FactorySelect
+            :model-value="form.model"
+            :options="[
+              ...(form.model && !selectedModel ? [{ value: form.model, label: `${form.model} - Custom` }] : []),
+              ...selectedProvider.models.map(m => ({ value: m.id, label: modelOptionLabel(m) })),
+            ]"
+            @update:model-value="onModelSelect"
+          />
           <p
             v-if="selectedModel"
             class="text-[11px] text-surface-500 dark:text-surface-400"

--- a/app/components/AppTopBar.vue
+++ b/app/components/AppTopBar.vue
@@ -25,6 +25,9 @@ const showMoreActions = ref(false)
 
 const config = useRuntimeConfig()
 const { activeOrg } = useCurrentOrg()
+const languageFeatureEnabled = computed(
+  () => config.public.languageFeatureEnabled === true,
+)
 
 const isDemo = computed(() => {
   const slug = config.public.demoOrgSlug
@@ -491,7 +494,7 @@ onUnmounted(() => {
                     <p class="px-1 text-[10px] font-semibold uppercase tracking-wide text-white/38">Organization</p>
                     <OrgSwitcher />
                   </div>
-                  <div class="space-y-1.5">
+                  <div v-if="languageFeatureEnabled" class="space-y-1.5">
                     <p class="px-1 text-[10px] font-semibold uppercase tracking-wide text-white/38">Language</p>
                     <LanguageSwitcher tone="factory" />
                   </div>

--- a/app/components/ApplicationDetailDrawer.vue
+++ b/app/components/ApplicationDetailDrawer.vue
@@ -146,7 +146,7 @@ onUnmounted(() => {
       leave-to-class="opacity-0"
     >
       <div
-        class="fixed inset-0 z-[55] bg-black/75 backdrop-blur-[1px]"
+        class="factory-dashboard-portal ui-modal-backdrop fixed inset-0 z-[55]"
         @click="emit('close')"
       />
     </Transition>

--- a/app/components/CandidateDetailDrawer.vue
+++ b/app/components/CandidateDetailDrawer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { X, ExternalLink, Mail, Phone, Calendar, Clock, Briefcase, FileText, Plus, Download, Eye } from 'lucide-vue-next'
 import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
-import { formatFileSize, getApplicationStatusBadgeClass } from '~/utils/status-display'
+import { getApplicationStatusBadgeClass } from '~/utils/status-display'
 
 const props = defineProps<{
   candidateId: string

--- a/app/components/CandidateDetailDrawer.vue
+++ b/app/components/CandidateDetailDrawer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { X, ExternalLink, Mail, Phone, Calendar, Clock, Briefcase, FileText, Plus, Download, Eye } from 'lucide-vue-next'
 import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
-import { getApplicationStatusBadgeClass } from '~/utils/status-display'
+import { formatFileSize, getApplicationStatusBadgeClass } from '~/utils/status-display'
 
 const props = defineProps<{
   candidateId: string
@@ -98,13 +98,6 @@ const documentTypeLabels: Record<string, string> = {
   other: 'Other',
 }
 
-function formatFileSize(bytes: number | null | undefined): string {
-  if (!bytes) return '—'
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
-}
-
 // ─── Body scroll lock + keyboard handling ─────────────────────────────────────
 
 function onKeydown(e: KeyboardEvent) {
@@ -132,7 +125,7 @@ onUnmounted(() => {
       leave-to-class="opacity-0"
     >
       <div
-        class="fixed inset-0 z-[55] bg-black/75 backdrop-blur-[1px]"
+        class="factory-dashboard-portal ui-modal-backdrop fixed inset-0 z-[55]"
         @click="emit('close')"
       />
     </Transition>

--- a/app/components/CandidateDetailSidebar.vue
+++ b/app/components/CandidateDetailSidebar.vue
@@ -860,14 +860,15 @@ function formatInterviewDate(dateStr: string) {
               <!-- Upload controls -->
               <div class="flex items-center justify-between">
                 <div class="flex items-center gap-2">
-                  <select
+                  <FactorySelect
                     v-model="selectedDocType"
-                    class="ui-field w-auto px-2.5 py-1.5 text-sm"
-                  >
-                    <option value="resume">Resume</option>
-                    <option value="cover_letter">Cover Letter</option>
-                    <option value="other">Other</option>
-                  </select>
+                    class="w-40"
+                    :options="[
+                      { value: 'resume', label: 'Resume' },
+                      { value: 'cover_letter', label: 'Cover Letter' },
+                      { value: 'other', label: 'Other' },
+                    ]"
+                  />
                 </div>
                 <button
                   :disabled="isUploading"

--- a/app/components/DynamicField.vue
+++ b/app/components/DynamicField.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ChevronDown, Upload, X } from 'lucide-vue-next'
-import { formatFileSize } from '~/utils/status-display'
 
 /**
  * Renders a custom question as the appropriate form field based on its type.

--- a/app/components/DynamicField.vue
+++ b/app/components/DynamicField.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ChevronDown, Upload, X } from 'lucide-vue-next'
+import { formatFileSize } from '~/utils/status-display'
 
 /**
  * Renders a custom question as the appropriate form field based on its type.
@@ -98,12 +99,6 @@ function clearFile() {
   if (fileInputRef.value) {
     fileInputRef.value.value = ''
   }
-}
-
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
 const inputClasses = 'w-full border bg-black/35 px-3.5 py-2.5 text-sm text-white placeholder:text-white/38 outline-none transition-colors focus:border-brand-500 focus:ring-2 focus:ring-brand-500/25'

--- a/app/components/FactorySelect.vue
+++ b/app/components/FactorySelect.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { ChevronDown, Check } from 'lucide-vue-next'
 
+defineOptions({
+  inheritAttrs: false,
+})
+
 const props = defineProps<{
+  id?: string
   modelValue: any
   options: Array<{ value: any; label: string }>
   placeholder?: string
@@ -58,6 +63,7 @@ onUnmounted(() => {
 <template>
   <div ref="menuRef" class="factory-filter-dropdown relative" :class="class">
     <button
+      :id="id"
       type="button"
       class="factory-filter-select factory-filter-dropdown-trigger flex w-full items-center justify-between gap-2 border px-3 py-2 text-sm text-left focus:outline-none transition-colors"
       :disabled="disabled"

--- a/app/components/InterviewScheduleSidebar.vue
+++ b/app/components/InterviewScheduleSidebar.vue
@@ -424,7 +424,7 @@ async function handleMoveToInterview() {
         leave-from-class="opacity-100"
         leave-to-class="opacity-0"
       >
-        <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" @click="emit('close')" />
+        <div class="ui-modal-backdrop absolute inset-0" @click="emit('close')" />
       </Transition>
 
       <!-- Sidebar panel -->

--- a/app/components/PropertyFilterBar.vue
+++ b/app/components/PropertyFilterBar.vue
@@ -204,30 +204,24 @@ const showableDefs = computed(() => definitions.value)
             <div class="ui-menu-divider pb-2 text-xs font-semibold text-surface-700 dark:text-surface-200">
               {{ definitionMap.get(f.propertyDefinitionId)!.name }}
             </div>
-            <select
-              :value="f.op"
-              class="ui-field px-2 py-1"
-              @change="(e) => patchFilter(idx, { op: (e.target as HTMLSelectElement).value as PropertyOperator })"
-            >
-              <option v-for="op in operatorsFor(definitionMap.get(f.propertyDefinitionId)!)" :key="op" :value="op">
-                {{ OPERATOR_LABELS[op] }}
-              </option>
-            </select>
+            <FactorySelect
+              :model-value="f.op"
+              :options="operatorsFor(definitionMap.get(f.propertyDefinitionId)!).map(op => ({ value: op, label: OPERATOR_LABELS[op] }))"
+              @update:model-value="(value) => patchFilter(idx, { op: value as PropertyOperator })"
+            />
 
             <!-- Value input by op + type -->
             <template v-if="!['isEmpty', 'isNotEmpty'].includes(f.op)">
               <!-- select equals -->
-              <select
+              <FactorySelect
                 v-if="definitionMap.get(f.propertyDefinitionId)!.type === 'select' && f.op === 'equals'"
-                :value="(f.value as string) ?? ''"
-                class="ui-field px-2 py-1"
-                @change="(e) => patchFilter(idx, { value: (e.target as HTMLSelectElement).value || null })"
-              >
-                <option value="">—</option>
-                <option v-for="opt in ((definitionMap.get(f.propertyDefinitionId)!.config as { options?: { id: string; label: string }[] } | null)?.options ?? [])" :key="opt.id" :value="opt.id">
-                  {{ opt.label }}
-                </option>
-              </select>
+                :model-value="(f.value as string) ?? ''"
+                :options="[
+                  { value: '', label: '—' },
+                  ...(((definitionMap.get(f.propertyDefinitionId)!.config as { options?: { id: string; label: string }[] } | null)?.options ?? []).map(opt => ({ value: opt.id, label: opt.label }))),
+                ]"
+                @update:model-value="(value) => patchFilter(idx, { value: value || null })"
+              />
 
               <!-- multi_select in -->
               <div v-else-if="definitionMap.get(f.propertyDefinitionId)!.type === 'multi_select' && f.op === 'in'" class="flex flex-wrap gap-1">
@@ -247,15 +241,15 @@ const showableDefs = computed(() => definitions.value)
               </div>
 
               <!-- checkbox equals -->
-              <select
+              <FactorySelect
                 v-else-if="definitionMap.get(f.propertyDefinitionId)!.type === 'checkbox'"
-                :value="String(f.value ?? false)"
-                class="ui-field px-2 py-1"
-                @change="(e) => patchFilter(idx, { value: (e.target as HTMLSelectElement).value === 'true' })"
-              >
-                <option value="true">checked</option>
-                <option value="false">unchecked</option>
-              </select>
+                :model-value="String(f.value ?? false)"
+                :options="[
+                  { value: 'true', label: 'checked' },
+                  { value: 'false', label: 'unchecked' },
+                ]"
+                @update:model-value="(value) => patchFilter(idx, { value: value === 'true' })"
+              />
 
               <!-- date / number equals -->
               <input

--- a/app/components/PropertySchemaEditor.vue
+++ b/app/components/PropertySchemaEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ChevronDown, GripVertical, Pencil, Plus, Trash2, X } from 'lucide-vue-next'
+import { GripVertical, Pencil, Plus, Trash2, X } from 'lucide-vue-next'
 import {
   PROPERTY_COLOR_CLASSES,
   PROPERTY_OPTION_COLORS,
@@ -292,12 +292,10 @@ const overlayTitle = computed(() => {
 
               <div v-if="formMode === 'create'">
                 <label class="mb-1 block text-xs font-medium text-white/68">Type</label>
-                <div class="relative">
-                  <select v-model="formType" class="factory-form-select">
-                    <option v-for="t in PROPERTY_TYPES" :key="t" :value="t">{{ PROPERTY_TYPE_LABELS[t] }}</option>
-                  </select>
-                  <ChevronDown class="factory-form-select-chevron" aria-hidden="true" />
-                </div>
+                <FactorySelect
+                  v-model="formType"
+                  :options="PROPERTY_TYPES.map(t => ({ value: t, label: PROPERTY_TYPE_LABELS[t] }))"
+                />
                 <p class="mt-1 text-[11px] text-white/38">Type cannot be changed after creation.</p>
               </div>
 
@@ -315,14 +313,15 @@ const overlayTitle = computed(() => {
               <div v-if="supportsNumberFormat">
                 <label class="mb-1 block text-xs font-medium text-white/68">Format</label>
                 <div class="flex items-center gap-2">
-                  <div class="relative flex-1">
-                    <select v-model="formNumberFormat" class="factory-form-select">
-                      <option value="plain">Plain</option>
-                      <option value="percent">Percent</option>
-                      <option value="currency">Currency</option>
-                    </select>
-                    <ChevronDown class="factory-form-select-chevron" aria-hidden="true" />
-                  </div>
+                  <FactorySelect
+                    v-model="formNumberFormat"
+                    class="flex-1"
+                    :options="[
+                      { value: 'plain', label: 'Plain' },
+                      { value: 'percent', label: 'Percent' },
+                      { value: 'currency', label: 'Currency' },
+                    ]"
+                  />
                   <input
                     v-if="formNumberFormat === 'currency'"
                     v-model="formCurrency"
@@ -339,15 +338,11 @@ const overlayTitle = computed(() => {
                 <label class="mb-1 block text-xs font-medium text-white/68">Options</label>
                 <ul class="space-y-1.5">
                   <li v-for="opt in formOptions" :key="opt.id" class="flex items-center gap-1.5">
-                    <div class="relative w-24 shrink-0">
-                      <select
-                        v-model="opt.color"
-                        class="factory-form-select !min-h-8 !px-2 !py-1 !pr-7 !text-xs"
-                      >
-                        <option v-for="c in PROPERTY_OPTION_COLORS" :key="c" :value="c">{{ c }}</option>
-                      </select>
-                      <ChevronDown class="factory-form-select-chevron !right-2 !size-3.5" aria-hidden="true" />
-                    </div>
+                    <FactorySelect
+                      v-model="opt.color"
+                      class="w-24 shrink-0"
+                      :options="PROPERTY_OPTION_COLORS.map(c => ({ value: c, label: c }))"
+                    />
                     <input
                       v-model="opt.label"
                       type="text"

--- a/app/components/QuestionForm.vue
+++ b/app/components/QuestionForm.vue
@@ -145,15 +145,11 @@ const isEditing = computed(() => !!props.question)
         <label for="q-type" class="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-1">
           Field Type
         </label>
-        <select
+        <FactorySelect
           id="q-type"
           v-model="form.type"
-          class="ui-field"
-        >
-          <option v-for="qt in questionTypes" :key="qt.value" :value="qt.value">
-            {{ qt.label }}
-          </option>
-        </select>
+          :options="questionTypes"
+        />
       </div>
 
       <!-- Description / help text -->

--- a/app/components/ScoreBreakdown.vue
+++ b/app/components/ScoreBreakdown.vue
@@ -49,6 +49,10 @@ const defaultAnalysisConfig = computed(() =>
   aiConfigOptions.value.find((c) => c.isDefaultAnalysis) ?? null,
 )
 const selectedAiConfigId = ref<string | null>(null)
+const aiConfigSelectOptions = computed(() => [
+  { value: null, label: `Default${defaultAnalysisConfig.value ? ` (${defaultAnalysisConfig.value.name})` : ''}` },
+  ...aiConfigOptions.value.map((c) => ({ value: c.id, label: c.name })),
+])
 
 // Cache last successful data so switching candidates doesn't flash "Loading scores…"
 const cachedScoreData = ref(scoreData.value)
@@ -135,16 +139,14 @@ async function retryParse() {
           </div>
         </div>
         <div class="flex items-center gap-1.5">
-          <select
+          <FactorySelect
             v-if="aiConfigOptions.length > 1"
             v-model="selectedAiConfigId"
             :disabled="isAnalyzing"
-            class="rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 px-2 py-1.5 text-xs text-surface-700 dark:text-surface-300 focus:outline-none focus:ring-1 focus:ring-brand-500 cursor-pointer max-w-[140px] truncate"
+            class="max-w-[140px]"
+            :options="aiConfigSelectOptions"
             :title="selectedAiConfigId ?? 'Use org default'"
-          >
-            <option :value="null">Default{{ defaultAnalysisConfig ? ` (${defaultAnalysisConfig.name})` : '' }}</option>
-            <option v-for="c in aiConfigOptions" :key="c.id" :value="c.id">{{ c.name }}</option>
-          </select>
+          />
           <button
             :disabled="isAnalyzing"
             class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-brand-600 rounded-lg hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
@@ -175,15 +177,13 @@ async function retryParse() {
             <h3 class="text-sm font-semibold text-surface-800 dark:text-surface-200">Composite Score</h3>
           </div>
           <div class="flex items-center gap-1.5">
-            <select
+            <FactorySelect
               v-if="aiConfigOptions.length > 1"
               v-model="selectedAiConfigId"
               :disabled="isAnalyzing"
-              class="rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 px-2 py-1 text-[11px] text-surface-700 dark:text-surface-300 focus:outline-none focus:ring-1 focus:ring-brand-500 cursor-pointer max-w-[140px] truncate"
-            >
-              <option :value="null">Default{{ defaultAnalysisConfig ? ` (${defaultAnalysisConfig.name})` : '' }}</option>
-              <option v-for="c in aiConfigOptions" :key="c.id" :value="c.id">{{ c.name }}</option>
-            </select>
+              class="max-w-[140px]"
+              :options="aiConfigSelectOptions"
+            />
             <button
               :disabled="isAnalyzing"
               class="text-xs text-brand-600 dark:text-brand-400 hover:underline disabled:opacity-50"

--- a/app/components/SettingsMobileNav.vue
+++ b/app/components/SettingsMobileNav.vue
@@ -5,6 +5,8 @@ import {
 
 const route = useRoute()
 const localePath = useLocalePath()
+const runtimeConfig = useRuntimeConfig()
+const languageFeatureEnabled = runtimeConfig.public.languageFeatureEnabled === true
 
 const settingsNav = [
   {
@@ -51,6 +53,10 @@ const settingsNav = [
   },
 ]
 
+const visibleSettingsNav = computed(() =>
+  settingsNav.filter((item) => languageFeatureEnabled || item.to !== '/dashboard/settings/localization'),
+)
+
 function isActive(to: string, exact: boolean) {
   const localizedTo = localePath(to)
   if (exact) return route.path === localizedTo
@@ -76,7 +82,7 @@ function isActive(to: string, exact: boolean) {
     <!-- Scrollable tabs -->
     <nav class="flex overflow-x-auto px-3 gap-1 pb-2 scrollbar-none">
       <NuxtLink
-        v-for="item in settingsNav"
+        v-for="item in visibleSettingsNav"
         :key="item.to"
         :to="$localePath(item.to)"
         class="ui-nav-link flex items-center gap-1.5 whitespace-nowrap rounded-lg px-3 py-1.5 text-xs font-medium no-underline shrink-0"

--- a/app/components/SettingsSidebar.vue
+++ b/app/components/SettingsSidebar.vue
@@ -6,6 +6,8 @@ import {
 
 const route = useRoute()
 const localePath = useLocalePath()
+const runtimeConfig = useRuntimeConfig()
+const languageFeatureEnabled = runtimeConfig.public.languageFeatureEnabled === true
 
 const settingsNav: Array<{
   label: string
@@ -66,6 +68,10 @@ const settingsNav: Array<{
   },
 ]
 
+const visibleSettingsNav = computed(() =>
+  settingsNav.filter((item) => languageFeatureEnabled || item.to !== '/dashboard/settings/localization'),
+)
+
 function isActive(to: string, exact: boolean) {
   const localizedTo = localePath(to)
   if (exact) return route.path === localizedTo
@@ -99,7 +105,7 @@ function isActive(to: string, exact: boolean) {
     <nav class="flex-1 px-3 pb-5">
       <div class="flex flex-col gap-0.5">
         <NuxtLink
-          v-for="item in settingsNav"
+          v-for="item in visibleSettingsNav"
           :key="item.to"
           :to="$localePath(item.to)"
           class="ui-nav-link group flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm no-underline"

--- a/app/layouts/settings.vue
+++ b/app/layouts/settings.vue
@@ -19,7 +19,9 @@ const isDemoAccount = computed(() => session.value?.user?.email === config.publi
 <template>
   <div class="factory-dashboard-shell flex min-h-screen flex-col bg-black text-white">
     <!-- AppTopBar: desktop only -->
-    <AppTopBar class="hidden lg:block" />
+    <div class="hidden lg:block">
+      <AppTopBar />
+    </div>
     <AppToasts />
     <PreviewUpsellModal v-if="isUpsellOpen" @close="closeUpsell" />
     <ClientOnly>

--- a/app/pages/dashboard/applications/index.vue
+++ b/app/pages/dashboard/applications/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { FileText, Search, X, Briefcase, Mail, Clock, ArrowUp, ArrowDown, ArrowUpDown, SlidersHorizontal, Maximize2, Minimize2, Check } from 'lucide-vue-next'
 import {
+  formatRelativeTime,
   getApplicationStatusBadgeClass,
   getApplicationStatusDotClass,
   getApplicationStatusLabel,
@@ -195,17 +196,6 @@ function clearAllFilters() {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function timeAgo(date: string | Date) {
-  const diff = Date.now() - new Date(date).getTime()
-  const mins = Math.floor(diff / 60_000)
-  if (mins < 60) return `${mins}m ago`
-  const hrs = Math.floor(mins / 60)
-  if (hrs < 24) return `${hrs}h ago`
-  const days = Math.floor(hrs / 24)
-  if (days < 30) return `${days}d ago`
-  return new Date(date).toLocaleDateString()
-}
 
 // ── Drawer + Saved Views ──────────────────────────────────────────────────────
 
@@ -645,7 +635,7 @@ const selectedApplicationId = ref<string | null>(null)
               <td v-if="visibleColumns.applied" class="px-4 py-3 text-white/60 whitespace-nowrap">
                 <TimelineDateLink :date="app.createdAt" class="inline-flex items-center gap-1.5">
                   <Clock class="size-3.5 shrink-0" />
-                  {{ timeAgo(app.createdAt) }}
+                  {{ formatRelativeTime(app.createdAt) }}
                 </TimelineDateLink>
               </td>
               <!-- Property columns -->

--- a/app/pages/dashboard/candidates/[id].vue
+++ b/app/pages/dashboard/candidates/[id].vue
@@ -2,7 +2,7 @@
 import { ArrowLeft, Pencil, Trash2, Mail, Phone, Calendar, Clock, Briefcase, FileText, Plus, Upload, Download, Eye, AlertTriangle } from 'lucide-vue-next'
 import { z } from 'zod'
 import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
-import { formatFileSize, getApplicationStatusBadgeClass } from '~/utils/status-display'
+import { getApplicationStatusBadgeClass } from '~/utils/status-display'
 
 definePageMeta({
   layout: 'dashboard',

--- a/app/pages/dashboard/candidates/[id].vue
+++ b/app/pages/dashboard/candidates/[id].vue
@@ -2,7 +2,7 @@
 import { ArrowLeft, Pencil, Trash2, Mail, Phone, Calendar, Clock, Briefcase, FileText, Plus, Upload, Download, Eye, AlertTriangle } from 'lucide-vue-next'
 import { z } from 'zod'
 import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
-import { getApplicationStatusBadgeClass } from '~/utils/status-display'
+import { formatFileSize, getApplicationStatusBadgeClass } from '~/utils/status-display'
 
 definePageMeta({
   layout: 'dashboard',
@@ -285,13 +285,6 @@ async function handleDeleteDoc(docId: string) {
   }
 }
 
-/** Format bytes into a human-readable string */
-function formatFileSize(bytes: number | null | undefined): string {
-  if (!bytes) return '—'
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
-}
 </script>
 
 <template>

--- a/app/pages/dashboard/index.vue
+++ b/app/pages/dashboard/index.vue
@@ -5,6 +5,7 @@ import {
   Eye, UserPlus, ExternalLink,
   LayoutDashboard, Zap,
 } from 'lucide-vue-next'
+import { getApplicationStatusBadgeClass } from '~/utils/status-display'
 
 definePageMeta({
   layout: 'dashboard',
@@ -87,15 +88,6 @@ function getJobActiveTotal(job: (typeof topJobs.value)[number]): number {
     + getJobStageCount(job, 'screening')
     + getJobStageCount(job, 'interview')
     + getJobStageCount(job, 'offer')
-}
-
-const statusBadgeClasses: Record<string, string> = {
-  new: 'bg-blue-50 text-blue-700 ring-blue-200/60 dark:bg-blue-950 dark:text-blue-400 dark:ring-blue-800/40',
-  screening: 'bg-violet-50 text-violet-700 ring-violet-200/60 dark:bg-violet-950 dark:text-violet-400 dark:ring-violet-800/40',
-  interview: 'bg-amber-50 text-amber-700 ring-amber-200/60 dark:bg-amber-950 dark:text-amber-400 dark:ring-amber-800/40',
-  offer: 'bg-teal-50 text-teal-700 ring-teal-200/60 dark:bg-teal-950 dark:text-teal-400 dark:ring-teal-800/40',
-  hired: 'bg-green-50 text-green-700 ring-green-200/60 dark:bg-green-950 dark:text-green-400 dark:ring-green-800/40',
-  rejected: 'bg-surface-100 text-surface-600 ring-surface-200 dark:bg-surface-800 dark:text-surface-400 dark:ring-surface-700',
 }
 
 const interviewTypeLabels: Record<string, string> = {
@@ -456,7 +448,7 @@ const isEmpty = computed(() =>
                     </span>
                     <span
                       class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold capitalize shrink-0 ring-1 ring-inset"
-                      :class="statusBadgeClasses[app.status] ?? 'bg-surface-100 text-surface-600 dark:bg-surface-800 dark:text-surface-400 ring-surface-200 dark:ring-surface-700'"
+                      :class="getApplicationStatusBadgeClass(app.status, 'subtle-ring')"
                     >
                       {{ app.status }}
                     </span>

--- a/app/pages/dashboard/interviews/[id].vue
+++ b/app/pages/dashboard/interviews/[id].vue
@@ -6,6 +6,13 @@ import {
   Save, X, Mail, Send, CheckCheck, ChevronDown, ExternalLink,
   Check, AlertCircle,
 } from 'lucide-vue-next'
+import {
+  getInterviewStatusBadgeClass,
+  getInterviewStatusDotClass,
+  getInterviewStatusLabel,
+  getInterviewTransitionButtonClass,
+  getInterviewTransitionLabel,
+} from '~/utils/status-display'
 
 definePageMeta({
   layout: 'dashboard',
@@ -31,35 +38,7 @@ useSeoMeta({
   robots: 'noindex, nofollow',
 })
 
-// ─── Status config ──────────────────────────────────────────────
 type InterviewStatus = 'scheduled' | 'completed' | 'cancelled' | 'no_show'
-
-const statusConfig: Record<InterviewStatus, { label: string; icon: any; class: string; dot: string }> = {
-  scheduled: {
-    label: 'Scheduled',
-    icon: Calendar,
-    class: 'bg-brand-50 text-brand-700 ring-brand-200 dark:bg-brand-950/50 dark:text-brand-300 dark:ring-brand-800',
-    dot: 'bg-brand-500',
-  },
-  completed: {
-    label: 'Completed',
-    icon: CheckCircle2,
-    class: 'bg-success-50 text-success-700 ring-success-200 dark:bg-success-950/50 dark:text-success-300 dark:ring-success-800',
-    dot: 'bg-success-500',
-  },
-  cancelled: {
-    label: 'Cancelled',
-    icon: XCircle,
-    class: 'bg-surface-100 text-surface-500 ring-surface-200 dark:bg-surface-800/50 dark:text-surface-400 dark:ring-surface-700',
-    dot: 'bg-surface-400',
-  },
-  no_show: {
-    label: 'No Show',
-    icon: AlertTriangle,
-    class: 'bg-danger-50 text-danger-700 ring-danger-200 dark:bg-danger-950/50 dark:text-danger-300 dark:ring-danger-800',
-    dot: 'bg-danger-500',
-  },
-}
 
 const typeIcons: Record<string, any> = {
   video: Video,
@@ -81,13 +60,6 @@ const typeLabels: Record<string, string> = {
 
 // ─── Status transitions (from shared single source of truth) ────
 import { INTERVIEW_STATUS_TRANSITIONS } from '~~/shared/status-transitions'
-
-const transitionClasses: Record<InterviewStatus, string> = {
-  scheduled: 'border border-surface-300 dark:border-surface-700 bg-white/80 dark:bg-surface-900 text-surface-700 dark:text-surface-300 hover:border-surface-400 dark:hover:border-surface-600 hover:bg-surface-50 dark:hover:bg-surface-800',
-  completed: 'bg-success-600 text-white shadow-sm shadow-success-900/20 hover:bg-success-700',
-  cancelled: 'bg-surface-500 text-white shadow-sm shadow-surface-900/20 hover:bg-surface-600',
-  no_show: 'bg-danger-600 text-white shadow-sm shadow-danger-900/20 hover:bg-danger-700',
-}
 
 const allowedTransitions = computed(() => {
   if (!interview.value) return [] as InterviewStatus[]
@@ -396,10 +368,10 @@ const localePath = useLocalePath()
                 </h1>
                 <span
                   class="inline-flex items-center gap-1 rounded-lg px-2.5 py-1 text-xs font-semibold uppercase tracking-wide ring-1 ring-inset"
-                  :class="statusConfig[interview.status as InterviewStatus]?.class"
+                  :class="getInterviewStatusBadgeClass(interview.status)"
                 >
-                  <span class="size-1.5 rounded-full" :class="statusConfig[interview.status as InterviewStatus]?.dot" />
-                  {{ statusConfig[interview.status as InterviewStatus]?.label }}
+                  <span class="size-1.5 rounded-full" :class="getInterviewStatusDotClass(interview.status)" />
+                  {{ getInterviewStatusLabel(interview.status) }}
                 </span>
               </div>
               <div class="mt-1.5 flex flex-wrap items-center gap-x-4 gap-y-0.5 text-sm text-surface-500 dark:text-surface-400">
@@ -466,14 +438,14 @@ const localePath = useLocalePath()
             :key="nextStatus"
             :disabled="isTransitioning"
             class="inline-flex cursor-pointer items-center rounded-full px-3.5 py-1.5 text-sm font-medium transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500/40 disabled:cursor-not-allowed disabled:opacity-50"
-            :class="transitionClasses[nextStatus]"
+            :class="getInterviewTransitionButtonClass(nextStatus)"
             @click="handleTransition(nextStatus)"
           >
             <span
               class="mr-2 inline-flex size-1.5 rounded-full"
               :class="nextStatus === 'completed' ? 'bg-success-200' : nextStatus === 'cancelled' ? 'bg-surface-200' : nextStatus === 'no_show' ? 'bg-danger-200' : 'bg-brand-200'"
             />
-            {{ nextStatus === 'scheduled' ? 'Re-schedule' : `Mark ${statusConfig[nextStatus]?.label}` }}
+            {{ nextStatus === 'scheduled' ? getInterviewTransitionLabel(nextStatus) : `Mark ${getInterviewStatusLabel(nextStatus)}` }}
           </button>
           <button
             class="inline-flex cursor-pointer items-center rounded-full border border-brand-200 dark:border-brand-800 bg-brand-50 dark:bg-brand-950/30 px-3.5 py-1.5 text-sm font-medium text-brand-700 dark:text-brand-300 hover:bg-brand-100 dark:hover:bg-brand-950/50 transition-all duration-150"
@@ -878,9 +850,8 @@ const localePath = useLocalePath()
 
     <!-- Reschedule Modal -->
     <Teleport to="body">
-      <div v-if="showReschedule" class="fixed inset-0 z-50 flex items-center justify-center">
-        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm" @click="showReschedule = false" />
-        <div class="relative bg-white dark:bg-surface-900 rounded-2xl shadow-2xl shadow-surface-900/10 dark:shadow-black/30 ring-1 ring-surface-200/80 dark:ring-surface-700/60 p-6 max-w-md w-full mx-4">
+      <div v-if="showReschedule" class="factory-dashboard-portal ui-modal-backdrop fixed inset-0 z-50 flex items-center justify-center p-4" @click.self="showReschedule = false">
+        <div class="ui-modal-panel relative w-full max-w-md p-6">
           <h3 class="text-lg font-semibold text-surface-900 dark:text-surface-100 mb-4">Reschedule Interview</h3>
 
           <div v-if="rescheduleError" class="mb-4 rounded-lg border border-danger-200 bg-danger-50 p-3 text-sm text-danger-700 dark:border-danger-800 dark:bg-danger-950/40 dark:text-danger-300">
@@ -945,9 +916,8 @@ const localePath = useLocalePath()
 
     <!-- Edit Details Modal -->
     <Teleport to="body">
-      <div v-if="showEditDetails" class="fixed inset-0 z-50 flex items-center justify-center">
-        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm" @click="showEditDetails = false" />
-        <div class="relative bg-white dark:bg-surface-900 rounded-2xl shadow-2xl shadow-surface-900/10 dark:shadow-black/30 ring-1 ring-surface-200/80 dark:ring-surface-700/60 p-6 max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto">
+      <div v-if="showEditDetails" class="factory-dashboard-portal ui-modal-backdrop fixed inset-0 z-50 flex items-center justify-center p-4" @click.self="showEditDetails = false">
+        <div class="ui-modal-panel relative w-full max-w-lg max-h-[90vh] overflow-y-auto p-6">
           <h3 class="text-lg font-semibold text-surface-900 dark:text-surface-100 mb-5">Edit Interview Details</h3>
 
           <div v-if="editErrors.submit" class="mb-4 rounded-lg border border-danger-200 bg-danger-50 p-3 text-sm text-danger-700 dark:border-danger-800 dark:bg-danger-950/40 dark:text-danger-300">

--- a/app/pages/dashboard/jobs/[id]/candidates.vue
+++ b/app/pages/dashboard/jobs/[id]/candidates.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Users, SlidersHorizontal, X, Check, ChevronsUpDown, ChevronUp, ChevronDown, UserRound } from 'lucide-vue-next'
 import {
+  formatRelativeTime,
   getApplicationStatusBadgeClass,
   getApplicationStatusLabel,
   getScoreBadgeClass,
@@ -175,17 +176,6 @@ const sorted = computed(() => {
 // ─────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────
-
-function timeAgo(date: string | Date) {
-  const diff = Date.now() - new Date(date).getTime()
-  const mins = Math.floor(diff / 60_000)
-  if (mins < 60) return `${mins}m ago`
-  const hrs = Math.floor(mins / 60)
-  if (hrs < 24) return `${hrs}h ago`
-  const days = Math.floor(hrs / 24)
-  if (days < 30) return `${days}d ago`
-  return new Date(date).toLocaleDateString()
-}
 
 // ─────────────────────────────────────────────
 // Row selection → sidebar
@@ -508,7 +498,7 @@ const isLoading = computed(() => jobFetchStatus.value === 'pending' || appFetchS
                   </span>
                 </td>
                 <td v-if="visibleCols.createdAt" class="hidden md:table-cell px-4 py-3 text-surface-500 dark:text-surface-400 whitespace-nowrap text-xs font-medium">
-                  <TimelineDateLink :date="app.createdAt">{{ timeAgo(app.createdAt) }}</TimelineDateLink>
+                  <TimelineDateLink :date="app.createdAt">{{ formatRelativeTime(app.createdAt) }}</TimelineDateLink>
                 </td>
               </tr>
             </tbody>

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -10,6 +10,11 @@ import {
 import type { PropertyEntry, PropertyFilter } from '~~/shared/properties'
 import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
 import { APPLICATION_STATUS_TRANSITIONS, INTERVIEW_STATUS_TRANSITIONS } from '~~/shared/status-transitions'
+import {
+  formatRelativeTime,
+  getApplicationTransitionButtonClass,
+  getApplicationTransitionLabel,
+} from '~/utils/status-display'
 
 definePageMeta({
   layout: 'dashboard',
@@ -535,37 +540,6 @@ useSeoMeta({
   robots: 'noindex, nofollow',
 })
 
-// ─────────────────────────────────────────────
-// Application status transitions
-// ─────────────────────────────────────────────
-
-const statusBadgeClasses: Record<string, string> = {
-  new: 'bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-400',
-  screening: 'bg-violet-50 text-violet-700 dark:bg-violet-950 dark:text-violet-400',
-  interview: 'bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-400',
-  offer: 'bg-teal-50 text-teal-700 dark:bg-teal-950 dark:text-teal-400',
-  hired: 'bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-400',
-  rejected: 'bg-surface-100 text-surface-500 dark:bg-surface-800 dark:text-surface-400',
-}
-
-const transitionLabels: Record<string, string> = {
-  new: 'Re-open',
-  screening: 'Screening',
-  interview: 'Interview',
-  offer: 'Offer',
-  hired: 'Hired',
-  rejected: 'Reject',
-}
-
-const transitionClasses: Record<string, string> = {
-  new: 'border border-surface-300 dark:border-surface-600 text-surface-600 dark:text-surface-300 hover:bg-surface-50 dark:hover:bg-surface-800',
-  screening: 'bg-violet-600 text-white hover:bg-violet-700',
-  interview: 'bg-amber-600 text-white hover:bg-amber-700',
-  offer: 'bg-teal-600 text-white hover:bg-teal-700',
-  hired: 'bg-green-700 text-white hover:bg-green-800',
-  rejected: 'bg-danger-600 text-white hover:bg-danger-700',
-}
-
 function formatStatusLabel(status: string) {
   return status.charAt(0).toUpperCase() + status.slice(1)
 }
@@ -586,23 +560,6 @@ function getCandidateInitials(firstName?: string, lastName?: string) {
   const first = firstName?.trim().charAt(0) ?? ''
   const last = lastName?.trim().charAt(0) ?? ''
   return `${first}${last}`.toUpperCase() || 'C'
-}
-
-function timeAgo(date: string | Date) {
-  const diff = Date.now() - new Date(date).getTime()
-  const mins = Math.floor(diff / 60_000)
-  if (mins < 60) return `${mins}m ago`
-  const hrs = Math.floor(mins / 60)
-  if (hrs < 24) return `${hrs}h ago`
-  const days = Math.floor(hrs / 24)
-  if (days < 30) return `${days}d ago`
-  return new Date(date).toLocaleDateString()
-}
-
-function scoreClass(score: number) {
-  if (score >= 75) return 'bg-success-50 text-success-700 dark:bg-success-950 dark:text-success-400'
-  if (score >= 40) return 'bg-warning-50 text-warning-700 dark:bg-warning-950 dark:text-warning-400'
-  return 'bg-danger-50 text-danger-700 dark:bg-danger-950 dark:text-danger-400'
 }
 
 const allowedTransitions = computed(() => {
@@ -1468,7 +1425,7 @@ function closeDocPreview() {
                   >
                     {{ app.score }} pts
                   </span>
-                  <span class="text-[11px] text-surface-400 dark:text-surface-500">{{ timeAgo(app.createdAt) }}</span>
+                  <span class="text-[11px] text-surface-400 dark:text-surface-500">{{ formatRelativeTime(app.createdAt) }}</span>
                   <span v-if="applicationsWithInterviews.has(app.id)" class="inline-flex items-center text-warning-500 dark:text-warning-400" title="Interview scheduled">
                     <Calendar class="size-3" />
                   </span>
@@ -1508,10 +1465,10 @@ function closeDocPreview() {
                   :key="nextStatus"
                   :disabled="isMutating"
                   class="cursor-pointer rounded-lg px-3 py-1.5 text-xs font-semibold transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm inline-flex items-center gap-1.5"
-                  :class="transitionClasses[nextStatus] ?? 'border border-surface-300 text-surface-600 hover:bg-surface-50'"
+                  :class="getApplicationTransitionButtonClass(nextStatus)"
                   @click="nextStatus === 'interview' ? openInterviewScheduler() : changeStatus(nextStatus)"
                 >
-                  {{ transitionLabels[nextStatus] ?? nextStatus }}
+                  {{ getApplicationTransitionLabel(nextStatus) }}
                   <kbd class="inline-flex items-center justify-center rounded px-1 py-0.5 text-[10px] font-mono leading-none opacity-60 bg-black/10 dark:bg-white/10 min-w-[16px]">{{ idx + 1 }}</kbd>
                 </button>
               </div>
@@ -2414,7 +2371,7 @@ function closeDocPreview() {
                 >
                   {{ app.score }}pts
                 </span>
-                <span class="text-[10px] text-surface-400 dark:text-surface-500">{{ timeAgo(app.createdAt) }}</span>
+                <span class="text-[10px] text-surface-400 dark:text-surface-500">{{ formatRelativeTime(app.createdAt) }}</span>
               </div>
             </div>
           </button>

--- a/app/pages/dashboard/jobs/index.vue
+++ b/app/pages/dashboard/jobs/index.vue
@@ -5,6 +5,7 @@ import {
   LayoutGrid, List, Table2, ArrowUp, ArrowDown, ArrowUpDown,
   Check, ChevronDown,
 } from 'lucide-vue-next'
+import { getJobStatusBadgeClass } from '~/utils/status-display'
 
 definePageMeta({
   layout: 'dashboard',
@@ -41,17 +42,6 @@ function getStageCount(pipeline: any, key: string): number {
 // ─────────────────────────────────────────────
 
 const { jobs, total, fetchStatus, error, refresh } = useJobs()
-
-// ─────────────────────────────────────────────
-// Job status config
-// ─────────────────────────────────────────────
-
-const statusBadgeClasses: Record<string, string> = {
-  draft: 'bg-surface-100 text-surface-600 dark:bg-surface-800 dark:text-surface-400',
-  open: 'bg-success-50 text-success-700 dark:bg-success-950 dark:text-success-400',
-  closed: 'bg-warning-50 text-warning-700 dark:bg-warning-950 dark:text-warning-400',
-  archived: 'bg-surface-100 text-surface-400 dark:bg-surface-800 dark:text-surface-500',
-}
 
 const typeLabels: Record<string, string> = {
   full_time: 'Full-time',
@@ -818,7 +808,7 @@ const noResults = computed(() => !isEmpty.value && filteredJobs.value.length ===
                 <td class="px-4 py-3">
                   <span
                     class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize"
-                    :class="statusBadgeClasses[j.status] ?? 'bg-surface-100 text-surface-600'"
+                    :class="getJobStatusBadgeClass(j.status)"
                   >
                     {{ j.status }}
                   </span>
@@ -883,7 +873,7 @@ const noResults = computed(() => !isEmpty.value && filteredJobs.value.length ===
               </NuxtLink>
               <span
                 class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium shrink-0 capitalize mt-0.5"
-                :class="statusBadgeClasses[j.status] ?? 'bg-surface-100 text-surface-600'"
+                :class="getJobStatusBadgeClass(j.status)"
               >
                 {{ j.status }}
               </span>
@@ -973,7 +963,7 @@ const noResults = computed(() => !isEmpty.value && filteredJobs.value.length ===
                 </NuxtLink>
                 <span
                   class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium shrink-0 capitalize mt-0.5"
-                  :class="statusBadgeClasses[j.status] ?? 'bg-surface-100 text-surface-600'"
+                  :class="getJobStatusBadgeClass(j.status)"
                 >
                   {{ j.status }}
                 </span>
@@ -1055,7 +1045,7 @@ const noResults = computed(() => !isEmpty.value && filteredJobs.value.length ===
                 </NuxtLink>
                 <span
                   class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium shrink-0 capitalize mt-0.5"
-                  :class="statusBadgeClasses[j.status] ?? 'bg-surface-100 text-surface-600'"
+                  :class="getJobStatusBadgeClass(j.status)"
                 >
                   {{ j.status }}
                 </span>

--- a/app/pages/dashboard/settings/members.vue
+++ b/app/pages/dashboard/settings/members.vue
@@ -2,7 +2,7 @@
 import type { Component } from 'vue'
 import {
   Users, UserPlus, Shield, ShieldCheck, Crown,
-  MoreHorizontal, Trash2, ChevronDown, Loader2,
+  MoreHorizontal, Trash2, Loader2,
   Mail, Clock, X, Check, AlertTriangle, RefreshCw,
   Link2, Copy, Eye, EyeOff, UserCheck, UserX, MessageSquare, Search,
 } from 'lucide-vue-next'
@@ -593,16 +593,14 @@ onUnmounted(() => {
               />
             </div>
 
-            <div class="relative">
-              <select
-                v-model="inviteRole"
-                class="ui-field appearance-none pr-8 cursor-pointer"
-              >
-                <option value="member">Member</option>
-                <option value="admin">Admin</option>
-              </select>
-              <ChevronDown class="ui-field-icon absolute right-2.5 top-1/2 -translate-y-1/2 size-3.5 pointer-events-none" />
-            </div>
+            <FactorySelect
+              v-model="inviteRole"
+              class="w-36"
+              :options="[
+                { value: 'member', label: 'Member' },
+                { value: 'admin', label: 'Admin' },
+              ]"
+            />
 
             <button
               :disabled="isInviting || !inviteEmail.trim()"
@@ -797,31 +795,23 @@ onUnmounted(() => {
           <div class="flex flex-wrap gap-3 items-end">
             <div>
               <label class="block text-xs font-medium text-surface-600 dark:text-surface-400 mb-1">Role</label>
-              <div class="relative">
-                <select
-                  v-model="newLinkRole"
-                  class="ui-field appearance-none pr-8 py-1.5 cursor-pointer"
-                >
-                  <option value="member">Member</option>
-                  <option value="admin">Admin</option>
-                </select>
-                <ChevronDown class="ui-field-icon absolute right-2.5 top-1/2 -translate-y-1/2 size-3 pointer-events-none" />
-              </div>
+              <FactorySelect
+                v-model="newLinkRole"
+                class="w-36"
+                :options="[
+                  { value: 'member', label: 'Member' },
+                  { value: 'admin', label: 'Admin' },
+                ]"
+              />
             </div>
 
             <div>
               <label class="block text-xs font-medium text-surface-600 dark:text-surface-400 mb-1">Expires in</label>
-              <div class="relative">
-                <select
-                  v-model="newLinkExpiresInHours"
-                  class="ui-field appearance-none pr-8 py-1.5 cursor-pointer"
-                >
-                  <option v-for="opt in expiryOptions" :key="opt.value" :value="opt.value">
-                    {{ opt.label }}
-                  </option>
-                </select>
-                <ChevronDown class="ui-field-icon absolute right-2.5 top-1/2 -translate-y-1/2 size-3 pointer-events-none" />
-              </div>
+              <FactorySelect
+                v-model="newLinkExpiresInHours"
+                class="w-36"
+                :options="expiryOptions.map(opt => ({ value: opt.value, label: opt.label }))"
+              />
             </div>
 
             <div>

--- a/app/utils/status-display.ts
+++ b/app/utils/status-display.ts
@@ -425,6 +425,24 @@ function titleizeStatus(status: string): string {
     .join(' ')
 }
 
+export function formatRelativeTime(date: string | Date, now = Date.now()): string {
+  const diff = now - new Date(date).getTime()
+  const mins = Math.max(0, Math.floor(diff / 60_000))
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  const days = Math.floor(hrs / 24)
+  if (days < 30) return `${days}d ago`
+  return new Date(date).toLocaleDateString()
+}
+
+export function formatFileSize(bytes: number | null | undefined): string {
+  if (bytes == null) return '—'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
 export function getApplicationStatusLabel(status: string): string {
   return isApplicationStatus(status) ? APPLICATION_STATUS_LABELS[status] : titleizeStatus(status)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,9 @@
         "vitest": "^4.1.0",
         "vue-tsc": "^3.2.5",
         "wait-on": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=22.22.0 <23 || >=24.11.0 <25"
       }
     },
     "node_modules/@ai-sdk/anthropic": {

--- a/server/api/dashboard/stats.get.ts
+++ b/server/api/dashboard/stats.get.ts
@@ -146,6 +146,8 @@ export default defineCachedEventHandler(async (event) => {
 }, {
   maxAge: 30,
   swr: true,
-  // Org-scoped caching: the request cookies + permission check ensure
-  // different organizations get separate cache entries.
+  // Nitro cached handlers strip request headers unless they are listed here.
+  // The auth/permission check needs cookies, and the cached response must stay
+  // scoped to the caller's session.
+  varies: ['cookie'],
 })

--- a/tests/unit/dashboard-stats-cache.test.ts
+++ b/tests/unit/dashboard-stats-cache.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('dashboard stats cache', () => {
+  const source = readFileSync(join(process.cwd(), 'server/api/dashboard/stats.get.ts'), 'utf8')
+
+  it('varies by cookie so the cached handler preserves auth headers', () => {
+    expect(source).toContain("varies: ['cookie']")
+  })
+})

--- a/tests/unit/language-feature-flag.test.ts
+++ b/tests/unit/language-feature-flag.test.ts
@@ -54,4 +54,21 @@ describe('language feature flag', () => {
     expect(switcher).toMatch(/languageFeatureEnabled/)
     expect(switcher).toMatch(/v-if="languageFeatureEnabled"/)
   })
+
+  it('hides the dashboard language menu section when language support is disabled', () => {
+    const topBar = read('app/components/AppTopBar.vue')
+
+    expect(topBar).toMatch(/languageFeatureEnabled/)
+    expect(topBar).toMatch(/v-if="languageFeatureEnabled"[\s\S]*<p[^>]*>Language<\/p>[\s\S]*<LanguageSwitcher/)
+  })
+
+  it('hides localization settings navigation when language support is disabled', () => {
+    const sidebar = read('app/components/SettingsSidebar.vue')
+    const mobileNav = read('app/components/SettingsMobileNav.vue')
+
+    expect(sidebar).toMatch(/languageFeatureEnabled/)
+    expect(sidebar).toMatch(/filter\(\(item\) => languageFeatureEnabled \|\| item\.to !== '\/dashboard\/settings\/localization'\)/)
+    expect(mobileNav).toMatch(/languageFeatureEnabled/)
+    expect(mobileNav).toMatch(/filter\(\(item\) => languageFeatureEnabled \|\| item\.to !== '\/dashboard\/settings\/localization'\)/)
+  })
 })

--- a/tests/unit/status-display.test.ts
+++ b/tests/unit/status-display.test.ts
@@ -14,6 +14,8 @@ import {
   getCandidateResponseIconClass,
   getCandidateResponseLabel,
   getCandidateResponseSymbol,
+  formatFileSize,
+  formatRelativeTime,
   getJobStatusBadgeClass,
   getJobStatusLabel,
   getScoreBadgeClass,
@@ -98,5 +100,17 @@ describe('status display helpers', () => {
     expect(getCandidateResponseButtonClass('tentative')).toContain('warning')
     expect(getCandidateResponseIconClass('declined')).toContain('danger')
     expect(getCandidateResponseSymbol('accepted')).toBe('✓')
+  })
+
+  it('centralizes common dashboard formatting helpers', () => {
+    const now = new Date('2026-05-23T12:00:00Z').getTime()
+
+    expect(formatRelativeTime('2026-05-23T11:58:00Z', now)).toBe('2m ago')
+    expect(formatRelativeTime('2026-05-23T09:00:00Z', now)).toBe('3h ago')
+    expect(formatRelativeTime('2026-05-20T12:00:00Z', now)).toBe('3d ago')
+    expect(formatFileSize(null)).toBe('—')
+    expect(formatFileSize(512)).toBe('512 B')
+    expect(formatFileSize(1536)).toBe('1.5 KB')
+    expect(formatFileSize(2 * 1024 * 1024)).toBe('2.0 MB')
   })
 })

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -552,6 +552,13 @@ describe('brand-neutral theme variables', () => {
     }
   })
 
+  it('does not pass layout visibility classes through fragment-root app chrome components', () => {
+    const settingsLayout = readProjectFile('app/layouts/settings.vue')
+
+    expect(settingsLayout).not.toMatch(/<AppTopBar\s+class=/)
+    expect(settingsLayout).toMatch(/<div\s+class="hidden lg:block">\s*<AppTopBar\s*\/>\s*<\/div>/)
+  })
+
   it('applies shared UI recipes to interview list and template surfaces', () => {
     const interviewList = readProjectFile('app/pages/dashboard/interviews/index.vue')
 

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -746,4 +746,105 @@ describe('brand-neutral theme variables', () => {
       }
     }
   })
+
+  it('keeps remaining detail surfaces behind shared modal and drawer recipes', () => {
+    const disallowedPatternsByFile: Array<{ path: string, patterns: RegExp[] }> = [
+      {
+        path: 'app/components/ApplicationDetailDrawer.vue',
+        patterns: [/fixed inset-0 z-\[55\] bg-black\/75/],
+      },
+      {
+        path: 'app/components/CandidateDetailDrawer.vue',
+        patterns: [/fixed inset-0 z-\[55\] bg-black\/75/],
+      },
+      {
+        path: 'app/components/InterviewScheduleSidebar.vue',
+        patterns: [/absolute inset-0 bg-black\/50/],
+      },
+      {
+        path: 'app/pages/dashboard/interviews/[id].vue',
+        patterns: [
+          /absolute inset-0 bg-black\/40/,
+          /relative bg-white dark:bg-surface-900 rounded-2xl/,
+          /const statusConfig:/,
+          /const transitionClasses:/,
+        ],
+      },
+    ]
+
+    for (const { path, patterns } of disallowedPatternsByFile) {
+      const source = readProjectFile(path)
+
+      for (const pattern of patterns) {
+        expect(source, `${path} should centralize ${pattern}`).not.toMatch(pattern)
+      }
+    }
+  })
+
+  it('does not leave native selects in internal Factory dashboard controls', () => {
+    const internalSelectFiles = [
+      'app/components/AiConfigForm.vue',
+      'app/components/CandidateDetailSidebar.vue',
+      'app/components/PropertyFilterBar.vue',
+      'app/components/PropertySchemaEditor.vue',
+      'app/components/QuestionForm.vue',
+      'app/components/ScoreBreakdown.vue',
+      'app/pages/dashboard/settings/members.vue',
+    ]
+
+    for (const path of internalSelectFiles) {
+      const source = readProjectFile(path)
+      expect(source, `${path} should use FactorySelect instead of native select`).not.toContain('<select')
+    }
+  })
+
+  it('keeps remaining dashboard display helpers centralized', () => {
+    const disallowedPatternsByFile: Array<{ path: string, patterns: RegExp[] }> = [
+      {
+        path: 'app/pages/dashboard/index.vue',
+        patterns: [/const statusBadgeClasses:/],
+      },
+      {
+        path: 'app/pages/dashboard/jobs/index.vue',
+        patterns: [/const statusBadgeClasses:/],
+      },
+      {
+        path: 'app/pages/dashboard/jobs/[id]/index.vue',
+        patterns: [
+          /const statusBadgeClasses:/,
+          /const transitionClasses:/,
+          /function timeAgo/,
+          /function scoreClass/,
+        ],
+      },
+      {
+        path: 'app/pages/dashboard/jobs/[id]/candidates.vue',
+        patterns: [/function timeAgo/],
+      },
+      {
+        path: 'app/pages/dashboard/applications/index.vue',
+        patterns: [/function timeAgo/],
+      },
+      {
+        path: 'app/components/CandidateDetailDrawer.vue',
+        patterns: [/function formatFileSize/],
+      },
+      {
+        path: 'app/pages/dashboard/candidates/[id].vue',
+        patterns: [/function formatFileSize/],
+      },
+      {
+        path: 'app/components/DynamicField.vue',
+        patterns: [/function formatFileSize/],
+      },
+    ]
+
+    for (const { path, patterns } of disallowedPatternsByFile) {
+      const source = readProjectFile(path)
+
+      for (const pattern of patterns) {
+        expect(source, `${path} should centralize ${pattern}`).not.toMatch(pattern)
+      }
+    }
+  })
 })

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -805,6 +805,13 @@ describe('brand-neutral theme variables', () => {
     }
   })
 
+  it('keeps FactorySelect labels associated with the interactive control', () => {
+    const source = readProjectFile('app/components/FactorySelect.vue')
+
+    expect(source).toMatch(/defineOptions\(\{\s*inheritAttrs:\s*false,\s*\}\)/)
+    expect(source).toMatch(/<button[\s\S]*:id="id"/)
+  })
+
   it('keeps remaining dashboard display helpers centralized', () => {
     const disallowedPatternsByFile: Array<{ path: string, patterns: RegExp[] }> = [
       {


### PR DESCRIPTION
## Summary

Completes the remaining Issue 8 theme-cleanup gaps found in the audit.

- centralizes remaining dashboard status/date/file-size display helpers in shared utilities
- routes lingering modal and drawer surfaces through shared portal/panel/backdrop recipes
- replaces native dashboard control selects with FactorySelect and adds tests to keep these patterns from drifting back
- removes the settings-layout dev warning caused by passing classes into fragment-root app chrome
- preserves authenticated dashboard stats caching by varying the cached handler on the session cookie
- hides remaining language/localization UI surfaces while language support is disabled by default

## Why

The prior Issue 8 pass handled the broad theme-token work, but a few dashboard surfaces still had local display mappings, one-off overlay styling, and native selects in internal controls. This PR closes those remaining implementation gaps while preserving Factory-facing product shell names.

Closes #8

## Validation

- npm run typecheck
- npm run test:unit
- npm run build
- git diff --check
- rg guard checks for the removed raw selects and modal/detail patterns
- npm run test:unit -- tests/unit/dashboard-stats-cache.test.ts tests/unit/auth-session.test.ts tests/unit/dockerfile-npm-auth.test.ts tests/unit/status-display.test.ts tests/unit/theme-neutrality.test.ts
- npm run test:unit -- tests/unit/language-feature-flag.test.ts tests/unit/theme-neutrality.test.ts tests/unit/status-display.test.ts tests/unit/dashboard-stats-cache.test.ts
- required-env browser smoke on localhost:3003 using the existing local req env from the 520e checkout
- local browser smoke on http://localhost:3001 after rebasing PR #34: /jobs returns 200, /dashboard loads with authenticated session, Microsoft SSO callback route reaches Better Auth instead of the Vite 426 listener

## Required-env browser QA

- /jobs rendered real job data, no framework overlay, and no console warnings/errors.
- /jobs search showed the no-match empty state, and the job type menu opened with All types, Full-time, Part-time, Contract, and Internship.
- /dashboard/jobs loaded authenticated dashboard data with the existing localhost session.
- /dashboard/jobs/factory-general-interest loaded the job pipeline detail surface.
- /dashboard/settings/members loaded authenticated settings data, rendered no native <select> elements in the page body, and emitted no browser console warnings/errors after the settings topbar wrapper fix.
- /jobs on localhost:3001 renders without public language switcher UI while language support is disabled.
- /dashboard on localhost:3001 loads after Microsoft SSO with the dev server bound to localhost:3001 for the configured callback origin.