### PR TITLE
fix: shorten Tracking and AI labels

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -2170,6 +2170,12 @@
     text-transform: uppercase !important;
   }
 
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-pipeline-status-chip {
+    font-weight: 300 !important;
+    letter-spacing: 0 !important;
+    text-transform: uppercase !important;
+  }
+
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-toolbar-button {
     min-height: 40px;
     border-color: var(--ui-border-strong) !important;

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -2202,6 +2202,26 @@
     color: #080808 !important;
   }
 
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-job-subnav-tab {
+    min-height: 32px;
+    border: 1px solid var(--ui-border-strong) !important;
+    background-color: rgb(0 0 0 / 0.45) !important;
+    color: rgb(255 255 255 / 0.62) !important;
+    box-shadow: none !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-job-subnav-tab:hover {
+    border-color: rgb(255 255 255 / 0.32) !important;
+    background-color: rgb(255 255 255 / 0.055) !important;
+    color: #ffffff !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-job-subnav-tab-active {
+    border-color: color-mix(in srgb, var(--color-brand-500) 75%, transparent) !important;
+    background-color: color-mix(in srgb, var(--color-brand-500) 14%, #000000) !important;
+    color: #ffffff !important;
+  }
+
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-job-more-button {
     height: 28px;
     width: 28px;

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -2171,6 +2171,8 @@
   }
 
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-pipeline-status-chip {
+    height: 32px !important;
+    min-height: 32px !important;
     font-weight: 300 !important;
     letter-spacing: 0 !important;
     text-transform: uppercase !important;

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -2309,6 +2309,40 @@
     color: rgb(255 205 213) !important;
   }
 
+  .factory-job-more-menu {
+    border-color: var(--ui-border-strong) !important;
+    background-color: #050505 !important;
+    color: #ffffff !important;
+    box-shadow: 0 18px 48px rgb(0 0 0 / 0.62) !important;
+  }
+
+  .factory-job-more-menu .factory-job-more-menu-item {
+    background-color: transparent !important;
+    color: rgb(255 255 255 / 0.72) !important;
+  }
+
+  .factory-job-more-menu .factory-job-more-menu-item svg {
+    color: var(--color-brand-400) !important;
+  }
+
+  .factory-job-more-menu .factory-job-more-menu-item:hover {
+    background-color: color-mix(in srgb, var(--color-brand-500) 14%, transparent) !important;
+    color: #ffffff !important;
+  }
+
+  .factory-job-more-menu .factory-job-more-menu-divider {
+    border-color: var(--ui-border) !important;
+  }
+
+  .factory-job-more-menu .factory-job-more-menu-danger {
+    color: rgb(253 164 175) !important;
+  }
+
+  .factory-job-more-menu .factory-job-more-menu-danger:hover {
+    background-color: rgb(244 63 94 / 0.14) !important;
+    color: rgb(255 205 213) !important;
+  }
+
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-ai-config-action {
     border-color: transparent !important;
     background-color: transparent !important;

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -371,6 +371,28 @@
     color: var(--color-surface-200);
   }
 
+  .ui-panel-close-button {
+    border-color: transparent !important;
+    background-color: transparent !important;
+    color: var(--color-surface-500) !important;
+  }
+
+  .ui-panel-close-button:hover:not(:disabled) {
+    border-color: transparent !important;
+    background-color: transparent !important;
+    color: var(--color-surface-700) !important;
+  }
+
+  .dark .ui-panel-close-button {
+    color: rgb(255 255 255 / 0.42) !important;
+  }
+
+  .dark .ui-panel-close-button:hover:not(:disabled) {
+    border-color: transparent !important;
+    background-color: transparent !important;
+    color: rgb(255 255 255 / 0.78) !important;
+  }
+
   .ui-button-danger {
     background-color: var(--color-danger-600);
     color: #ffffff;
@@ -1286,6 +1308,22 @@
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-button-ghost:hover:not(:disabled) {
     background-color: color-mix(in srgb, var(--color-brand-500) 12%, transparent) !important;
     color: #ffffff !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-panel-close-button,
+  .factory-dashboard-portal.ui-panel-close-button,
+  .factory-dashboard-portal .ui-panel-close-button {
+    border-color: transparent !important;
+    background-color: transparent !important;
+    color: rgb(255 255 255 / 0.42) !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-panel-close-button:hover:not(:disabled),
+  .factory-dashboard-portal.ui-panel-close-button:hover:not(:disabled),
+  .factory-dashboard-portal .ui-panel-close-button:hover:not(:disabled) {
+    border-color: transparent !important;
+    background-color: transparent !important;
+    color: rgb(255 255 255 / 0.78) !important;
   }
 
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-button-danger {

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -775,6 +775,11 @@
     width: 0.5rem;
     height: 0.5rem;
     border-radius: 9999px;
+    background-color: var(--color-surface-400);
+  }
+
+  .ui-status-dot-brand {
+    background-color: var(--color-brand-500);
   }
 
   .ui-status-dot-success {
@@ -783,6 +788,10 @@
 
   .ui-status-dot-warning {
     background-color: var(--color-warning-500);
+  }
+
+  .ui-status-dot-danger {
+    background-color: var(--color-danger-500);
   }
 
   .ui-code {
@@ -1437,6 +1446,10 @@
 
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-status-dot-warning {
     background-color: rgb(245 158 11) !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-status-dot-danger {
+    background-color: rgb(239 68 68) !important;
   }
 
   :where(.factory-dashboard-shell, .factory-dashboard-portal) :is(

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -781,6 +781,10 @@
     background-color: var(--color-success-500);
   }
 
+  .ui-status-dot-warning {
+    background-color: var(--color-warning-500);
+  }
+
   .ui-code {
     border-radius: 0.25rem;
     background-color: var(--color-surface-100);
@@ -1429,6 +1433,10 @@
 
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-status-dot-success {
     background-color: rgb(34 197 94) !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-status-dot-warning {
+    background-color: rgb(245 158 11) !important;
   }
 
   :where(.factory-dashboard-shell, .factory-dashboard-portal) :is(

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -2222,6 +2222,43 @@
     color: #ffffff !important;
   }
 
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-job-status-action {
+    height: 28px;
+    min-height: 28px;
+    border-color: var(--ui-border-strong) !important;
+    background-color: rgb(0 0 0 / 0.45) !important;
+    color: rgb(255 255 255 / 0.72) !important;
+    font-weight: 400 !important;
+    letter-spacing: 0 !important;
+    line-height: 1 !important;
+    text-transform: uppercase !important;
+    box-shadow: none !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-job-status-action:hover:not(:disabled) {
+    border-color: #ffffff !important;
+    background-color: #ffffff !important;
+    color: #080808 !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-job-status-action-open {
+    border-color: color-mix(in srgb, var(--color-success-500) 70%, transparent) !important;
+    background-color: color-mix(in srgb, var(--color-success-500) 22%, #000000) !important;
+    color: rgb(187 247 208) !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-job-status-action-closed {
+    border-color: color-mix(in srgb, var(--color-brand-500) 75%, transparent) !important;
+    background-color: color-mix(in srgb, var(--color-brand-500) 92%, #000000) !important;
+    color: #ffffff !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-job-status-action-secondary {
+    border-color: var(--ui-border-strong) !important;
+    background-color: rgb(0 0 0 / 0.45) !important;
+    color: rgb(255 255 255 / 0.72) !important;
+  }
+
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-job-more-button {
     height: 28px;
     width: 28px;

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -2584,7 +2584,7 @@
   }
 
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-pipeline-segment-screening {
-    background-color: color-mix(in srgb, var(--color-brand-500) 72%, #ffffff 28%) !important;
+    background-color: var(--color-brand-500) !important;
   }
 
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-pipeline-segment-interview {

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -444,6 +444,49 @@
     color: var(--color-surface-500);
   }
 
+  .ui-filter-chip {
+    display: inline-flex;
+    box-sizing: border-box;
+    min-height: 2.375rem;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--color-surface-300);
+    border-radius: 0.375rem;
+    background-color: #ffffff;
+    color: var(--color-surface-600);
+    transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
+  }
+
+  .ui-filter-chip-inactive:hover {
+    border-color: var(--color-surface-400);
+    background-color: var(--color-surface-50);
+    color: var(--color-surface-800);
+  }
+
+  .ui-filter-chip-active {
+    border-color: var(--color-brand-500);
+    background-color: var(--color-brand-50);
+    color: var(--color-brand-700);
+  }
+
+  .dark .ui-filter-chip {
+    border-color: var(--color-surface-700);
+    background-color: var(--color-surface-900);
+    color: var(--color-surface-300);
+  }
+
+  .dark .ui-filter-chip-inactive:hover {
+    border-color: var(--color-surface-600);
+    background-color: var(--color-surface-800);
+    color: var(--color-surface-100);
+  }
+
+  .dark .ui-filter-chip-active {
+    border-color: var(--color-brand-500);
+    background-color: color-mix(in srgb, var(--color-brand-500) 16%, transparent);
+    color: var(--color-brand-300);
+  }
+
   .ui-icon-state {
     display: flex;
     width: 3rem;
@@ -1285,6 +1328,27 @@
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-field:focus-within {
     border-color: color-mix(in srgb, var(--color-brand-500) 75%, transparent) !important;
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-brand-500) 20%, transparent) !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-filter-chip {
+    min-height: 38px;
+    border: 1px solid var(--ui-border-strong) !important;
+    border-radius: 0 !important;
+    background-color: rgb(0 0 0 / 0.45) !important;
+    color: rgb(255 255 255 / 0.72) !important;
+    box-shadow: none !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-filter-chip-inactive:hover {
+    border-color: rgb(255 255 255 / 0.32) !important;
+    background-color: rgb(255 255 255 / 0.055) !important;
+    color: #ffffff !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-filter-chip-active {
+    border-color: color-mix(in srgb, var(--color-brand-500) 75%, transparent) !important;
+    background-color: color-mix(in srgb, var(--color-brand-500) 14%, #000000) !important;
+    color: #ffffff !important;
   }
 
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-icon-state {

--- a/app/components/AppBackLink.vue
+++ b/app/components/AppBackLink.vue
@@ -14,7 +14,7 @@ defineEmits<{
   click: [event: MouseEvent]
 }>()
 
-const baseClass = 'inline-flex h-10 min-h-10 items-center gap-2 border border-white/16 bg-black px-4 py-0 text-xs font-medium uppercase tracking-normal text-white/62 transition-colors no-underline hover:border-brand-500 hover:text-white'
+const baseClass = 'inline-flex h-10 min-h-10 items-center gap-2 border border-white/16 bg-black px-4 py-0 text-xs font-medium uppercase tracking-normal text-white/62 transition-colors no-underline hover:border-white hover:bg-white hover:text-black'
 </script>
 
 <template>

--- a/app/components/AppTopBar.vue
+++ b/app/components/AppTopBar.vue
@@ -492,7 +492,7 @@ onUnmounted(() => {
                 <div class="border-b border-white/10 p-2 space-y-2">
                   <div class="space-y-1.5">
                     <p class="px-1 text-[10px] font-semibold uppercase tracking-wide text-white/38">Organization</p>
-                    <OrgSwitcher />
+                    <OrgSwitcher inline-panel />
                   </div>
                   <div v-if="languageFeatureEnabled" class="space-y-1.5">
                     <p class="px-1 text-[10px] font-semibold uppercase tracking-wide text-white/38">Language</p>

--- a/app/components/AppTopBar.vue
+++ b/app/components/AppTopBar.vue
@@ -231,7 +231,7 @@ onUnmounted(() => {
           </NuxtLink>
 
           <!-- Desktop nav links -->
-          <nav class="hidden md:flex items-center gap-0.5">
+          <nav class="hidden md:flex min-w-0 items-center gap-0.5 overflow-visible">
             <NuxtLink
               v-for="item in primaryNavItems"
               :key="item.to"
@@ -243,8 +243,8 @@ onUnmounted(() => {
                 : 'border-transparent text-white/58 hover:text-white'"
             >
               <component :is="item.icon" class="size-4" />
-              <span class="hidden xl:inline">{{ item.label }}</span>
-              <span class="pointer-events-none absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 translate-y-1 whitespace-nowrap border border-white/12 bg-black px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-white opacity-0 shadow-xl shadow-black/40 transition-all duration-150 xl:hidden group-hover:translate-y-0 group-hover:opacity-100 group-focus-visible:translate-y-0 group-focus-visible:opacity-100">
+              <span class="hidden min-[1500px]:inline">{{ item.label }}</span>
+              <span class="pointer-events-none absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 translate-y-1 whitespace-nowrap border border-white/12 bg-black px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-white opacity-0 shadow-xl shadow-black/40 transition-all duration-150 min-[1500px]:hidden group-hover:translate-y-0 group-hover:opacity-100 group-focus-visible:translate-y-0 group-focus-visible:opacity-100">
                 {{ item.label }}
               </span>
             </NuxtLink>
@@ -260,8 +260,8 @@ onUnmounted(() => {
                 : 'border-transparent text-white/58 hover:text-white'"
             >
               <component :is="item.icon" class="size-4" />
-              <span class="hidden 2xl:inline">{{ item.label }}</span>
-              <span class="pointer-events-none absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 translate-y-1 whitespace-nowrap border border-white/12 bg-black px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-white opacity-0 shadow-xl shadow-black/40 transition-all duration-150 2xl:hidden group-hover:translate-y-0 group-hover:opacity-100 group-focus-visible:translate-y-0 group-focus-visible:opacity-100">
+              <span class="hidden min-[1800px]:inline">{{ item.label }}</span>
+              <span class="pointer-events-none absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 translate-y-1 whitespace-nowrap border border-white/12 bg-black px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-white opacity-0 shadow-xl shadow-black/40 transition-all duration-150 min-[1800px]:hidden group-hover:translate-y-0 group-hover:opacity-100 group-focus-visible:translate-y-0 group-focus-visible:opacity-100">
                 {{ item.label }}
               </span>
             </NuxtLink>
@@ -320,7 +320,7 @@ onUnmounted(() => {
         </div>
 
         <!-- Right: Actions -->
-        <div class="flex items-center gap-1 lg:gap-1.5">
+        <div class="flex shrink-0 items-center gap-1 pl-2 lg:gap-1.5 lg:pl-3 xl:pl-4">
           <!-- Get Started CTA (demo mode only) -->
           <div v-if="isDemo" ref="getStartedMenuRoot" class="relative hidden sm:block">
             <button
@@ -384,7 +384,7 @@ onUnmounted(() => {
 
           <!-- New Job button (desktop) -->
           <button
-            class="factory-button-cta factory-button-premium hidden h-9 items-center gap-1.5 px-3.5 text-[13px] sm:inline-flex"
+            class="factory-button-cta factory-button-premium mx-1 hidden h-9 items-center gap-1.5 px-3.5 text-[13px] sm:inline-flex"
             @click="handleNewJobClick"
           >
             <Plus class="size-3.5" />

--- a/app/components/AppTopBar.vue
+++ b/app/components/AppTopBar.vue
@@ -104,6 +104,7 @@ const { data: feedbackConfig } = useFetch('/api/feedback/config', {
 const isFeedbackEnabled = computed(() => feedbackConfig.value?.enabled === true)
 
 const showChatbot = useFeatureFlagEnabled('chatbot-experience')
+const showFactoryMoreActions = false
 
 const jobTabs = computed(() => {
   if (!activeJobId.value) return []
@@ -393,6 +394,7 @@ onUnmounted(() => {
 
           <!-- More actions dropdown -->
           <div
+            v-if="showFactoryMoreActions"
             ref="moreActionsMenuRoot"
             class="relative hidden sm:block"
             @mouseenter="showMoreActions = true"

--- a/app/components/AppTopBar.vue
+++ b/app/components/AppTopBar.vue
@@ -112,7 +112,7 @@ const jobTabs = computed(() => {
     { label: 'Pipeline', to: base, icon: Kanban, exact: true },
     { label: 'Table', to: `${base}/candidates`, icon: Table2, exact: true },
     { label: 'Application Form', to: `${base}/application-form`, icon: FileText, exact: true },
-    { label: 'AI Analysis', to: `${base}/ai-analysis`, icon: Sparkles, exact: true },
+    { label: 'AI', to: `${base}/ai-analysis`, icon: Sparkles, exact: true },
     { label: 'Settings', to: `${base}/settings`, icon: Settings, exact: true },
   ]
 })
@@ -128,8 +128,8 @@ const mainNav: Array<{ label: string; to: string; icon: typeof Briefcase; exact:
   { label: 'Applications', to: '/dashboard/applications', icon: FileText, exact: false },
   { label: 'Interviews', to: '/dashboard/interviews', icon: Calendar, exact: false },
   { label: 'Timeline', to: '/dashboard/timeline', icon: History, exact: true },
-  { label: 'Source Tracking', to: '/dashboard/source-tracking', icon: Radio, exact: true },
-  { label: 'AI Analysis', to: '/dashboard/ai-analysis', icon: Sparkles, exact: true },
+  { label: 'Tracking', to: '/dashboard/source-tracking', icon: Radio, exact: true },
+  { label: 'AI', to: '/dashboard/ai-analysis', icon: Sparkles, exact: true },
   { label: 'Settings', to: '/dashboard/settings', icon: Settings, exact: false },
 ]
 
@@ -138,7 +138,7 @@ const mainNav: Array<{ label: string; to: string; icon: typeof Briefcase; exact:
 const flaggedNav = computed(() => {
   const items: Array<{ label: string; to: string; icon: typeof Briefcase; exact: boolean; afterLabel: string }> = []
   if (showChatbot.value) {
-    items.push({ label: 'Assistant', to: '/dashboard/chatbot', icon: MessageCircle, exact: false, afterLabel: 'AI Analysis' })
+    items.push({ label: 'Assistant', to: '/dashboard/chatbot', icon: MessageCircle, exact: false, afterLabel: 'AI' })
   }
   return items
 })

--- a/app/components/AppTopBar.vue
+++ b/app/components/AppTopBar.vue
@@ -589,10 +589,10 @@ onUnmounted(() => {
               v-for="tab in jobTabs"
               :key="tab.to"
               :to="$localePath(tab.to)"
-              class="factory-button-cta factory-button-cta-sm flex items-center gap-1.5 border px-2.5 py-1 text-xs transition-all duration-200 no-underline whitespace-nowrap shrink-0"
+              class="factory-button-cta factory-button-cta-sm factory-job-subnav-tab flex items-center gap-1.5 border px-2.5 py-1 text-xs transition-all duration-200 no-underline whitespace-nowrap shrink-0"
               :class="isActiveRoute(tab.to, tab.exact)
-                ? 'border-brand-500/50 bg-brand-500/12 text-white'
-                : 'border-transparent text-white/50 hover:bg-white/[0.04] hover:text-white'"
+                ? 'factory-job-subnav-tab-active border-brand-500/50 bg-brand-500/12 text-white'
+                : 'factory-job-subnav-tab-inactive text-white/50 hover:bg-white/[0.04] hover:text-white'"
             >
               <component :is="tab.icon" class="size-3.5" />
               <span class="hidden sm:inline">{{ tab.label }}</span>

--- a/app/components/AppTopBar.vue
+++ b/app/components/AppTopBar.vue
@@ -562,10 +562,11 @@ onUnmounted(() => {
         <div class="flex items-center gap-2 sm:gap-4 px-3 sm:px-4 lg:px-6 h-10 overflow-x-auto scrollbar-none">
           <NuxtLink
             :to="$localePath('/dashboard/jobs')"
-            class="hidden sm:flex items-center gap-1 text-xs font-medium text-white/45 hover:text-white transition-colors no-underline shrink-0"
+            class="hidden sm:flex size-8 items-center justify-center text-white/45 hover:text-white transition-colors no-underline shrink-0"
+            aria-label="All jobs"
+            title="All jobs"
           >
             <ChevronLeft class="size-3.5" />
-            All Jobs
           </NuxtLink>
 
           <div class="hidden sm:block w-px h-4 bg-white/10 shrink-0" />

--- a/app/components/ApplicationDetailDrawer.vue
+++ b/app/components/ApplicationDetailDrawer.vue
@@ -176,7 +176,8 @@ onUnmounted(() => {
               Open full page
             </NuxtLink>
             <button
-              class="factory-toolbar-button p-1.5 text-white/58 hover:text-white transition-colors"
+              class="ui-panel-close-button p-1.5 transition-colors"
+              aria-label="Close application detail"
               @click="emit('close')"
             >
               <X class="size-4" />

--- a/app/components/ApplyCandidateModal.vue
+++ b/app/components/ApplyCandidateModal.vue
@@ -78,7 +78,7 @@ async function applyCandidate(candidateId: string) {
           </div>
           <button
             type="button"
-            class="flex size-8 cursor-pointer items-center justify-center border border-transparent bg-transparent text-white/42 transition-colors hover:border-white/14 hover:bg-white/[0.06] hover:text-white"
+            class="ui-panel-close-button flex size-8 cursor-pointer items-center justify-center transition-colors"
             aria-label="Close"
             @click="emit('close')"
           >

--- a/app/components/CandidateDetailDrawer.vue
+++ b/app/components/CandidateDetailDrawer.vue
@@ -341,7 +341,7 @@ onUnmounted(() => {
                       Schedule
                     </button>
                     <span
-                      class="inline-flex shrink-0 items-center border px-2 py-0.5 text-[10px] font-semibold uppercase"
+                      class="inline-flex h-8 min-h-8 shrink-0 items-center border px-2.5 py-0 text-[10px] font-semibold uppercase"
                       :class="getApplicationStatusBadgeClass(app.status, 'factory')"
                     >
                       {{ app.status }}

--- a/app/components/CandidateDetailDrawer.vue
+++ b/app/components/CandidateDetailDrawer.vue
@@ -155,7 +155,8 @@ onUnmounted(() => {
               Open full page
             </NuxtLink>
             <button
-              class="factory-toolbar-button p-1.5 text-white/58 hover:text-white transition-colors"
+              class="ui-panel-close-button p-1.5 transition-colors"
+              aria-label="Close candidate detail"
               @click="emit('close')"
             >
               <X class="size-4" />

--- a/app/components/CandidateDetailSidebar.vue
+++ b/app/components/CandidateDetailSidebar.vue
@@ -527,7 +527,7 @@ function formatInterviewDate(dateStr: string) {
             @click="activeTab = 'ai_analysis'"
           >
             <Brain class="size-3.5" />
-            AI Analysis
+            AI
           </button>
           <button
             class="ui-tab cursor-pointer px-3 py-2.5 text-sm font-medium -mb-px inline-flex items-center gap-1.5"

--- a/app/components/CandidateDetailSidebar.vue
+++ b/app/components/CandidateDetailSidebar.vue
@@ -479,7 +479,7 @@ function formatInterviewDate(dateStr: string) {
             Schedule
           </button>
           <button
-            class="ui-button ui-button-ghost p-1.5"
+            class="ui-button ui-button-ghost ui-panel-close-button p-1.5"
             title="Close (Esc)"
             @click="emit('close')"
           >

--- a/app/components/ChatbotSourcesPanel.vue
+++ b/app/components/ChatbotSourcesPanel.vue
@@ -64,7 +64,8 @@ function hrefFor(s: ChatbotSource): string | null {
         </span>
       </div>
       <button
-        class="inline-flex size-7 items-center justify-center rounded text-surface-500 hover:bg-surface-200 dark:hover:bg-surface-800 cursor-pointer border-0 bg-transparent"
+        class="ui-panel-close-button inline-flex size-7 items-center justify-center rounded cursor-pointer border-0"
+        aria-label="Close sources"
         @click="emit('close')"
       >
         <X class="size-4" />

--- a/app/components/FilterDrawer.vue
+++ b/app/components/FilterDrawer.vue
@@ -111,7 +111,7 @@ onUnmounted(() => {
           </div>
           <button
             type="button"
-            class="ui-button ui-button-ghost shrink-0 p-1.5"
+            class="ui-button ui-button-ghost ui-panel-close-button shrink-0 p-1.5"
             aria-label="Close"
             @click="close"
           >
@@ -150,7 +150,7 @@ onUnmounted(() => {
             </button>
             <button
               type="button"
-              class="ui-button ui-button-ghost p-1.5"
+              class="ui-button ui-button-ghost ui-panel-close-button p-1.5"
               aria-label="Cancel"
               @click="showSaveForm = false; newName = ''"
             >

--- a/app/components/InterviewScheduleSidebar.vue
+++ b/app/components/InterviewScheduleSidebar.vue
@@ -458,7 +458,8 @@ async function handleMoveToInterview() {
                 </p>
               </div>
               <button
-                class="flex items-center justify-center rounded-lg p-2 -mr-1.5 -mt-0.5 text-surface-400 hover:text-surface-600 hover:bg-surface-100 dark:text-surface-500 dark:hover:text-surface-300 dark:hover:bg-surface-800 transition-colors cursor-pointer"
+                class="ui-panel-close-button flex items-center justify-center rounded-lg p-2 -mr-1.5 -mt-0.5 transition-colors cursor-pointer"
+                aria-label="Close interview scheduler"
                 @click="showSuccess ? emit('scheduled', createdInterview ?? undefined) : emit('close')"
               >
                 <X class="size-4" />

--- a/app/components/JobSubNavActions.vue
+++ b/app/components/JobSubNavActions.vue
@@ -24,11 +24,18 @@ const jobTransitionLabels: Record<string, string> = {
   archived: 'Archive',
 }
 
+const jobTransitionTooltips: Record<string, string> = {
+  draft: 'Move this job back to draft so it is no longer published.',
+  open: 'Publish this job so candidates can apply.',
+  closed: 'Close this job so new candidates can no longer apply.',
+  archived: 'Archive this job and remove it from active hiring workflows.',
+}
+
 const jobTransitionClasses: Record<string, string> = {
-  open: 'bg-success-600 text-white hover:bg-success-700',
-  closed: 'factory-button-cta factory-button-premium',
-  draft: 'border border-surface-300 dark:border-surface-600 text-surface-600 dark:text-surface-300 hover:bg-surface-50 dark:hover:bg-surface-800',
-  archived: 'border border-surface-300 dark:border-surface-600 text-surface-600 dark:text-surface-300 hover:bg-surface-50 dark:hover:bg-surface-800',
+  open: 'factory-job-status-action-open',
+  closed: 'factory-job-status-action-closed',
+  draft: 'factory-job-status-action-secondary',
+  archived: 'factory-job-status-action-secondary',
 }
 
 const allowedJobTransitions = computed(() => {
@@ -214,8 +221,10 @@ function openPropertyEditor(scope: 'org' | 'job') {
       <button
         v-if="primaryJobTransition"
         :disabled="isJobTransitioning"
-        class="inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2.5 py-1 text-[11px] font-semibold transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
-        :class="jobTransitionClasses[primaryJobTransition] ?? 'border border-surface-300 text-surface-600 hover:bg-surface-50'"
+        class="factory-button-cta factory-button-cta-sm factory-job-status-action inline-flex cursor-pointer items-center gap-1.5 border px-2.5 py-0 text-[11px] transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+        :class="jobTransitionClasses[primaryJobTransition] ?? 'factory-job-status-action-secondary'"
+        :title="jobTransitionTooltips[primaryJobTransition] ?? `Change job status to ${primaryJobTransition}`"
+        :aria-label="jobTransitionTooltips[primaryJobTransition] ?? `Change job status to ${primaryJobTransition}`"
         @click="handleJobTransition(primaryJobTransition)"
       >
         {{ jobTransitionLabels[primaryJobTransition] ?? primaryJobTransition }}

--- a/app/components/OrgSwitcher.vue
+++ b/app/components/OrgSwitcher.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { ChevronDown } from 'lucide-vue-next'
 
+const props = defineProps<{
+  inlinePanel?: boolean
+}>()
+
 const { orgs, activeOrg, switchOrg } = useCurrentOrg()
 const isOpen = ref(false)
 const isSwitching = ref(false)
@@ -46,7 +50,10 @@ onUnmounted(() => document.removeEventListener('click', onClickOutside))
 
     <div
       v-if="isOpen"
-      class="absolute top-[calc(100%+4px)] left-0 z-50 min-w-full w-max overflow-hidden border border-white/12 bg-black shadow-2xl shadow-black/50"
+      class="z-50 overflow-hidden border border-white/12 bg-black shadow-2xl shadow-black/50"
+      :class="props.inlinePanel
+        ? 'relative mt-1 max-h-56 w-full overflow-y-auto'
+        : 'absolute top-[calc(100%+4px)] left-0 min-w-full w-max'"
     >
       <div class="border-b border-white/10 px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-white/38">
         Organization

--- a/app/components/PropertyFilterBar.vue
+++ b/app/components/PropertyFilterBar.vue
@@ -197,7 +197,7 @@ const showableDefs = computed(() => definitions.value)
       <div
         v-if="editingIdx === idx"
         :ref="(el) => setEditElRef(el, idx)"
-        class="ui-floating-menu absolute left-0 top-full z-30 mt-1 w-80 max-w-[calc(100vw-2rem)] p-3"
+        class="ui-floating-menu factory-filter-dropdown-menu absolute left-0 top-full z-50 mt-1 w-80 max-w-[calc(100vw-2rem)] p-3"
       >
         <template v-if="definitionMap.get(f.propertyDefinitionId) as PropertyDefinition">
           <div class="space-y-2">
@@ -287,7 +287,7 @@ const showableDefs = computed(() => definitions.value)
     <div class="relative" ref="pickerEl">
       <button
         type="button"
-        class="ui-button ui-button-secondary px-2.5 py-1 text-xs"
+        class="ui-button ui-button-secondary factory-filter-dropdown-trigger px-2.5 py-1 text-xs"
         @click="pickerOpen = !pickerOpen"
       >
         <component :is="modelValue.length === 0 ? Filter : Plus" class="size-3.5" />
@@ -295,14 +295,14 @@ const showableDefs = computed(() => definitions.value)
       </button>
       <div
         v-if="pickerOpen"
-        class="ui-floating-menu absolute left-0 top-full z-30 mt-1 w-64 max-w-[calc(100vw-2rem)]"
+        class="ui-floating-menu factory-filter-dropdown-menu absolute left-0 top-full z-50 mt-1 w-64 max-w-[calc(100vw-2rem)]"
       >
         <div class="max-h-72 overflow-y-auto py-1">
           <button
             v-for="def in showableDefs"
             :key="def.id"
             type="button"
-            class="ui-menu-action justify-between px-3 py-1.5 text-sm"
+            class="ui-menu-action factory-filter-dropdown-option justify-between px-3 py-1.5 text-sm"
             @click="addFilter(def)"
           >
             <span class="truncate text-surface-800 dark:text-surface-100">{{ def.name }}</span>

--- a/app/components/PropertySchemaEditor.vue
+++ b/app/components/PropertySchemaEditor.vue
@@ -221,7 +221,7 @@ const overlayTitle = computed(() => {
             </p>
           </div>
           <button
-            class="factory-toolbar-button inline-flex h-9 min-h-9 w-9 cursor-pointer items-center justify-center border p-0 transition-colors"
+            class="ui-panel-close-button inline-flex h-9 min-h-9 w-9 cursor-pointer items-center justify-center p-0 transition-colors"
             aria-label="Close properties"
             @click="emit('close')"
           >

--- a/app/components/ScoreBreakdown.vue
+++ b/app/components/ScoreBreakdown.vue
@@ -63,6 +63,11 @@ watch(scoreData, (val) => {
 const resolvedScoreData = computed(() => scoreData.value ?? cachedScoreData.value)
 const hasScores = computed(() => (resolvedScoreData.value?.scores?.length ?? 0) > 0)
 const isInitialLoad = computed(() => status.value === 'pending' && !cachedScoreData.value)
+const scoringSummary = computed(() => {
+  const summary = resolvedScoreData.value?.latestRun?.summary
+  return typeof summary === 'string' ? summary.trim() : ''
+})
+const scoringSummaryFallback = 'No AI summary was stored for this score. Re-score to generate one.'
 
 function confidenceLabel(confidence: number): string {
   if (confidence >= 80) return 'High'
@@ -205,6 +210,24 @@ async function retryParse() {
             {{ resolvedScoreData!.latestRun?.compositeScore ?? '—' }}
           </span>
           <span class="text-sm text-surface-400">/ 100</span>
+        </div>
+
+        <div class="mt-4">
+          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-surface-500 dark:text-surface-500">
+            AI summary
+          </p>
+          <p
+            v-if="scoringSummary"
+            class="mt-2 max-w-3xl text-sm leading-6 text-surface-700 dark:text-surface-300"
+          >
+            {{ scoringSummary }}
+          </p>
+          <p
+            v-else
+            class="mt-2 max-w-3xl text-sm leading-6 text-surface-500 dark:text-surface-500"
+          >
+            {{ scoringSummaryFallback }}
+          </p>
         </div>
 
         <!-- Run metadata -->

--- a/app/components/ScoreBreakdown.vue
+++ b/app/components/ScoreBreakdown.vue
@@ -185,10 +185,13 @@ async function retryParse() {
               :options="aiConfigSelectOptions"
             />
             <button
+              type="button"
               :disabled="isAnalyzing"
-              class="text-xs text-brand-600 dark:text-brand-400 hover:underline disabled:opacity-50"
+              class="factory-button-cta factory-button-premium inline-flex h-8 min-h-8 cursor-pointer items-center justify-center gap-1.5 px-2.5 py-0 text-[11px] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
               @click="runAnalysis"
             >
+              <Loader2 v-if="isAnalyzing" class="size-3 animate-spin" />
+              <Brain v-else class="size-3" />
               {{ isAnalyzing ? 'Re-scoring…' : 'Re-score' }}
             </button>
           </div>

--- a/app/composables/useJob.ts
+++ b/app/composables/useJob.ts
@@ -17,6 +17,23 @@ export function useJob(id: MaybeRefOrGetter<string>) {
     },
   )
 
+  function syncJobListCache(updatedJob: { id: string } & Record<string, unknown>) {
+    const { data: sidebarJobsData } = useNuxtData<{ data: Array<Record<string, unknown>> }>('sidebar-jobs-list')
+    if (!sidebarJobsData.value?.data) return
+
+    sidebarJobsData.value = {
+      ...sidebarJobsData.value,
+      data: sidebarJobsData.value.data.map((item) => {
+        if (item.id !== updatedJob.id) return item
+        return {
+          ...item,
+          ...updatedJob,
+          pipeline: item.pipeline,
+        }
+      }),
+    }
+  }
+
   /** Update job fields (partial) and refresh both detail and list caches */
   async function updateJob(payload: Partial<{
     title: string
@@ -41,8 +58,10 @@ export function useJob(id: MaybeRefOrGetter<string>) {
         method: 'PATCH',
         body: payload,
       })
+      syncJobListCache(updated)
       await refresh()
       await refreshNuxtData('jobs')
+      await refreshNuxtData('sidebar-jobs-list')
       return updated
     } catch (error) {
       handlePreviewReadOnlyError(error)
@@ -59,6 +78,7 @@ export function useJob(id: MaybeRefOrGetter<string>) {
       throw error
     }
     await refreshNuxtData('jobs')
+    await refreshNuxtData('sidebar-jobs-list')
     await navigateTo(localePath('/dashboard/jobs'))
   }
 

--- a/app/pages/dashboard/ai-analysis.vue
+++ b/app/pages/dashboard/ai-analysis.vue
@@ -15,7 +15,7 @@ definePageMeta({
 })
 
 useSeoMeta({
-  title: 'AI Analysis — Factory Careers',
+  title: 'AI — Factory Careers',
   robots: 'noindex, nofollow',
 })
 
@@ -164,7 +164,7 @@ function formatDateTime(dateStr: string | Date): string {
       <!-- ─── Header ─── -->
       <div class="flex items-center justify-between mb-10">
         <div>
-          <h1 class="text-2xl font-bold text-surface-900 dark:text-surface-50 tracking-tight">AI Analysis</h1>
+          <h1 class="text-2xl font-bold text-surface-900 dark:text-surface-50 tracking-tight">AI</h1>
           <p class="text-sm text-surface-400 dark:text-surface-500 mt-1">Overview of AI scoring runs and token usage</p>
         </div>
       </div>

--- a/app/pages/dashboard/candidates/index.vue
+++ b/app/pages/dashboard/candidates/index.vue
@@ -614,17 +614,27 @@ const selectedCandidateId = ref<string | null>(null)
                   </div>
                 </div>
                 <button
-                  v-else
+                  v-else-if="c.quickNotes"
                   type="button"
                   class="group/notes flex items-start gap-1 text-left w-full min-h-[1.5rem]"
                   @click="startEditNotes(c.id, c.quickNotes ?? null)"
                 >
                   <StickyNote class="size-3.5 shrink-0 mt-0.5 text-surface-300 dark:text-surface-600 group-hover/notes:text-brand-500 transition-colors" />
                   <span
-                    v-if="c.quickNotes"
                     class="text-xs text-surface-600 dark:text-white/60 line-clamp-2 group-hover/notes:text-surface-900 dark:group-hover/notes:text-surface-100 transition-colors"
                   >{{ c.quickNotes }}</span>
-                  <span v-else class="text-xs text-surface-300 dark:text-surface-600 group-hover/notes:text-white/60 transition-colors italic">Add note…</span>
+                </button>
+                <button
+                  v-else
+                  type="button"
+                  class="group/notes flex w-full cursor-pointer items-center justify-between border border-dashed border-white/12 bg-black px-3 py-2 text-left text-sm text-surface-400 transition-colors hover:border-brand-500/70 hover:bg-brand-500/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-brand-500/40"
+                  @click="startEditNotes(c.id, null)"
+                >
+                  <span class="inline-flex items-center gap-1.5 italic">
+                    <StickyNote class="size-3.5 shrink-0 text-surface-400 transition-colors group-hover/notes:text-brand-400" />
+                    No notes yet.
+                  </span>
+                  <span class="text-xs font-semibold uppercase text-brand-400 transition-colors group-hover/notes:text-brand-300">Add Notes</span>
                 </button>
               </td>
               <!-- Property columns (must come AFTER quick notes to match header order) -->

--- a/app/pages/dashboard/index.vue
+++ b/app/pages/dashboard/index.vue
@@ -22,7 +22,7 @@ const localePath = useLocalePath()
 const { track } = useTrack()
 const { formatPersonName } = useOrgSettings()
 
-onMounted(() => track('dashboard_viewed'))
+let dashboardNowTimer: ReturnType<typeof setInterval> | undefined
 
 // ─────────────────────────────────────────────
 // Fetch dashboard stats
@@ -42,17 +42,35 @@ const {
 // Upcoming interviews (next 7 days)
 // ─────────────────────────────────────────────
 
-const now = new Date()
-// Truncate to start-of-day so the useFetch key is identical on server & client
-// (prevents SSR/hydration mismatch from sub-second timestamp drift)
-const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-const weekFromToday = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000)
+const dashboardNowIso = useState('dashboard-upcoming-interviews-now', () => new Date().toISOString())
+const dashboardNow = computed(() => new Date(dashboardNowIso.value))
+const weekFromDashboardNowIso = computed(() =>
+  new Date(dashboardNow.value.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+)
 
 const { interviews: upcomingInterviews } = useInterviews({
   status: 'scheduled',
-  from: today.toISOString(),
-  to: weekFromToday.toISOString(),
+  from: dashboardNowIso,
+  to: weekFromDashboardNowIso,
   limit: 5,
+})
+
+const upcomingInterviewsForCard = computed(() =>
+  upcomingInterviews.value.filter((interview) =>
+    new Date(interview.scheduledAt).getTime() >= dashboardNow.value.getTime(),
+  ),
+)
+
+onMounted(() => {
+  track('dashboard_viewed')
+  dashboardNowIso.value = new Date().toISOString()
+  dashboardNowTimer = setInterval(() => {
+    dashboardNowIso.value = new Date().toISOString()
+  }, 60_000)
+})
+
+onUnmounted(() => {
+  if (dashboardNowTimer) clearInterval(dashboardNowTimer)
 })
 
 // ─────────────────────────────────────────────
@@ -101,12 +119,12 @@ const interviewTypeLabels: Record<string, string> = {
 
 function formatRelativeDate(dateStr: string) {
   const date = new Date(dateStr)
-  const diffMs = date.getTime() - now.getTime()
+  const diffMs = date.getTime() - dashboardNow.value.getTime()
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
   const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
 
+  if (diffMs <= 0) return 'Now'
   if (diffDays === 0) {
-    if (diffHours <= 0) return 'Now'
     return `In ${diffHours}h`
   }
   if (diffDays === 1) return 'Tomorrow'
@@ -120,7 +138,7 @@ function formatTime(dateStr: string) {
 
 function formatDate(dateStr: string) {
   const date = new Date(dateStr)
-  const diffMs = now.getTime() - date.getTime()
+  const diffMs = dashboardNow.value.getTime() - date.getTime()
   const diffMins = Math.floor(diffMs / 60000)
   const diffHours = Math.floor(diffMs / 3600000)
   const diffDays = Math.floor(diffMs / 86400000)
@@ -487,7 +505,7 @@ const isEmpty = computed(() =>
               </NuxtLink>
             </div>
 
-            <div v-if="upcomingInterviews.length === 0" class="px-5 py-10 text-center">
+            <div v-if="upcomingInterviewsForCard.length === 0" class="px-5 py-10 text-center">
               <div class="mx-auto mb-4 flex items-center justify-center size-12 rounded-2xl bg-surface-100 dark:bg-surface-800">
                 <Calendar class="size-5 text-surface-400 dark:text-surface-500" />
               </div>
@@ -497,7 +515,7 @@ const isEmpty = computed(() =>
 
             <div v-else class="divide-y divide-surface-100 dark:divide-surface-800">
               <NuxtLink
-                v-for="interview in upcomingInterviews"
+                v-for="interview in upcomingInterviewsForCard"
                 :key="interview.id"
                 :to="localePath(`/dashboard/interviews/${interview.id}`)"
                 class="block px-5 py-3.5 hover:bg-surface-50 dark:hover:bg-surface-800/40 transition-colors no-underline group"

--- a/app/pages/dashboard/index.vue
+++ b/app/pages/dashboard/index.vue
@@ -43,15 +43,16 @@ const {
 // ─────────────────────────────────────────────
 
 const dashboardNowIso = useState('dashboard-upcoming-interviews-now', () => new Date().toISOString())
+const dashboardInterviewQueryFromIso = useState('dashboard-upcoming-interviews-query-from', () => new Date().toISOString())
 const dashboardNow = computed(() => new Date(dashboardNowIso.value))
-const weekFromDashboardNowIso = computed(() =>
-  new Date(dashboardNow.value.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+const dashboardInterviewQueryToIso = computed(() =>
+  new Date(new Date(dashboardInterviewQueryFromIso.value).getTime() + 7 * 24 * 60 * 60 * 1000).toISOString(),
 )
 
 const { interviews: upcomingInterviews } = useInterviews({
   status: 'scheduled',
-  from: dashboardNowIso,
-  to: weekFromDashboardNowIso,
+  from: dashboardInterviewQueryFromIso,
+  to: dashboardInterviewQueryToIso,
   limit: 5,
 })
 
@@ -63,7 +64,9 @@ const upcomingInterviewsForCard = computed(() =>
 
 onMounted(() => {
   track('dashboard_viewed')
-  dashboardNowIso.value = new Date().toISOString()
+  const mountedAtIso = new Date().toISOString()
+  dashboardNowIso.value = mountedAtIso
+  dashboardInterviewQueryFromIso.value = mountedAtIso
   dashboardNowTimer = setInterval(() => {
     dashboardNowIso.value = new Date().toISOString()
   }, 60_000)

--- a/app/pages/dashboard/interviews/index.vue
+++ b/app/pages/dashboard/interviews/index.vue
@@ -442,10 +442,9 @@ const statusCounts = computed(() => {
                     {{ interviewItem.title }}
                   </NuxtLink>
                   <span
-                    class="ui-pill inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ring-1 ring-inset"
+                    class="ui-pill inline-flex items-center justify-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ring-1 ring-inset"
                     :class="getInterviewStatusBadgeClass(interviewItem.status)"
                   >
-                    <span class="ui-status-dot size-1.5 rounded-full" :class="getInterviewStatusDotClass(interviewItem.status)" />
                     {{ getInterviewStatusLabel(interviewItem.status) }}
                   </span>
                 </div>

--- a/app/pages/dashboard/interviews/index.vue
+++ b/app/pages/dashboard/interviews/index.vue
@@ -334,13 +334,13 @@ const statusCounts = computed(() => {
         <button
           v-for="s in STATUS_OPTIONS"
           :key="s"
-          class="ui-filter-chip inline-flex h-[38px] items-center gap-1.5 px-3 text-xs cursor-pointer"
+          class="ui-filter-chip inline-flex h-[38px] items-center gap-1.5 px-3 text-[11px] font-light uppercase leading-none tracking-normal cursor-pointer"
           :class="activeStatus === s ? 'ui-filter-chip-active' : 'ui-filter-chip-inactive'"
           @click="activeStatus = activeStatus === s ? undefined : s"
         >
           <span class="ui-status-dot size-1.5 rounded-full" :class="getInterviewStatusDotClass(s)" />
           {{ getInterviewStatusLabel(s) }}
-          <span class="tabular-nums text-[10px] font-semibold" :class="activeStatus === s ? 'text-brand-600 dark:text-brand-400' : 'text-surface-400 dark:text-surface-500'">{{ statusCounts[s] }}</span>
+          <span class="tabular-nums text-[10px] font-normal" :class="activeStatus === s ? 'text-brand-600 dark:text-brand-400' : 'text-surface-400 dark:text-surface-500'">{{ statusCounts[s] }}</span>
         </button>
       </div>
 

--- a/app/pages/dashboard/interviews/index.vue
+++ b/app/pages/dashboard/interviews/index.vue
@@ -135,6 +135,15 @@ function isUpcoming(dateStr: string) {
   return new Date(dateStr) > new Date()
 }
 
+type InterviewDisplayStatus = InterviewStatus | 'scheduled_past'
+
+function getInterviewDisplayStatus(interviewItem: typeof interviews.value[number]): InterviewDisplayStatus {
+  if (interviewItem.status === 'scheduled' && !isUpcoming(interviewItem.scheduledAt)) {
+    return 'scheduled_past'
+  }
+  return interviewItem.status as InterviewStatus
+}
+
 function getCandidateInitials(firstName?: string, lastName?: string) {
   const first = firstName?.trim().charAt(0) ?? ''
   const last = lastName?.trim().charAt(0) ?? ''
@@ -443,9 +452,9 @@ const statusCounts = computed(() => {
                   </NuxtLink>
                   <span
                     class="ui-pill inline-flex items-center justify-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ring-1 ring-inset"
-                    :class="getInterviewStatusBadgeClass(interviewItem.status)"
+                    :class="getInterviewStatusBadgeClass(getInterviewDisplayStatus(interviewItem))"
                   >
-                    {{ getInterviewStatusLabel(interviewItem.status) }}
+                    {{ getInterviewStatusLabel(getInterviewDisplayStatus(interviewItem)) }}
                   </span>
                 </div>
 
@@ -595,7 +604,7 @@ const statusCounts = computed(() => {
               <!-- Timeline dot -->
               <div
                 class="absolute -left-[calc(1.5rem+5px)] top-5 size-2.5 rounded-full ring-2 ring-white dark:ring-surface-950"
-                :class="getInterviewStatusDotClass(interviewItem.status)"
+                :class="getInterviewStatusDotClass(getInterviewDisplayStatus(interviewItem))"
               />
 
               <div class="flex items-start justify-between gap-3">
@@ -607,9 +616,9 @@ const statusCounts = computed(() => {
                     <span class="text-xs text-surface-400">{{ interviewItem.duration }}min</span>
                     <span
                       class="ui-pill inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-semibold ring-1 ring-inset"
-                      :class="getInterviewStatusBadgeClass(interviewItem.status)"
+                      :class="getInterviewStatusBadgeClass(getInterviewDisplayStatus(interviewItem))"
                     >
-                      {{ getInterviewStatusLabel(interviewItem.status) }}
+                      {{ getInterviewStatusLabel(getInterviewDisplayStatus(interviewItem)) }}
                     </span>
                   </div>
                   <p class="mt-1 text-sm font-medium">

--- a/app/pages/dashboard/jobs/[id]/ai-analysis.vue
+++ b/app/pages/dashboard/jobs/[id]/ai-analysis.vue
@@ -17,7 +17,7 @@ const { job, status: jobFetchStatus, error: jobError, updateJob } = useJob(jobId
 
 useSeoMeta({
   title: computed(() =>
-    job.value ? `AI Analysis — ${job.value.title} — Factory Careers` : 'AI Analysis — Factory Careers',
+    job.value ? `AI — ${job.value.title} — Factory Careers` : 'AI — Factory Careers',
   ),
   robots: 'noindex, nofollow',
 })
@@ -320,7 +320,7 @@ function resetCriteria() {
     <template v-else-if="job">
       <!-- Header -->
       <div class="mb-6">
-        <h1 class="text-2xl font-bold text-surface-900 dark:text-surface-50">AI Analysis</h1>
+        <h1 class="text-2xl font-bold text-surface-900 dark:text-surface-50">AI</h1>
         <p class="text-sm text-surface-500 dark:text-surface-400 mt-1">
           Configure how AI evaluates and scores candidates for <strong>{{ job.title }}</strong>.
         </p>

--- a/app/pages/dashboard/jobs/[id]/application-form.vue
+++ b/app/pages/dashboard/jobs/[id]/application-form.vue
@@ -286,7 +286,7 @@ async function copyTrackingUrl(code: string) {
               :to="localePath({ path: '/dashboard/source-tracking', query: { jobId } })"
               class="text-sm font-semibold text-surface-700 dark:text-surface-300 hover:text-brand-600 dark:hover:text-brand-400 transition-colors"
             >
-              Source Tracking Links
+              Tracking Links
             </NuxtLink>
           </div>
           <button

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -1469,10 +1469,7 @@ function closeDocPreview() {
                       </span>
                       <button
                         :disabled="isScoringIndividual"
-                        class="inline-flex cursor-pointer items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
-                        :class="currentSummary.score != null
-                          ? 'text-surface-500 hover:text-brand-600 hover:bg-brand-50 dark:text-surface-400 dark:hover:text-brand-400 dark:hover:bg-brand-950/40'
-                          : 'text-brand-600 bg-brand-50 hover:bg-brand-100 dark:text-brand-400 dark:bg-brand-950/40 dark:hover:bg-brand-950/60 ring-1 ring-brand-200 dark:ring-brand-800'"
+                        class="factory-button-cta factory-button-premium inline-flex h-8 min-h-8 cursor-pointer items-center justify-center gap-1.5 px-2.5 py-0 text-[11px] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                         @click="scoreIndividualCandidate(currentSummary.id)"
                       >
                         <Loader2 v-if="isScoringIndividual" class="size-3 animate-spin" />

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -1135,8 +1135,10 @@ function closeDocPreview() {
 
           <!-- Fullscreen toggle -->
           <button
-            class="ml-auto flex shrink-0 cursor-pointer items-center justify-center rounded-lg p-2 text-surface-400 hover:bg-surface-100 hover:text-surface-600 dark:text-surface-500 dark:hover:bg-surface-800 dark:hover:text-surface-300 transition-all duration-200 focus:outline-none"
-            :title="isFullscreen ? 'Exit focus mode (Esc)' : 'Focus mode'"
+            type="button"
+            class="factory-toolbar-button ml-auto inline-flex shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors"
+            :title="isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'"
+            :aria-label="isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'"
             @click="toggleFullscreen"
           >
             <Minimize2 v-if="isFullscreen" class="size-4" />

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -1101,12 +1101,15 @@ function closeDocPreview() {
       <!-- ═══════════════════════════════════════ -->
       <!-- PIPELINE STATUS TABS                     -->
       <!-- ═══════════════════════════════════════ -->
-      <div class="shrink-0 border-b border-white/10 bg-white/[0.02] ui-dashboard-panel-header">
-        <div class="factory-dashboard-tabs flex items-center gap-1 overflow-x-auto scrollbar-thin sm:scrollbar-none px-3 sm:px-5 py-2">
+      <div class="factory-pipeline-stage-strip shrink-0 border-b border-white/10 bg-white/[0.02]">
+        <div class="factory-dashboard-tabs flex items-center gap-1.5 overflow-x-auto scrollbar-thin sm:scrollbar-none px-3 sm:px-5 py-1">
+          <span class="shrink-0 pr-2 text-xs font-light uppercase leading-none text-white/48">
+            Pipeline stages
+          </span>
           <button
             v-for="status in PIPELINE_STATUSES"
             :key="`tab-${status}`"
-            class="ui-filter-chip factory-pipeline-status-chip relative flex h-[38px] shrink-0 cursor-pointer items-center gap-2 px-3.5 text-xs !font-light uppercase leading-none tracking-normal transition-all duration-200 focus:outline-none"
+            class="ui-filter-chip factory-pipeline-status-chip relative flex h-8 shrink-0 cursor-pointer items-center gap-2 px-3.5 text-xs !font-light uppercase leading-none tracking-normal transition-all duration-200 focus:outline-none"
             :class="[
               isFocusStatus(status) ? 'ui-filter-chip-active factory-pipeline-status-chip-active' : 'ui-filter-chip-inactive',
               `factory-pipeline-status-chip-${status}`,
@@ -1136,7 +1139,7 @@ function closeDocPreview() {
           <!-- Fullscreen toggle -->
           <button
             type="button"
-            class="factory-toolbar-button ml-auto inline-flex shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors"
+            class="factory-toolbar-button ml-auto inline-flex h-8 min-h-8 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg border px-2 py-0 text-sm font-medium transition-colors"
             :title="isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'"
             :aria-label="isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'"
             @click="toggleFullscreen"

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -916,27 +916,9 @@ const pipelineContainer = useTemplateRef<HTMLElement>('pipelineContainer')
 const teleportTarget = computed(() => isFullscreen.value && pipelineContainer.value ? pipelineContainer.value : 'body')
 
 async function toggleFullscreen() {
-  if (!isFullscreen.value) {
-    isFullscreen.value = true
-    await nextTick()
-    pipelineContainer.value?.requestFullscreen?.()
-  }
-  else {
-    isFullscreen.value = false
-    if (document.fullscreenElement) {
-      document.exitFullscreen?.()
-    }
-  }
+  isFullscreen.value = !isFullscreen.value
+  await nextTick()
 }
-
-function onFullscreenChange() {
-  if (!document.fullscreenElement) {
-    isFullscreen.value = false
-  }
-}
-
-onMounted(() => document.addEventListener('fullscreenchange', onFullscreenChange))
-onBeforeUnmount(() => document.removeEventListener('fullscreenchange', onFullscreenChange))
 
 function goToPreviousStage() {
   const idx = PIPELINE_STATUSES.indexOf(focusStatus.value)
@@ -955,6 +937,11 @@ function goToNextStage() {
 function handleKeyNavigation(event: KeyboardEvent) {
   if (event.key === 'Escape' && showDocPreview.value) {
     closeDocPreview()
+    return
+  }
+
+  if (event.key === 'Escape' && isFullscreen.value) {
+    isFullscreen.value = false
     return
   }
 
@@ -1089,7 +1076,7 @@ function closeDocPreview() {
   <div
     ref="pipelineContainer"
     :class="isFullscreen
-      ? 'flex h-screen flex-col overflow-hidden bg-surface-50 dark:bg-surface-950'
+      ? 'fixed inset-0 z-50 flex h-screen flex-col overflow-hidden bg-surface-50 dark:bg-surface-950 factory-dashboard-portal'
       : 'absolute inset-0 flex flex-col overflow-hidden'"
   >
     <!-- Loading -->

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -1137,10 +1137,12 @@ function closeDocPreview() {
           <button
             v-for="status in PIPELINE_STATUSES"
             :key="`tab-${status}`"
-            class="relative flex shrink-0 cursor-pointer items-center gap-2 rounded-lg px-3.5 py-2 text-sm font-medium transition-all duration-200 focus:outline-none"
-            :class="isFocusStatus(status)
-              ? 'bg-brand-50 text-brand-700 shadow-sm ring-1 ring-brand-200/60 dark:bg-brand-950/40 dark:text-brand-300 dark:ring-brand-800/40'
-              : 'text-surface-500 hover:bg-surface-50 hover:text-surface-700 dark:text-surface-400 dark:hover:bg-surface-800/60 dark:hover:text-surface-200'"
+            class="ui-filter-chip factory-pipeline-status-chip relative flex h-[38px] shrink-0 cursor-pointer items-center gap-2 px-3.5 text-[11px] !font-light uppercase leading-none tracking-normal transition-all duration-200 focus:outline-none"
+            :class="[
+              isFocusStatus(status) ? 'ui-filter-chip-active factory-pipeline-status-chip-active' : 'ui-filter-chip-inactive',
+              `factory-pipeline-status-chip-${status}`,
+            ]"
+            style="font-weight: 300 !important"
             @click="setFocusStatus(status)"
           >
             <span class="pipeline-status-dot size-2 rounded-full" :class="{
@@ -1153,10 +1155,10 @@ function closeDocPreview() {
             }" />
             {{ formatStatusLabel(status) }}
             <span
-              class="inline-flex min-w-[20px] items-center justify-center rounded-md px-1.5 py-0.5 text-[11px] font-semibold tabular-nums transition-colors duration-200"
+              class="tabular-nums text-[10px] font-normal transition-colors duration-200"
               :class="isFocusStatus(status)
-                ? 'bg-brand-100 text-brand-700 dark:bg-brand-900/50 dark:text-brand-300'
-                : 'bg-surface-100 text-surface-500 dark:bg-surface-800/80 dark:text-surface-400'"
+                ? 'text-brand-600 dark:text-brand-400'
+                : 'text-surface-400 dark:text-surface-500'"
             >
               {{ statusCounts[status] ?? 0 }}
             </span>

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -1672,15 +1672,26 @@ function closeDocPreview() {
               <div v-if="showSection.profile" ref="overviewRef" class="space-y-5 max-w-4xl mx-auto">
                 <!-- Notes -->
                 <div class="ui-panel ui-dashboard-panel p-5">
-                  <div class="flex items-center gap-2.5 mb-4">
-                    <div class="flex size-7 items-center justify-center rounded-lg bg-warning-50 dark:bg-warning-950/40">
-                      <MessageSquare class="size-3.5 text-warning-600 dark:text-warning-400" />
+                  <div class="mb-3 flex items-center justify-between">
+                    <div class="flex items-center gap-2">
+                      <MessageSquare class="size-4 text-surface-500 dark:text-surface-400" />
+                      <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-200">Notes</h3>
                     </div>
-                    <h3 class="text-sm font-semibold text-surface-800 dark:text-surface-200">Notes</h3>
                   </div>
-                  <p class="text-sm leading-relaxed text-surface-600 dark:text-surface-300 whitespace-pre-wrap">
-                    {{ currentSummary.notes || 'No notes yet.' }}
+                  <p
+                    v-if="currentSummary.notes"
+                    class="text-sm text-surface-600 dark:text-surface-300 whitespace-pre-wrap"
+                  >
+                    {{ currentSummary.notes }}
                   </p>
+                  <NuxtLink
+                    v-else
+                    :to="$localePath(`/dashboard/applications/${currentSummary.id}`)"
+                    class="group flex w-full cursor-pointer items-center justify-between border border-dashed border-white/12 bg-black px-3 py-3 text-left text-sm text-surface-400 transition-colors hover:border-brand-500/70 hover:bg-brand-500/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-brand-500/40 no-underline"
+                  >
+                    <span class="italic">No notes yet.</span>
+                    <span class="text-xs font-semibold uppercase text-brand-400 transition-colors group-hover:text-brand-300">Add Notes</span>
+                  </NuxtLink>
                 </div>
 
                 <!-- Quick links -->

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -1106,7 +1106,7 @@ function closeDocPreview() {
           <button
             v-for="status in PIPELINE_STATUSES"
             :key="`tab-${status}`"
-            class="ui-filter-chip factory-pipeline-status-chip relative flex h-[38px] shrink-0 cursor-pointer items-center gap-2 px-3.5 text-[11px] !font-light uppercase leading-none tracking-normal transition-all duration-200 focus:outline-none"
+            class="ui-filter-chip factory-pipeline-status-chip relative flex h-[38px] shrink-0 cursor-pointer items-center gap-2 px-3.5 text-xs !font-light uppercase leading-none tracking-normal transition-all duration-200 focus:outline-none"
             :class="[
               isFocusStatus(status) ? 'ui-filter-chip-active factory-pipeline-status-chip-active' : 'ui-filter-chip-inactive',
               `factory-pipeline-status-chip-${status}`,
@@ -1124,7 +1124,7 @@ function closeDocPreview() {
             }" />
             {{ formatStatusLabel(status) }}
             <span
-              class="tabular-nums text-[10px] font-normal transition-colors duration-200"
+              class="tabular-nums text-xs font-normal transition-colors duration-200"
               :class="isFocusStatus(status)
                 ? 'text-brand-600 dark:text-brand-400'
                 : 'text-surface-400 dark:text-surface-500'"

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -1098,24 +1098,6 @@ function closeDocPreview() {
       <!-- Quick actions teleported to sub-nav bar -->
       <JobSubNavActions :job-id="jobId" />
 
-      <!-- Keyboard shortcut hints in sub-nav bar (pipeline-specific) -->
-      <Teleport to="#job-sub-nav-actions">
-        <div class="hidden sm:flex items-center gap-2 text-[10px] font-medium text-surface-400 dark:text-surface-500">
-          <div class="flex items-center gap-1 rounded-md bg-surface-100/80 px-2 py-0.5 dark:bg-surface-800/60">
-            <span class="font-mono text-[10px]">↑↓</span>
-            <span>candidates</span>
-          </div>
-          <div class="flex items-center gap-1 rounded-md bg-surface-100/80 px-2 py-0.5 dark:bg-surface-800/60">
-            <span class="font-mono text-[10px]">←→</span>
-            <span>stages</span>
-          </div>
-          <div class="flex items-center gap-1 rounded-md bg-surface-100/80 px-2 py-0.5 dark:bg-surface-800/60">
-            <span class="font-mono text-[10px]">1-9</span>
-            <span>actions</span>
-          </div>
-        </div>
-      </Teleport>
-
       <!-- ═══════════════════════════════════════ -->
       <!-- PIPELINE STATUS TABS                     -->
       <!-- ═══════════════════════════════════════ -->

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -1586,7 +1586,7 @@ function closeDocPreview() {
                       <span class="block px-3.5 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-surface-400 dark:text-surface-500">Sections</span>
                       <label class="flex items-center gap-2.5 px-3.5 py-2 text-sm text-surface-700 dark:text-surface-300 hover:bg-surface-50 dark:hover:bg-surface-800/80 cursor-pointer select-none transition-colors">
                         <input v-model="overviewSections.aiAnalysis" type="checkbox" class="size-3.5 rounded border-surface-300 text-brand-600 focus:ring-brand-500 dark:border-surface-600 dark:bg-surface-800" />
-                        AI Analysis
+                        AI
                       </label>
                       <label class="flex items-center gap-2.5 px-3.5 py-2 text-sm text-surface-700 dark:text-surface-300 hover:bg-surface-50 dark:hover:bg-surface-800/80 cursor-pointer select-none transition-colors">
                         <input v-model="overviewSections.interviews" type="checkbox" class="size-3.5 rounded border-surface-300 text-brand-600 focus:ring-brand-500 dark:border-surface-600 dark:bg-surface-800" />
@@ -1614,7 +1614,7 @@ function closeDocPreview() {
                     : 'border-transparent text-surface-500 hover:text-surface-700 hover:border-surface-300 dark:text-surface-400 dark:hover:text-surface-300 dark:hover:border-surface-600'"
                   @click="detailTab = 'ai-analysis'"
                 >
-                  AI Analysis
+                  AI
                 </button>
                 <button
                   class="cursor-pointer px-3.5 py-2.5 text-sm font-medium transition-all duration-150 border-b-2 -mb-px"

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -1257,10 +1257,10 @@ function closeDocPreview() {
                     <button
                       v-for="opt in scoreFilterOptions"
                       :key="opt.value"
-                      class="cursor-pointer rounded-md px-2 py-1 text-[11px] font-medium transition-all duration-150"
+                      class="ui-filter-chip relative flex h-8 shrink-0 cursor-pointer items-center px-2.5 text-xs !font-light uppercase leading-none tracking-normal transition-all duration-200 focus:outline-none"
                       :class="scoreFilter === opt.value
-                        ? 'bg-brand-600 text-white shadow-sm dark:bg-brand-500'
-                        : 'bg-white text-surface-600 ring-1 ring-inset ring-surface-200 hover:bg-surface-50 dark:bg-surface-800 dark:text-surface-300 dark:ring-surface-700 dark:hover:bg-surface-700'"
+                        ? 'ui-filter-chip-active'
+                        : 'ui-filter-chip-inactive'"
                       @click="scoreFilter = opt.value"
                     >
                       {{ opt.label }}
@@ -1275,10 +1275,10 @@ function closeDocPreview() {
                     <button
                       v-for="opt in interviewFilterOptions"
                       :key="opt.value"
-                      class="cursor-pointer rounded-md px-2 py-1 text-[11px] font-medium transition-all duration-150"
+                      class="ui-filter-chip relative flex h-8 shrink-0 cursor-pointer items-center px-2.5 text-xs !font-light uppercase leading-none tracking-normal transition-all duration-200 focus:outline-none"
                       :class="interviewFilter === opt.value
-                        ? 'bg-brand-600 text-white shadow-sm dark:bg-brand-500'
-                        : 'bg-white text-surface-600 ring-1 ring-inset ring-surface-200 hover:bg-surface-50 dark:bg-surface-800 dark:text-surface-300 dark:ring-surface-700 dark:hover:bg-surface-700'"
+                        ? 'ui-filter-chip-active'
+                        : 'ui-filter-chip-inactive'"
                       @click="interviewFilter = opt.value"
                     >
                       {{ opt.label }}

--- a/app/pages/dashboard/jobs/new.vue
+++ b/app/pages/dashboard/jobs/new.vue
@@ -1862,7 +1862,7 @@ const questionTypeLabels: Record<QuestionType, string> = {
                             {{ createdLinkCount }} tracking {{ createdLinkCount === 1 ? 'link' : 'links' }} created.
                           </span>
                           View all analytics and manage links in the
-                          <NuxtLink :to="$localePath('/dashboard/source-tracking')" class="text-brand-600 dark:text-brand-400 font-medium underline underline-offset-2">Source Tracking dashboard</NuxtLink>.
+                          <NuxtLink :to="$localePath('/dashboard/source-tracking')" class="text-brand-600 dark:text-brand-400 font-medium underline underline-offset-2">Tracking dashboard</NuxtLink>.
                         </p>
                       </div>
                     </div>

--- a/app/pages/dashboard/settings/index.vue
+++ b/app/pages/dashboard/settings/index.vue
@@ -259,7 +259,7 @@ async function handleDeleteOrg() {
             </p>
           </div>
           <button
-            class="ui-button ui-button-danger shrink-0 px-3.5 py-2"
+            class="ui-button ui-button-danger-outline shrink-0 px-3.5 py-2"
             @click="showDeleteConfirm = true"
           >
             <Trash2 class="size-4" />

--- a/app/pages/dashboard/source-tracking/[id].vue
+++ b/app/pages/dashboard/source-tracking/[id].vue
@@ -27,7 +27,7 @@ const { formatPersonName } = useOrgSettings()
 const linkId = computed(() => route.params.id as string)
 
 useSeoMeta({
-  title: 'Link Details — Source Tracking — Factory Careers',
+  title: 'Link Details — Tracking — Factory Careers',
   description: 'Detailed analytics for a tracking link',
 })
 
@@ -284,7 +284,7 @@ async function handleSidebarUpdated() {
         :to="localePath('/dashboard/source-tracking')"
         class="underline ml-auto font-medium"
       >
-        Back to Source Tracking
+        Back to Tracking
       </NuxtLink>
     </div>
 
@@ -296,7 +296,7 @@ async function handleSidebarUpdated() {
           :to="localePath('/dashboard/source-tracking')"
           class="mb-4"
         >
-          Back to Source Tracking
+          Back to Tracking
         </AppBackLink>
 
         <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">

--- a/app/pages/dashboard/source-tracking/index.vue
+++ b/app/pages/dashboard/source-tracking/index.vue
@@ -14,7 +14,7 @@ definePageMeta({
 })
 
 useSeoMeta({
-  title: 'Source Tracking — Factory Careers',
+  title: 'Tracking — Factory Careers',
   description: 'Track where your applications come from',
 })
 
@@ -311,7 +311,7 @@ const showTab = ref<'overview' | 'links' | 'table'>(initialTab)
       <!-- ─── Header ─── -->
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6 sm:mb-10">
         <div>
-          <h1 class="text-xl sm:text-2xl font-bold text-surface-900 dark:text-surface-50 tracking-tight">Source Tracking</h1>
+          <h1 class="text-xl sm:text-2xl font-bold text-surface-900 dark:text-surface-50 tracking-tight">Tracking</h1>
           <p class="text-sm text-surface-400 dark:text-surface-500 mt-1">
             Track where your applications come from
           </p>

--- a/app/utils/status-display.ts
+++ b/app/utils/status-display.ts
@@ -138,6 +138,7 @@ const APPLICATION_TRANSITION_DOT_CLASSES: Record<ApplicationStatusKey, string> =
 
 const INTERVIEW_STATUS_KEYS = [
   'scheduled',
+  'scheduled_past',
   'completed',
   'cancelled',
   'no_show',
@@ -147,6 +148,7 @@ type InterviewStatusKey = typeof INTERVIEW_STATUS_KEYS[number]
 
 const INTERVIEW_STATUS_LABELS: Record<InterviewStatusKey, string> = {
   scheduled: 'Scheduled',
+  scheduled_past: 'Past Due',
   completed: 'Completed',
   cancelled: 'Cancelled',
   no_show: 'No Show',
@@ -154,6 +156,7 @@ const INTERVIEW_STATUS_LABELS: Record<InterviewStatusKey, string> = {
 
 const INTERVIEW_TRANSITION_LABELS: Record<InterviewStatusKey, string> = {
   scheduled: 'Re-schedule',
+  scheduled_past: 'Past Due',
   completed: 'Completed',
   cancelled: 'Cancel',
   no_show: 'No Show',
@@ -162,6 +165,7 @@ const INTERVIEW_TRANSITION_LABELS: Record<InterviewStatusKey, string> = {
 const INTERVIEW_STATUS_BADGE_CLASSES: Record<InterviewStatusBadgeVariant, Record<InterviewStatusKey, string>> = {
   ring: {
     scheduled: 'bg-brand-50 text-brand-700 ring-brand-200 dark:bg-brand-950/50 dark:text-brand-300 dark:ring-brand-800',
+    scheduled_past: 'bg-warning-50 text-warning-700 ring-warning-200 dark:bg-warning-950/50 dark:text-warning-300 dark:ring-warning-800',
     completed: 'bg-success-50 text-success-700 ring-success-200 dark:bg-success-950/50 dark:text-success-300 dark:ring-success-800',
     cancelled: 'bg-surface-100 text-surface-500 ring-surface-200 dark:bg-surface-800/50 dark:text-surface-400 dark:ring-surface-700',
     no_show: 'bg-danger-50 text-danger-700 ring-danger-200 dark:bg-danger-950/50 dark:text-danger-300 dark:ring-danger-800',
@@ -174,6 +178,7 @@ const INTERVIEW_STATUS_BADGE_FALLBACKS: Record<InterviewStatusBadgeVariant, stri
 
 const INTERVIEW_STATUS_DOT_CLASSES: Record<InterviewStatusKey, string> = {
   scheduled: 'ui-status-dot-brand',
+  scheduled_past: 'ui-status-dot-warning',
   completed: 'ui-status-dot-success',
   cancelled: 'ui-status-dot',
   no_show: 'ui-status-dot-danger',
@@ -182,6 +187,7 @@ const INTERVIEW_STATUS_DOT_CLASSES: Record<InterviewStatusKey, string> = {
 const INTERVIEW_TRANSITION_BUTTON_CLASSES: Record<InterviewTransitionButtonVariant, Record<InterviewStatusKey, string>> = {
   solid: {
     scheduled: 'ui-button-secondary',
+    scheduled_past: 'ui-button-secondary',
     completed: 'ui-button-success',
     cancelled: 'ui-button-secondary',
     no_show: 'ui-button-danger',

--- a/render.yaml
+++ b/render.yaml
@@ -63,6 +63,8 @@ services:
         sync: false
       - key: RESEND_FROM_EMAIL
         sync: false
+      - key: MICROSOFT_CALENDAR_AUTH_MODE
+        value: application
       - key: MICROSOFT_CALENDAR_CLIENT_ID
         sync: false
       - key: MICROSOFT_CALENDAR_CLIENT_SECRET

--- a/tests/unit/candidate-detail-drawer.test.ts
+++ b/tests/unit/candidate-detail-drawer.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('candidate detail drawer', () => {
+  it('keeps application row schedule actions and status badges the same height', () => {
+    const source = readProjectFile('app/components/CandidateDetailDrawer.vue')
+
+    expect(source).toContain('factory-toolbar-button inline-flex h-8 min-h-8 items-center gap-1 border')
+    expect(source).toContain('inline-flex h-8 min-h-8 shrink-0 items-center border px-2.5 py-0 text-[10px] font-semibold uppercase')
+  })
+})

--- a/tests/unit/candidate-quick-notes.test.ts
+++ b/tests/unit/candidate-quick-notes.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('candidate quick notes', () => {
+  it('uses the shared dashed add-note empty state', () => {
+    const source = readProjectFile('app/pages/dashboard/candidates/index.vue')
+
+    expect(source).toContain('border border-dashed border-white/12 bg-black')
+    expect(source).toContain('Add Notes')
+    expect(source).not.toContain('Add note…')
+  })
+})

--- a/tests/unit/dashboard-upcoming-interviews.test.ts
+++ b/tests/unit/dashboard-upcoming-interviews.test.ts
@@ -5,9 +5,16 @@ import { join } from 'node:path'
 describe('dashboard upcoming interviews', () => {
   const source = readFileSync(join(process.cwd(), 'app/pages/dashboard/index.vue'), 'utf8')
 
-  it('queries upcoming interviews from the current time, not the start of the day', () => {
+  it('queries upcoming interviews from a current-time window, not the start of the day', () => {
     expect(source).not.toContain('from: today.toISOString()')
-    expect(source).toContain('from: dashboardNowIso')
+    expect(source).toContain("useState('dashboard-upcoming-interviews-query-from'")
+    expect(source).toContain('from: dashboardInterviewQueryFromIso')
+    expect(source).toContain('to: dashboardInterviewQueryToIso')
+  })
+
+  it('keeps the interview fetch key stable while refreshing relative times', () => {
+    expect(source).toContain('dashboardInterviewQueryFromIso.value = mountedAtIso')
+    expect(source).not.toMatch(/setInterval\(\(\) => \{\s*dashboardInterviewQueryFromIso\.value = new Date\(\)\.toISOString\(\)/)
   })
 
   it('filters stale cached interviews before rendering the upcoming card', () => {

--- a/tests/unit/dashboard-upcoming-interviews.test.ts
+++ b/tests/unit/dashboard-upcoming-interviews.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('dashboard upcoming interviews', () => {
+  const source = readFileSync(join(process.cwd(), 'app/pages/dashboard/index.vue'), 'utf8')
+
+  it('queries upcoming interviews from the current time, not the start of the day', () => {
+    expect(source).not.toContain('from: today.toISOString()')
+    expect(source).toContain('from: dashboardNowIso')
+  })
+
+  it('filters stale cached interviews before rendering the upcoming card', () => {
+    expect(source).toContain('upcomingInterviewsForCard')
+    expect(source).toMatch(/new Date\(interview\.scheduledAt\)\.getTime\(\) >= dashboardNow\.value\.getTime\(\)/)
+    expect(source).toMatch(/v-for="interview in upcomingInterviewsForCard"/)
+  })
+
+  it('refreshes its current-time boundary while the dashboard stays open', () => {
+    expect(source).toContain('dashboardNowTimer = setInterval')
+    expect(source).toContain('dashboardNowIso.value = new Date().toISOString()')
+    expect(source).toContain('if (dashboardNowTimer) clearInterval(dashboardNowTimer)')
+  })
+
+  it('never formats upcoming interview relative dates as negative days', () => {
+    expect(source).toContain("if (diffMs <= 0) return 'Now'")
+    expect(source).not.toContain("if (diffHours <= 0) return 'Now'")
+  })
+})

--- a/tests/unit/interview-display-status.test.ts
+++ b/tests/unit/interview-display-status.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('interview display status', () => {
+  const source = readFileSync(join(process.cwd(), 'app/pages/dashboard/interviews/index.vue'), 'utf8')
+
+  it('shows scheduled interviews in the past as a distinct display status', () => {
+    expect(source).toContain("return 'scheduled_past'")
+    expect(source).toContain('getInterviewDisplayStatus(interviewItem)')
+    expect(source).toMatch(/getInterviewStatusLabel\(getInterviewDisplayStatus\(interviewItem\)\)/)
+    expect(source).toMatch(/getInterviewStatusBadgeClass\(getInterviewDisplayStatus\(interviewItem\)\)/)
+  })
+})

--- a/tests/unit/job-cache-refresh.test.ts
+++ b/tests/unit/job-cache-refresh.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('job cache refresh', () => {
+  it('keeps the topbar job status cache responsive after job mutations', () => {
+    const topbar = readProjectFile('app/components/AppTopBar.vue')
+    const useJob = readProjectFile('app/composables/useJob.ts')
+
+    expect(topbar).toContain("key: 'sidebar-jobs-list'")
+    expect(useJob).toContain("useNuxtData<{ data: Array<Record<string, unknown>> }>('sidebar-jobs-list')")
+    expect(useJob).toContain('syncJobListCache(updated)')
+    expect(useJob).toMatch(/refreshNuxtData\('sidebar-jobs-list'\)/)
+  })
+})

--- a/tests/unit/job-filter-chips.test.ts
+++ b/tests/unit/job-filter-chips.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('job pipeline filter chips', () => {
+  it('uses shared Factory chip styling for score and interview filters', () => {
+    const source = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+
+    expect(source).toContain('ui-filter-chip relative flex h-8 shrink-0 cursor-pointer items-center px-2.5')
+    expect(source).toContain('ui-filter-chip-active')
+    expect(source).toContain('ui-filter-chip-inactive')
+    expect(source).not.toContain('cursor-pointer rounded-md px-2 py-1 text-[11px] font-medium transition-all duration-150')
+  })
+})

--- a/tests/unit/job-overview-notes.test.ts
+++ b/tests/unit/job-overview-notes.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('job application overview notes', () => {
+  it('uses the full application notes empty-state structure', () => {
+    const source = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+
+    expect(source).toContain('currentSummary.notes')
+    expect(source).toContain('border border-dashed border-white/12 bg-black')
+    expect(source).toContain('No notes yet.')
+    expect(source).toContain('Add Notes')
+    expect(source).not.toContain("currentSummary.notes || 'No notes yet.'")
+  })
+})

--- a/tests/unit/job-subnav-actions.test.ts
+++ b/tests/unit/job-subnav-actions.test.ts
@@ -16,4 +16,14 @@ describe('job subnav actions', () => {
     expect(jobDetail).not.toContain('<span>stages</span>')
     expect(jobDetail).not.toContain('<span>actions</span>')
   })
+
+  it('uses the applications toolbar button recipe for the pipeline fullscreen control', () => {
+    const applications = readProjectFile('app/pages/dashboard/applications/index.vue')
+    const jobDetail = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+
+    expect(applications).toContain('factory-toolbar-button inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors')
+    expect(jobDetail).toContain('factory-toolbar-button ml-auto inline-flex shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors')
+    expect(jobDetail).toContain(":title=\"isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'\"")
+    expect(jobDetail).toContain(":aria-label=\"isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'\"")
+  })
 })

--- a/tests/unit/job-subnav-actions.test.ts
+++ b/tests/unit/job-subnav-actions.test.ts
@@ -22,7 +22,7 @@ describe('job subnav actions', () => {
     const jobDetail = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
 
     expect(applications).toContain('factory-toolbar-button inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors')
-    expect(jobDetail).toContain('factory-toolbar-button ml-auto inline-flex shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors')
+    expect(jobDetail).toContain('factory-toolbar-button ml-auto inline-flex h-8 min-h-8 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg border px-2 py-0 text-sm font-medium transition-colors')
     expect(jobDetail).toContain(":title=\"isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'\"")
     expect(jobDetail).toContain(":aria-label=\"isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'\"")
   })
@@ -35,5 +35,14 @@ describe('job subnav actions', () => {
     expect(menuRule).toContain('background-color: #050505 !important')
     expect(menuRule).toContain('color: #ffffff !important')
     expect(itemRule).toContain('color: rgb(255 255 255 / 0.72) !important')
+  })
+
+  it('labels pipeline stage chips and keeps their strip compact', () => {
+    const jobDetail = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+
+    expect(jobDetail).toContain('Pipeline stages')
+    expect(jobDetail).toContain('factory-pipeline-stage-strip shrink-0 border-b')
+    expect(jobDetail).toContain('px-3 sm:px-5 py-1')
+    expect(jobDetail).toContain('factory-pipeline-status-chip relative flex h-8')
   })
 })

--- a/tests/unit/job-subnav-actions.test.ts
+++ b/tests/unit/job-subnav-actions.test.ts
@@ -26,4 +26,14 @@ describe('job subnav actions', () => {
     expect(jobDetail).toContain(":title=\"isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'\"")
     expect(jobDetail).toContain(":aria-label=\"isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'\"")
   })
+
+  it('keeps the teleported job actions menu opaque and readable', () => {
+    const css = readProjectFile('app/assets/css/main.css')
+    const menuRule = css.match(/\.factory-job-more-menu\s*\{[^}]+\}/)?.[0] ?? ''
+    const itemRule = css.match(/\.factory-job-more-menu \.factory-job-more-menu-item\s*\{[^}]+\}/)?.[0] ?? ''
+
+    expect(menuRule).toContain('background-color: #050505 !important')
+    expect(menuRule).toContain('color: #ffffff !important')
+    expect(itemRule).toContain('color: rgb(255 255 255 / 0.72) !important')
+  })
 })

--- a/tests/unit/job-subnav-actions.test.ts
+++ b/tests/unit/job-subnav-actions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('job subnav actions', () => {
+  it('does not render keyboard shortcut hints as subnav action controls', () => {
+    const jobDetail = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+
+    expect(jobDetail).toContain('<JobSubNavActions :job-id="jobId" />')
+    expect(jobDetail).not.toContain('Keyboard shortcut hints in sub-nav bar')
+    expect(jobDetail).not.toContain('<span>candidates</span>')
+    expect(jobDetail).not.toContain('<span>stages</span>')
+    expect(jobDetail).not.toContain('<span>actions</span>')
+  })
+})

--- a/tests/unit/panel-close-buttons.test.ts
+++ b/tests/unit/panel-close-buttons.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('panel close buttons', () => {
+  it('uses a no-fill ghost recipe for filter and side panel close buttons', () => {
+    const css = readProjectFile('app/assets/css/main.css')
+    const closeRule = css.match(/\.ui-panel-close-button\s*\{[^}]+\}/)?.[0] ?? ''
+    const closeHoverRule = css.match(/\.ui-panel-close-button:hover:not\(:disabled\)\s*\{[^}]+\}/)?.[0] ?? ''
+    const factoryHoverRule = css.match(/\.factory-dashboard-portal \.ui-panel-close-button:hover:not\(:disabled\)\s*\{[^}]+\}/)?.[0] ?? ''
+
+    expect(closeRule).toContain('background-color: transparent !important')
+    expect(closeHoverRule).toContain('background-color: transparent !important')
+    expect(factoryHoverRule).toContain('background-color: transparent !important')
+  })
+
+  it('applies the close recipe to common filter and right side panel X controls', () => {
+    for (const path of [
+      'app/components/FilterDrawer.vue',
+      'app/components/ApplicationDetailDrawer.vue',
+      'app/components/CandidateDetailDrawer.vue',
+      'app/components/CandidateDetailSidebar.vue',
+      'app/components/InterviewScheduleSidebar.vue',
+      'app/components/PropertySchemaEditor.vue',
+      'app/components/ChatbotSourcesPanel.vue',
+      'app/components/ApplyCandidateModal.vue',
+    ]) {
+      expect(readProjectFile(path), `${path} should use panel close styling`).toContain('ui-panel-close-button')
+    }
+  })
+})

--- a/tests/unit/property-filter-bar.test.ts
+++ b/tests/unit/property-filter-bar.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('property filter picker', () => {
+  it('uses Factory dropdown styling for the add-filter picker', () => {
+    const source = readProjectFile('app/components/PropertyFilterBar.vue')
+
+    expect(source).toContain('factory-filter-dropdown-trigger')
+    expect(source).toContain('factory-filter-dropdown-menu')
+    expect(source).toContain('factory-filter-dropdown-option')
+    expect(source).toContain('z-50')
+  })
+})

--- a/tests/unit/render-blueprint.test.ts
+++ b/tests/unit/render-blueprint.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Render blueprint', () => {
+  const source = readFileSync(join(process.cwd(), 'render.yaml'), 'utf8')
+
+  it('keeps production Microsoft Calendar in app-only mode', () => {
+    expect(source).toContain('key: MICROSOFT_CALENDAR_AUTH_MODE')
+    expect(source).toContain('value: application')
+  })
+})

--- a/tests/unit/score-breakdown-button.test.ts
+++ b/tests/unit/score-breakdown-button.test.ts
@@ -7,6 +7,15 @@ function readProjectFile(path: string) {
 }
 
 describe('score breakdown actions', () => {
+  it('renders the AI summary from the latest scoring run', () => {
+    const source = readProjectFile('app/components/ScoreBreakdown.vue')
+
+    expect(source).toContain('const scoringSummary = computed')
+    expect(source).toContain('AI summary')
+    expect(source).toContain('{{ scoringSummary }}')
+    expect(source).toContain('No AI summary was stored for this score. Re-score to generate one.')
+  })
+
   it('uses the shared Factory button recipe for the re-score action', () => {
     const source = readProjectFile('app/components/ScoreBreakdown.vue')
 

--- a/tests/unit/score-breakdown-button.test.ts
+++ b/tests/unit/score-breakdown-button.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('score breakdown actions', () => {
+  it('uses the shared Factory button recipe for the re-score action', () => {
+    const source = readProjectFile('app/components/ScoreBreakdown.vue')
+
+    expect(source).toContain('factory-button-cta factory-button-premium')
+    expect(source).not.toContain('text-xs text-brand-600 dark:text-brand-400 hover:underline')
+  })
+
+  it('uses the shared Factory button recipe for the selected candidate score action', () => {
+    const source = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+
+    expect(source).toMatch(/currentSummary\.score != null[\s\S]*factory-button-cta factory-button-premium/)
+    expect(source).not.toContain('inline-flex cursor-pointer items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium')
+  })
+})

--- a/tests/unit/status-display.test.ts
+++ b/tests/unit/status-display.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import {
   APPLICATION_PIPELINE_STAGES,
   getApplicationStatusBadgeClass,
@@ -30,6 +32,8 @@ import {
 } from '../../app/utils/status-display'
 
 describe('status display helpers', () => {
+  const stylesheet = readFileSync(join(process.cwd(), 'app/assets/css/main.css'), 'utf8')
+
   it('returns centralized labels with readable fallbacks', () => {
     expect(getApplicationStatusLabel('screening')).toBe('Screening')
     expect(getApplicationTransitionLabel('new')).toBe('Re-open')
@@ -98,6 +102,14 @@ describe('status display helpers', () => {
     expect(getInterviewStatusLabel('scheduled_past')).toBe('Past Due')
     expect(getInterviewStatusBadgeClass('scheduled_past')).toContain('warning')
     expect(getInterviewStatusDotClass('scheduled_past')).toContain('warning')
+  })
+
+  it('defines every interview status dot class used by filter chips', () => {
+    for (const status of ['scheduled', 'scheduled_past', 'completed', 'cancelled', 'no_show']) {
+      const dotClass = getInterviewStatusDotClass(status)
+
+      expect(stylesheet, `${dotClass} should be defined`).toContain(`.${dotClass}`)
+    }
   })
 
   it('centralizes candidate interview response display values', () => {

--- a/tests/unit/status-display.test.ts
+++ b/tests/unit/status-display.test.ts
@@ -14,6 +14,9 @@ import {
   getCandidateResponseIconClass,
   getCandidateResponseLabel,
   getCandidateResponseSymbol,
+  getInterviewStatusBadgeClass,
+  getInterviewStatusDotClass,
+  getInterviewStatusLabel,
   formatFileSize,
   formatRelativeTime,
   getJobStatusBadgeClass,
@@ -89,6 +92,12 @@ describe('status display helpers', () => {
     expect(getJobStatusBadgeClass('open')).toContain('success')
     expect(getJobStatusBadgeClass('closed', 'ring')).toContain('ring-warning-200')
     expect(getJobStatusBadgeClass('unknown', 'ring')).toContain('ring-surface-200')
+  })
+
+  it('centralizes past-due interview display status', () => {
+    expect(getInterviewStatusLabel('scheduled_past')).toBe('Past Due')
+    expect(getInterviewStatusBadgeClass('scheduled_past')).toContain('warning')
+    expect(getInterviewStatusDotClass('scheduled_past')).toContain('warning')
   })
 
   it('centralizes candidate interview response display values', () => {

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -500,7 +500,7 @@ describe('brand-neutral theme variables', () => {
     const recipeUsage = [
       {
         path: 'app/pages/dashboard/settings/index.vue',
-        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-field', 'ui-alert-danger', 'ui-button-primary', 'ui-button-danger', 'ui-button-secondary'],
+        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-field', 'ui-alert-danger', 'ui-button-primary', 'ui-button-danger', 'ui-button-danger-outline', 'ui-button-secondary'],
       },
       {
         path: 'app/pages/dashboard/settings/account.vue',

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -122,6 +122,16 @@ describe('brand-neutral theme variables', () => {
     expect(css).toMatch(/\.factory-pipeline-status-chip\s*\{[\s\S]*font-weight:\s*300 !important/)
   })
 
+  it('uses an in-app focus mode for the job pipeline instead of native fullscreen', () => {
+    const jobDetail = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+
+    expect(jobDetail).toContain('fixed inset-0 z-50 flex h-screen')
+    expect(jobDetail).toContain("event.key === 'Escape' && isFullscreen.value")
+    expect(jobDetail).not.toContain('requestFullscreen')
+    expect(jobDetail).not.toContain('exitFullscreen')
+    expect(jobDetail).not.toContain('fullscreenchange')
+  })
+
   it('adapts shared UI recipes inside the Factory dashboard shell', () => {
     const css = readProjectFile('app/assets/css/main.css')
 

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -133,6 +133,14 @@ describe('brand-neutral theme variables', () => {
     expect(css).toMatch(/\.factory-pipeline-status-chip\s*\{[\s\S]*font-weight:\s*300 !important/)
   })
 
+  it('uses the regular brand color for dashboard pipeline screening segments', () => {
+    const css = readProjectFile('app/assets/css/main.css')
+    const screeningSegment = css.match(/\.factory-pipeline-segment-screening\s*\{[^}]+\}/)?.[0] ?? ''
+
+    expect(screeningSegment).toContain('background-color: var(--color-brand-500) !important')
+    expect(screeningSegment).not.toContain('color-mix')
+  })
+
   it('uses an in-app focus mode for the job pipeline instead of native fullscreen', () => {
     const jobDetail = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
 

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -129,10 +129,10 @@ describe('brand-neutral theme variables', () => {
     expect(jobDetail).toContain('ui-filter-chip factory-pipeline-status-chip')
     expect(jobDetail).toContain('ui-filter-chip-active factory-pipeline-status-chip-active')
     expect(jobDetail).toContain('ui-filter-chip-inactive')
-    expect(jobDetail).toContain('factory-pipeline-status-chip relative flex h-[38px] shrink-0 cursor-pointer items-center gap-2 px-3.5 text-xs')
+    expect(jobDetail).toContain('factory-pipeline-status-chip relative flex h-8 shrink-0 cursor-pointer items-center gap-2 px-3.5 text-xs')
     expect(jobDetail).toContain('tabular-nums text-xs font-normal')
     expect(jobDetail).toContain('style="font-weight: 300 !important"')
-    expect(css).toMatch(/\.factory-pipeline-status-chip\s*\{[\s\S]*font-weight:\s*300 !important/)
+    expect(css).toMatch(/\.factory-pipeline-status-chip\s*\{[\s\S]*height:\s*32px !important;[\s\S]*min-height:\s*32px !important;[\s\S]*font-weight:\s*300 !important/)
   })
 
   it('uses the regular brand color for dashboard pipeline screening segments', () => {

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -111,6 +111,17 @@ describe('brand-neutral theme variables', () => {
     expect(css).toMatch(/\.factory-dashboard-shell,[\s\S]*\.factory-dashboard-portal\)[\s\S]*\.ui-filter-chip\s*\{[\s\S]*min-height:\s*38px;[\s\S]*border:\s*1px solid var\(--ui-border-strong\) !important/)
   })
 
+  it('uses the shared filter chip recipe for job pipeline stage tabs', () => {
+    const jobDetail = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+    const css = readProjectFile('app/assets/css/main.css')
+
+    expect(jobDetail).toContain('ui-filter-chip factory-pipeline-status-chip')
+    expect(jobDetail).toContain('ui-filter-chip-active factory-pipeline-status-chip-active')
+    expect(jobDetail).toContain('ui-filter-chip-inactive')
+    expect(jobDetail).toContain('style="font-weight: 300 !important"')
+    expect(css).toMatch(/\.factory-pipeline-status-chip\s*\{[\s\S]*font-weight:\s*300 !important/)
+  })
+
   it('adapts shared UI recipes inside the Factory dashboard shell', () => {
     const css = readProjectFile('app/assets/css/main.css')
 

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -43,6 +43,9 @@ describe('brand-neutral theme variables', () => {
       '.ui-button-danger-outline',
       '.ui-button-success',
       '.ui-field',
+      '.ui-filter-chip',
+      '.ui-filter-chip-active',
+      '.ui-filter-chip-inactive',
       '.ui-icon-state',
       '.ui-icon-state-danger',
       '.ui-icon-state-success',
@@ -76,7 +79,10 @@ describe('brand-neutral theme variables', () => {
       '.ui-icon-tile',
       '.ui-pill-success',
       '.ui-status-dot',
+      '.ui-status-dot-brand',
       '.ui-status-dot-success',
+      '.ui-status-dot-warning',
+      '.ui-status-dot-danger',
       '.ui-code',
       '.ui-inline-link',
       '.ui-inline-link-brand',
@@ -96,6 +102,13 @@ describe('brand-neutral theme variables', () => {
     expect(css).toContain('var(--color-success-')
     expect(css).toContain('var(--color-brand-')
     expect(css).not.toMatch(/\.factory-(panel|alert|field|icon-state)\b/)
+  })
+
+  it('keeps filter chips as bordered controls aligned with toolbar fields', () => {
+    const css = readProjectFile('app/assets/css/main.css')
+
+    expect(css).toMatch(/\.ui-filter-chip\s*\{[\s\S]*min-height:\s*2\.375rem;[\s\S]*border:\s*1px solid/)
+    expect(css).toMatch(/\.factory-dashboard-shell,[\s\S]*\.factory-dashboard-portal\)[\s\S]*\.ui-filter-chip\s*\{[\s\S]*min-height:\s*38px;[\s\S]*border:\s*1px solid var\(--ui-border-strong\) !important/)
   })
 
   it('adapts shared UI recipes inside the Factory dashboard shell', () => {

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -129,6 +129,8 @@ describe('brand-neutral theme variables', () => {
     expect(jobDetail).toContain('ui-filter-chip factory-pipeline-status-chip')
     expect(jobDetail).toContain('ui-filter-chip-active factory-pipeline-status-chip-active')
     expect(jobDetail).toContain('ui-filter-chip-inactive')
+    expect(jobDetail).toContain('factory-pipeline-status-chip relative flex h-[38px] shrink-0 cursor-pointer items-center gap-2 px-3.5 text-xs')
+    expect(jobDetail).toContain('tabular-nums text-xs font-normal')
     expect(jobDetail).toContain('style="font-weight: 300 !important"')
     expect(css).toMatch(/\.factory-pipeline-status-chip\s*\{[\s\S]*font-weight:\s*300 !important/)
   })

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -109,6 +109,7 @@ describe('brand-neutral theme variables', () => {
 
     expect(css).toMatch(/\.ui-filter-chip\s*\{[\s\S]*min-height:\s*2\.375rem;[\s\S]*border:\s*1px solid/)
     expect(css).toMatch(/\.factory-dashboard-shell,[\s\S]*\.factory-dashboard-portal\)[\s\S]*\.ui-filter-chip\s*\{[\s\S]*min-height:\s*38px;[\s\S]*border:\s*1px solid var\(--ui-border-strong\) !important/)
+    expect(css).toMatch(/\.factory-job-subnav-tab\s*\{[\s\S]*min-height:\s*32px;[\s\S]*border:\s*1px solid var\(--ui-border-strong\) !important/)
   })
 
   it('uses the shared filter chip recipe for job pipeline stage tabs', () => {

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -110,6 +110,16 @@ describe('brand-neutral theme variables', () => {
     expect(css).toMatch(/\.ui-filter-chip\s*\{[\s\S]*min-height:\s*2\.375rem;[\s\S]*border:\s*1px solid/)
     expect(css).toMatch(/\.factory-dashboard-shell,[\s\S]*\.factory-dashboard-portal\)[\s\S]*\.ui-filter-chip\s*\{[\s\S]*min-height:\s*38px;[\s\S]*border:\s*1px solid var\(--ui-border-strong\) !important/)
     expect(css).toMatch(/\.factory-job-subnav-tab\s*\{[\s\S]*min-height:\s*32px;[\s\S]*border:\s*1px solid var\(--ui-border-strong\) !important/)
+    expect(css).toMatch(/\.factory-job-status-action\s*\{[\s\S]*height:\s*28px;[\s\S]*font-weight:\s*400 !important/)
+  })
+
+  it('explains job status actions with tooltips', () => {
+    const actions = readProjectFile('app/components/JobSubNavActions.vue')
+
+    expect(actions).toContain('factory-job-status-action')
+    expect(actions).toContain('Publish this job so candidates can apply.')
+    expect(actions).toContain(':title="jobTransitionTooltips[primaryJobTransition]')
+    expect(actions).toContain(':aria-label="jobTransitionTooltips[primaryJobTransition]')
   })
 
   it('uses the shared filter chip recipe for job pipeline stage tabs', () => {

--- a/tests/unit/topbar-responsive.test.ts
+++ b/tests/unit/topbar-responsive.test.ts
@@ -21,4 +21,11 @@ describe('dashboard top bar responsiveness', () => {
     expect(source).toContain('const showFactoryMoreActions = false')
     expect(source).toMatch(/v-if="showFactoryMoreActions"[\s\S]*title="More options"/)
   })
+
+  it('uses bordered Factory controls for job context sub-navigation tabs', () => {
+    expect(source).toContain('factory-job-subnav-tab')
+    expect(source).toContain('factory-job-subnav-tab-active')
+    expect(source).toContain('factory-job-subnav-tab-inactive')
+    expect(source).not.toContain('border-transparent text-white/50')
+  })
 })

--- a/tests/unit/topbar-responsive.test.ts
+++ b/tests/unit/topbar-responsive.test.ts
@@ -30,6 +30,12 @@ describe('dashboard top bar responsiveness', () => {
     expect(source).not.toContain('border-transparent text-white/50')
   })
 
+  it('renders the job context back link as icon-only', () => {
+    expect(source).toContain('aria-label="All jobs"')
+    expect(source).toContain('title="All jobs"')
+    expect(source).not.toMatch(/<ChevronLeft class="size-3\.5" \/>\s*All Jobs/)
+  })
+
   it('uses white-fill hover treatment for dashboard back links', () => {
     expect(backLinkSource).toContain('hover:border-white hover:bg-white hover:text-black')
     expect(backLinkSource).not.toContain('hover:border-brand-500')

--- a/tests/unit/topbar-responsive.test.ts
+++ b/tests/unit/topbar-responsive.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('dashboard top bar responsiveness', () => {
+  const source = readFileSync(join(process.cwd(), 'app/components/AppTopBar.vue'), 'utf8')
+
+  it('delays full nav labels until there is room for the desktop actions', () => {
+    expect(source).toContain('hidden min-[1500px]:inline')
+    expect(source).toContain('min-[1500px]:hidden')
+    expect(source).toContain('hidden min-[1800px]:inline')
+    expect(source).toContain('min-[1800px]:hidden')
+  })
+
+  it('keeps the New Job CTA separated from collapsing nav items', () => {
+    expect(source).toContain('flex shrink-0 items-center gap-1 pl-2 lg:gap-1.5 lg:pl-3 xl:pl-4')
+    expect(source).toContain('factory-button-cta factory-button-premium mx-1 hidden h-9')
+  })
+})

--- a/tests/unit/topbar-responsive.test.ts
+++ b/tests/unit/topbar-responsive.test.ts
@@ -16,4 +16,9 @@ describe('dashboard top bar responsiveness', () => {
     expect(source).toContain('flex shrink-0 items-center gap-1 pl-2 lg:gap-1.5 lg:pl-3 xl:pl-4')
     expect(source).toContain('factory-button-cta factory-button-premium mx-1 hidden h-9')
   })
+
+  it('temporarily hides the desktop more actions menu pending a Factory refactor', () => {
+    expect(source).toContain('const showFactoryMoreActions = false')
+    expect(source).toMatch(/v-if="showFactoryMoreActions"[\s\S]*title="More options"/)
+  })
 })

--- a/tests/unit/topbar-responsive.test.ts
+++ b/tests/unit/topbar-responsive.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 
 describe('dashboard top bar responsiveness', () => {
   const source = readFileSync(join(process.cwd(), 'app/components/AppTopBar.vue'), 'utf8')
+  const backLinkSource = readFileSync(join(process.cwd(), 'app/components/AppBackLink.vue'), 'utf8')
 
   it('delays full nav labels until there is room for the desktop actions', () => {
     expect(source).toContain('hidden min-[1500px]:inline')
@@ -27,5 +28,10 @@ describe('dashboard top bar responsiveness', () => {
     expect(source).toContain('factory-job-subnav-tab-active')
     expect(source).toContain('factory-job-subnav-tab-inactive')
     expect(source).not.toContain('border-transparent text-white/50')
+  })
+
+  it('uses white-fill hover treatment for dashboard back links', () => {
+    expect(backLinkSource).toContain('hover:border-white hover:bg-white hover:text-black')
+    expect(backLinkSource).not.toContain('hover:border-brand-500')
   })
 })


### PR DESCRIPTION
## Summary
- Rename dashboard Source Tracking labels to Tracking
- Rename dashboard AI Analysis labels to AI
- Keep existing routes and internal tracking terminology unchanged
- Include related dashboard polish that landed in the same stack: in-app job focus mode, shared filter/close button styling, and dashboard interview timing cleanup

## Validation
- npm run test:unit
- npm run typecheck
- git diff --check
- Verified dashboard routes respond from the local dev server with expected auth redirects