### PR TITLE
fix: handle auth origin errors with toasts

### DIFF
--- a/app/layouts/auth.vue
+++ b/app/layouts/auth.vue
@@ -54,5 +54,6 @@ const localePath = useLocalePath()
         </div>
       </section>
     </main>
+    <AppToasts />
   </div>
 </template>

--- a/app/pages/auth/sign-in.vue
+++ b/app/pages/auth/sign-in.vue
@@ -12,11 +12,15 @@ useSeoMeta({
 
 const FACTORY_SSO_PROVIDER_ID = "thefactoryhq-sso";
 
-const error = ref("");
 const ssoRedirecting = ref(false);
 const route = useRoute();
 const localePath = useLocalePath();
 const { track } = useTrack();
+const toast = useToast();
+
+function showSignInError(message: string, details?: string) {
+    toast.error("Microsoft sign-in failed", { message, details });
+}
 
 onMounted(() => {
     track("signin_page_viewed");
@@ -26,16 +30,17 @@ onMounted(() => {
 
     const description = route.query.error_description as string | undefined;
     const normalizedError = ssoError.replace(/\+/g, " ");
-    error.value =
+    showSignInError(
         description?.replace(/\+/g, " ") ||
         (normalizedError === "account not linked"
             ? "That Microsoft account is not linked to Factory Careers yet. Ask an owner for an invitation, then try again."
-            : "SSO authentication failed. Please try again.");
+            : "SSO authentication failed. Please try again."),
+        normalizedError,
+    );
 });
 
 async function handleFactorySso() {
     ssoRedirecting.value = true;
-    error.value = "";
 
     const pendingInvitation = route.query.invitation as string | undefined;
     const callbackURL = pendingInvitation
@@ -54,9 +59,11 @@ async function handleFactorySso() {
         });
 
         if (result.error) {
-            error.value =
+            showSignInError(
                 result.error.message ??
-                "Microsoft SSO is not available yet. Ask an owner to check the SSO configuration.";
+                "Microsoft SSO is not available yet. Ask an owner to check the SSO configuration.",
+                result.error.code,
+            );
             ssoRedirecting.value = false;
             return;
         }
@@ -69,10 +76,11 @@ async function handleFactorySso() {
 
         track("signin_sso_started");
     } catch (e: unknown) {
-        error.value =
+        showSignInError(
             e instanceof Error
                 ? e.message
-                : "Microsoft SSO sign-in failed. Please try again.";
+                : "Microsoft SSO sign-in failed. Please try again.",
+        );
         ssoRedirecting.value = false;
     }
 }
@@ -80,13 +88,6 @@ async function handleFactorySso() {
 
 <template>
     <form class="flex flex-col gap-5" @submit.prevent="handleFactorySso">
-        <div
-            v-if="error"
-            class="border border-danger-500/35 bg-danger-950/50 p-3 text-sm leading-6 text-danger-100"
-        >
-            {{ error }}
-        </div>
-
         <button
             type="submit"
             :disabled="ssoRedirecting"

--- a/app/pages/auth/sign-up.vue
+++ b/app/pages/auth/sign-up.vue
@@ -15,11 +15,11 @@ const name = ref("");
 const email = ref("");
 const password = ref("");
 const confirmPassword = ref("");
-const error = ref("");
 const isLoading = ref(false);
 const config = useRuntimeConfig();
 const localePath = useLocalePath();
 const { track } = useTrack();
+const toast = useToast();
 const { data: authProviders } = await useFetch('/api/auth/providers');
 const oidcEnabled = computed(() => authProviders.value?.oidc ?? false);
 const oidcProviderName = computed(
@@ -46,27 +46,31 @@ const publicSignupEnabled = computed(
     () => config.public.factoryPublicSignupEnabled === true,
 );
 
-async function handleSignUp() {
-    error.value = "";
+function showSignUpError(title: string, message: string, details?: string) {
+    toast.error(title, { message, details });
+}
 
+async function handleSignUp() {
     if (!publicSignupEnabled.value) {
-        error.value =
-            "Factory Careers account creation is invitation-only. Sign in with Microsoft or use an invitation link.";
+        showSignUpError(
+            "Access is invitation-only",
+            "Factory Careers account creation is invitation-only. Sign in with Microsoft or use an invitation link.",
+        );
         return;
     }
 
     if (!name.value || !email.value || !password.value) {
-        error.value = "All fields are required.";
+        showSignUpError("Check your details", "All fields are required.");
         return;
     }
 
     if (password.value.length < 8) {
-        error.value = "Password must be at least 8 characters.";
+        showSignUpError("Check your details", "Password must be at least 8 characters.");
         return;
     }
 
     if (password.value !== confirmPassword.value) {
-        error.value = "Passwords do not match.";
+        showSignUpError("Check your details", "Passwords do not match.");
         return;
     }
 
@@ -81,15 +85,12 @@ async function handleSignUp() {
     });
 
     if (result.error) {
-        if (result.error.status === 500) {
-            error.value =
-                result.error.message && result.error.message !== "Server Error"
-                    ? result.error.message
-                    : 'Sign-up failed due to a server error. Make sure BETTER_AUTH_URL is set to "https://careers.thefactoryhq.com" in production and redeploy.';
-        } else {
-            error.value =
-                result.error.message ?? "Sign-up failed. Please try again.";
-        }
+        const message = result.error.status === 500
+            ? result.error.message && result.error.message !== "Server Error"
+                ? result.error.message
+                : 'Sign-up failed due to a server error. Make sure BETTER_AUTH_URL is set to "https://careers.thefactoryhq.com" in production and redeploy.'
+            : result.error.message ?? "Sign-up failed. Please try again.";
+        showSignUpError("Sign-up failed", message, result.error.code);
         track("signup_failed", { error_type: result.error.code ?? "unknown" });
         isLoading.value = false;
         return;
@@ -111,20 +112,29 @@ async function handleSignUp() {
 
 async function handleSsoSignUp() {
     isLoading.value = true;
-    error.value = "";
     const callbackURL = pendingInvitation.value
         ? localePath(`/auth/accept-invitation/${pendingInvitation.value}`)
         : localePath("/dashboard");
     try {
-        await authClient.signIn.oauth2({
+        const result = await authClient.signIn.oauth2({
             providerId: "oidc",
             callbackURL,
         });
+        if (result.error) {
+            showSignUpError(
+                "SSO sign-up failed",
+                result.error.message ?? "SSO sign-up failed. Please try again.",
+                result.error.code,
+            );
+            isLoading.value = false;
+        }
     } catch (e: unknown) {
-        error.value =
+        showSignUpError(
+            "SSO sign-up failed",
             e instanceof Error
                 ? e.message
-                : "SSO sign-up failed. Please try again.";
+                : "SSO sign-up failed. Please try again.",
+        );
         isLoading.value = false;
     }
 }
@@ -136,20 +146,29 @@ async function handleSsoSignUp() {
  */
 async function handleSocialSignUp(providerId: string) {
     socialLoading.value = providerId;
-    error.value = "";
     const callbackURL = pendingInvitation.value
         ? localePath(`/auth/accept-invitation/${pendingInvitation.value}`)
         : localePath("/onboarding/create-org");
     try {
-        await authClient.signIn.social({
+        const result = await authClient.signIn.social({
             provider: providerId as "google" | "github" | "microsoft",
             callbackURL,
         });
+        if (result.error) {
+            showSignUpError(
+                "Social sign-up failed",
+                result.error.message ?? "Social sign-up failed. Please try again.",
+                result.error.code,
+            );
+            socialLoading.value = null;
+        }
     } catch (e: unknown) {
-        error.value =
+        showSignUpError(
+            "Social sign-up failed",
             e instanceof Error
                 ? e.message
-                : "Social sign-up failed. Please try again.";
+                : "Social sign-up failed. Please try again.",
+        );
         socialLoading.value = null;
     }
 }
@@ -190,13 +209,6 @@ async function handleSocialSignUp(providerId: string) {
         >
             Create account
         </h2>
-
-        <div
-            v-if="error"
-            class="rounded-md border border-danger-200 dark:border-danger-800 bg-danger-50 dark:bg-danger-950 p-3 text-sm text-danger-700 dark:text-danger-400"
-        >
-            {{ error }}
-        </div>
 
         <!-- Social sign-up providers (Google, GitHub, Microsoft) -->
         <template v-if="socialProviders.length">

--- a/server/api/auth/[...all].ts
+++ b/server/api/auth/[...all].ts
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
     })
 
     // Detect BETTER_AUTH_URL mismatch — the #1 self-hosting setup issue
-    const requestOrigin = requestUrl.origin
+    const requestOrigin = getRequestURL(event, { xForwardedHost: true }).origin
     const configuredUrl = env.BETTER_AUTH_URL?.trim() || env.RAILWAY_PUBLIC_DOMAIN?.trim()
     const configuredOrigin = configuredUrl
       ? (() => { try { return new URL(configuredUrl.startsWith('http') ? configuredUrl : `https://${configuredUrl}`).origin } catch { return configuredUrl } })()

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -8,6 +8,11 @@ import { ac, owner, admin, member } from "~~/shared/permissions";
 import { sendOrgInvitationEmail, sendPasswordResetEmail } from "./email";
 import { deleteFromS3 } from "./s3";
 import { readPositiveIntegerEnv } from "./rateLimitConfig";
+import {
+  collectRequestTrustedOrigins,
+  normalizeTrustedOrigin,
+  uniqueTrustedOrigins,
+} from "./authOrigins";
 import * as schema from "../database/schema";
 
 type Auth = ReturnType<typeof betterAuth>;
@@ -72,12 +77,17 @@ function resolveTrustedOrigins(baseUrl: string): (request?: Request) => Promise<
         ]
       : [];
 
-  const staticOrigins = Array.from(
-    new Set([baseOrigin.origin, ...configuredOrigins, ...defaultDevOrigins]),
-  );
+  const staticOrigins = uniqueTrustedOrigins([
+    baseOrigin.origin,
+    ...configuredOrigins,
+    ...defaultDevOrigins,
+  ]);
 
-  return async () => {
-    const allOrigins = [...staticOrigins];
+  return async (request) => {
+    const allOrigins = [
+      ...staticOrigins,
+      ...collectRequestTrustedOrigins(request),
+    ];
 
     // Load already-registered SSO provider issuers from the database
     try {
@@ -86,7 +96,8 @@ function resolveTrustedOrigins(baseUrl: string): (request?: Request) => Promise<
         .from(schema.ssoProvider);
 
       for (const p of providers) {
-        try { allOrigins.push(new URL(p.issuer).origin); } catch {}
+        const issuerOrigin = normalizeTrustedOrigin(p.issuer);
+        if (issuerOrigin) allOrigins.push(issuerOrigin);
       }
     } catch {
       // Table may not exist yet (pre-migration)

--- a/server/utils/authOrigins.ts
+++ b/server/utils/authOrigins.ts
@@ -69,14 +69,6 @@ export function collectRequestTrustedOrigins(request?: Request): string[] {
     if (origin) origins.add(origin)
   }
 
-  const headerOrigin =
-    originFromUrl(request.headers.get('origin')) ??
-    originFromUrl(request.headers.get('referer'))
-
-  if (headerOrigin && origins.has(headerOrigin)) {
-    origins.add(headerOrigin)
-  }
-
   return [...origins]
 }
 

--- a/server/utils/authOrigins.ts
+++ b/server/utils/authOrigins.ts
@@ -1,0 +1,89 @@
+function firstHeaderValue(value: string | null): string | null {
+  const first = value?.split(',')[0]?.trim()
+  return first || null
+}
+
+function protocolFrom(value: string | null): 'http' | 'https' | null {
+  const protocol = firstHeaderValue(value)?.toLowerCase()
+  return protocol === 'http' || protocol === 'https' ? protocol : null
+}
+
+function requestProtocol(request: Request): 'http' | 'https' {
+  const forwardedProtocol = protocolFrom(request.headers.get('x-forwarded-proto'))
+  if (forwardedProtocol) return forwardedProtocol
+
+  try {
+    const protocol = new URL(request.url).protocol
+    return protocol === 'http:' ? 'http' : 'https'
+  } catch {
+    return 'https'
+  }
+}
+
+function originFromHost(host: string | null, protocol: 'http' | 'https'): string | null {
+  const cleanHost = firstHeaderValue(host)
+    ?.replace(/^https?:\/\//i, '')
+    .split('/')[0]
+    ?.trim()
+
+  if (!cleanHost) return null
+  return normalizeTrustedOrigin(`${protocol}://${cleanHost}`)
+}
+
+function originFromUrl(value: string | null): string | null {
+  if (!value) return null
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+      ? url.origin
+      : null
+  } catch {
+    return null
+  }
+}
+
+export function normalizeTrustedOrigin(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  if (!trimmed) return null
+
+  if (trimmed.includes('*') || trimmed.includes('?')) {
+    return trimmed.replace(/\/+$/, '')
+  }
+
+  const explicitOrigin = originFromUrl(trimmed)
+  if (explicitOrigin) return explicitOrigin
+
+  return originFromUrl(`https://${trimmed.replace(/^\/+/, '')}`)
+}
+
+export function collectRequestTrustedOrigins(request?: Request): string[] {
+  if (!request) return []
+
+  const origins = new Set<string>()
+  const protocol = requestProtocol(request)
+  const requestOrigin = originFromUrl(request.url)
+  const forwardedOrigin = originFromHost(request.headers.get('x-forwarded-host'), protocol)
+  const hostOrigin = originFromHost(request.headers.get('host'), protocol)
+
+  for (const origin of [requestOrigin, forwardedOrigin, hostOrigin]) {
+    if (origin) origins.add(origin)
+  }
+
+  const headerOrigin =
+    originFromUrl(request.headers.get('origin')) ??
+    originFromUrl(request.headers.get('referer'))
+
+  if (headerOrigin && origins.has(headerOrigin)) {
+    origins.add(headerOrigin)
+  }
+
+  return [...origins]
+}
+
+export function uniqueTrustedOrigins(origins: Array<string | null | undefined>): string[] {
+  const normalized = origins
+    .map((origin) => normalizeTrustedOrigin(origin))
+    .filter((origin): origin is string => !!origin)
+
+  return [...new Set(normalized)]
+}

--- a/tests/unit/auth-origin.test.ts
+++ b/tests/unit/auth-origin.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectRequestTrustedOrigins,
+  normalizeTrustedOrigin,
+} from '../../server/utils/authOrigins'
+
+describe('auth trusted origin helpers', () => {
+  it('trusts the public forwarded origin for proxied production auth posts', () => {
+    const request = new Request('http://internal-render:10000/api/auth/sign-in/sso', {
+      method: 'POST',
+      headers: {
+        origin: 'https://careers.thefactoryhq.com',
+        host: 'internal-render:10000',
+        'x-forwarded-host': 'careers.thefactoryhq.com',
+        'x-forwarded-proto': 'https',
+      },
+    })
+
+    expect(collectRequestTrustedOrigins(request)).toContain('https://careers.thefactoryhq.com')
+  })
+
+  it('does not trust an unrelated origin header just because it was sent', () => {
+    const request = new Request('https://careers.thefactoryhq.com/api/auth/sign-in/sso', {
+      method: 'POST',
+      headers: {
+        origin: 'https://attacker.example',
+        host: 'careers.thefactoryhq.com',
+      },
+    })
+
+    expect(collectRequestTrustedOrigins(request)).not.toContain('https://attacker.example')
+  })
+
+  it('normalizes configured urls with paths to plain origins', () => {
+    expect(normalizeTrustedOrigin('https://careers.thefactoryhq.com/api/auth'))
+      .toBe('https://careers.thefactoryhq.com')
+  })
+
+  it('keeps trusted-origin wildcard patterns intact', () => {
+    expect(normalizeTrustedOrigin('https://*.factory-preview.example'))
+      .toBe('https://*.factory-preview.example')
+  })
+})

--- a/tests/unit/auth-toast-surface.test.ts
+++ b/tests/unit/auth-toast-surface.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = process.cwd()
+const read = (path: string) => readFileSync(join(root, path), 'utf8')
+
+describe('auth error toast surface', () => {
+  it('mounts the global toast renderer on auth pages', () => {
+    expect(read('app/layouts/auth.vue')).toContain('<AppToasts />')
+  })
+
+  it('shows Microsoft sign-in failures through toast errors', () => {
+    const source = read('app/pages/auth/sign-in.vue')
+
+    expect(source).toContain('const toast = useToast()')
+    expect(source).toContain('toast.error(')
+    expect(source).not.toContain('v-if="error"')
+  })
+
+  it('shows social sign-up failures through toast errors', () => {
+    const source = read('app/pages/auth/sign-up.vue')
+
+    expect(source).toContain('const toast = useToast()')
+    expect(source).toContain('toast.error(')
+  })
+})


### PR DESCRIPTION
## Summary

- show auth failures on the auth pages through the global toast surface
- add request-aware trusted-origin handling for proxied production auth requests
- keep origin normalization covered with regression tests

## Root cause

Better Auth validates POST requests with cookies against `trustedOrigins`. Our resolver accepted a request argument but ignored it, so proxied production requests could arrive with a public browser origin that was not represented by the internal request URL/host seen by the server.

## Validation

- `npm run test:unit`
- `npm run typecheck` (exits 0; Nuxt/Vue prints the existing `vue-router/volar/sfc-route-blocks` package-export warning)
