### PR TITLE
fix: centralize remaining display helpers

### DIFF
--- a/app/pages/dashboard/chatbot/[[id]].vue
+++ b/app/pages/dashboard/chatbot/[[id]].vue
@@ -5,6 +5,7 @@ import {
   Check, BookOpen, PanelRightClose, PanelRightOpen,
 } from 'lucide-vue-next'
 import MarkdownDescription from '~/components/MarkdownDescription.vue'
+import { formatFileSize } from '~/utils/status-display'
 
 definePageMeta({
   layout: 'dashboard',
@@ -189,12 +190,6 @@ const suggestions = computed(() => {
 function applySuggestion(s: string) {
   draft.value = s
   nextTick(() => composerRef.value?.focus())
-}
-
-function formatBytes(bytes: number) {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
 }
 
 function toolLabel(name: string) {
@@ -535,7 +530,7 @@ async function startNew() {
               >
                 <FileText class="size-3.5 text-brand-500" />
                 <span class="max-w-[160px] truncate font-medium">{{ a.filename }}</span>
-                <span class="text-surface-400">{{ formatBytes(a.sizeBytes) }}</span>
+                <span class="text-surface-400">{{ formatFileSize(a.sizeBytes) }}</span>
                 <button
                   class="ml-1 inline-flex items-center justify-center rounded p-0.5 text-surface-400 hover:bg-surface-200 dark:hover:bg-surface-700 hover:text-danger-500 transition-colors cursor-pointer border-0 bg-transparent"
                   :aria-label="`Remove ${a.filename}`"

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -12,8 +12,11 @@ import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
 import { APPLICATION_STATUS_TRANSITIONS, INTERVIEW_STATUS_TRANSITIONS } from '~~/shared/status-transitions'
 import {
   formatRelativeTime,
+  getApplicationStatusBadgeClass,
   getApplicationTransitionButtonClass,
   getApplicationTransitionLabel,
+  getInterviewStatusBadgeClass,
+  getScoreBadgeClass,
 } from '~/utils/status-display'
 
 definePageMeta({
@@ -380,19 +383,6 @@ function getTimelineActionStyle(action: string): TimelineActionStyle {
   return map[action] ?? { icon: Clock, color: 'text-surface-500 dark:text-surface-400', bg: 'bg-surface-100 dark:bg-surface-800' }
 }
 
-function getTimelineStatusBadge(status: string): string {
-  const s = status.toLowerCase()
-  const map: Record<string, string> = {
-    new: 'bg-blue-100 text-blue-700 dark:bg-blue-900/60 dark:text-blue-300',
-    screening: 'bg-violet-100 text-violet-700 dark:bg-violet-900/60 dark:text-violet-300',
-    interview: 'bg-amber-100 text-amber-700 dark:bg-amber-900/60 dark:text-amber-300',
-    offer: 'bg-teal-100 text-teal-700 dark:bg-teal-900/60 dark:text-teal-300',
-    hired: 'bg-green-100 text-green-700 dark:bg-green-900/60 dark:text-green-300',
-    rejected: 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-300',
-  }
-  return map[s] ?? 'bg-surface-100 text-surface-600 dark:bg-surface-800 dark:text-surface-300'
-}
-
 function describeTimelineItem(item: TimelineEntry): string {
   const actor = item.actorName ?? item.actorEmail ?? 'System'
   const action = timelineActionLabels[item.action] ?? item.action
@@ -671,13 +661,6 @@ const interviewTypeLabels: Record<string, string> = {
   technical: 'Technical',
   panel: 'Panel',
   take_home: 'Take Home',
-}
-
-const interviewStatusClasses: Record<string, string> = {
-  scheduled: 'bg-brand-50 text-brand-700 ring-brand-200 dark:bg-brand-950/50 dark:text-brand-300 dark:ring-brand-800',
-  completed: 'bg-success-50 text-success-700 ring-success-200 dark:bg-success-950/50 dark:text-success-300 dark:ring-success-800',
-  cancelled: 'bg-surface-100 text-surface-500 ring-surface-200 dark:bg-surface-800/50 dark:text-surface-400 dark:ring-surface-700',
-  no_show: 'bg-danger-50 text-danger-700 ring-danger-200 dark:bg-danger-950/50 dark:text-danger-300 dark:ring-danger-800',
 }
 
 function formatInterviewDateTime(dateStr: string) {
@@ -1021,13 +1004,6 @@ onBeforeUnmount(() => {
 // ─────────────────────────────────────────────
 // Job status transitions (Publish, Close, etc.)
 // ─────────────────────────────────────────────
-
-const jobStatusBadgeClasses: Record<string, string> = {
-  draft: 'bg-surface-100 dark:bg-surface-800 text-surface-600 dark:text-surface-400',
-  open: 'bg-success-50 dark:bg-success-950 text-success-700 dark:text-success-400',
-  closed: 'bg-warning-50 dark:bg-warning-950 text-warning-700 dark:text-warning-400',
-  archived: 'bg-surface-100 dark:bg-surface-800 text-surface-400',
-}
 
 const isScoringIndividual = ref(false)
 
@@ -1417,11 +1393,7 @@ function closeDocPreview() {
                   <span
                     v-if="app.score != null"
                     class="inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-semibold ring-1 ring-inset"
-                    :class="{
-                      'bg-success-50 text-success-700 ring-success-200 dark:bg-success-950/60 dark:text-success-400 dark:ring-success-800': app.score >= 75,
-                      'bg-warning-50 text-warning-700 ring-warning-200 dark:bg-warning-950/60 dark:text-warning-400 dark:ring-warning-800': app.score >= 40 && app.score < 75,
-                      'bg-danger-50 text-danger-700 ring-danger-200 dark:bg-danger-950/60 dark:text-danger-400 dark:ring-danger-800': app.score < 40,
-                    }"
+                    :class="getScoreBadgeClass(app.score, 'muted')"
                   >
                     {{ app.score }} pts
                   </span>
@@ -1492,14 +1464,7 @@ function closeDocPreview() {
                       </h2>
                       <span
                         class="inline-flex shrink-0 items-center rounded-lg px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide ring-1 ring-inset"
-                        :class="{
-                          'bg-blue-50 text-blue-700 ring-blue-200 dark:bg-blue-950/50 dark:text-blue-400 dark:ring-blue-800': currentSummary.status === 'new',
-                          'bg-violet-50 text-violet-700 ring-violet-200 dark:bg-violet-950/50 dark:text-violet-400 dark:ring-violet-800': currentSummary.status === 'screening',
-                          'bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-950/50 dark:text-amber-400 dark:ring-amber-800': currentSummary.status === 'interview',
-                          'bg-teal-50 text-teal-700 ring-teal-200 dark:bg-teal-950/50 dark:text-teal-400 dark:ring-teal-800': currentSummary.status === 'offer',
-                          'bg-green-50 text-green-700 ring-green-200 dark:bg-green-950/50 dark:text-green-400 dark:ring-green-800': currentSummary.status === 'hired',
-                          'bg-surface-100 text-surface-500 ring-surface-200 dark:bg-surface-800/50 dark:text-surface-400 dark:ring-surface-700': currentSummary.status === 'rejected',
-                        }"
+                        :class="getApplicationStatusBadgeClass(currentSummary.status, 'ring')"
                       >
                         {{ currentSummary.status }}
                       </span>
@@ -1522,11 +1487,7 @@ function closeDocPreview() {
                       <span
                         v-if="currentSummary.score != null"
                         class="inline-flex items-center rounded-md px-2 py-0.5 text-[11px] font-semibold ring-1 ring-inset"
-                        :class="{
-                          'bg-success-50 text-success-700 ring-success-200 dark:bg-success-950/60 dark:text-success-400 dark:ring-success-800': currentSummary.score >= 75,
-                          'bg-warning-50 text-warning-700 ring-warning-200 dark:bg-warning-950/60 dark:text-warning-400 dark:ring-warning-800': currentSummary.score >= 40 && currentSummary.score < 75,
-                          'bg-danger-50 text-danger-700 ring-danger-200 dark:bg-danger-950/60 dark:text-danger-400 dark:ring-danger-800': currentSummary.score < 40,
-                        }"
+                        :class="getScoreBadgeClass(currentSummary.score, 'muted')"
                       >
                         {{ currentSummary.score }} pts
                       </span>
@@ -1834,7 +1795,7 @@ function closeDocPreview() {
                       <div class="flex items-center gap-2.5 shrink-0">
                         <span
                           class="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ring-1 ring-inset"
-                          :class="interviewStatusClasses[iv.status] ?? 'bg-surface-100 text-surface-500 ring-surface-200'"
+                          :class="getInterviewStatusBadgeClass(iv.status)"
                         >
                           <component :is="interviewStatusIcons[iv.status as InterviewStatus] ?? Calendar" class="size-3" />
                           {{ iv.status === 'no_show' ? 'No Show' : iv.status }}
@@ -2292,9 +2253,9 @@ function closeDocPreview() {
                           <span class="text-[13px] font-medium text-surface-900 dark:text-surface-100 shrink-0">{{ timelineActionLabels[item.action] ?? item.action }}</span>
                           <span class="text-[13px] text-surface-500 dark:text-surface-400">{{ item.resourceType }}</span>
                           <template v-if="item.action === 'status_changed' && item.metadata">
-                            <span v-if="item.metadata.from_status || item.metadata.fromStatus" class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none" :class="getTimelineStatusBadge(String(item.metadata.from_status ?? item.metadata.fromStatus))">{{ item.metadata.from_status ?? item.metadata.fromStatus }}</span>
+                            <span v-if="item.metadata.from_status || item.metadata.fromStatus" class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none" :class="getApplicationStatusBadgeClass(String(item.metadata.from_status ?? item.metadata.fromStatus), 'soft')">{{ item.metadata.from_status ?? item.metadata.fromStatus }}</span>
                             <ArrowRight class="size-2.5 text-surface-400 dark:text-surface-500 shrink-0" />
-                            <span v-if="item.metadata.to_status || item.metadata.toStatus" class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none" :class="getTimelineStatusBadge(String(item.metadata.to_status ?? item.metadata.toStatus))">{{ item.metadata.to_status ?? item.metadata.toStatus }}</span>
+                            <span v-if="item.metadata.to_status || item.metadata.toStatus" class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none" :class="getApplicationStatusBadgeClass(String(item.metadata.to_status ?? item.metadata.toStatus), 'soft')">{{ item.metadata.to_status ?? item.metadata.toStatus }}</span>
                           </template>
                           <template v-else-if="item.action === 'scored' && item.metadata?.score">
                             <span class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none bg-accent-100 text-accent-700 dark:bg-accent-900/60 dark:text-accent-300">{{ item.metadata.score }} pts</span>

--- a/app/utils/status-display.ts
+++ b/app/utils/status-display.ts
@@ -397,6 +397,10 @@ const SOURCE_CHANNEL_DOT_FALLBACK_CLASS = 'bg-surface-400 dark:bg-surface-500'
 
 type ScoreBucket = 'high' | 'medium' | 'low' | 'empty'
 
+function normalizeApplicationStatus(status: string): string {
+  return status.trim().toLowerCase()
+}
+
 function isApplicationStatus(status: string): status is ApplicationStatusKey {
   return APPLICATION_STATUS_KEYS.includes(status as ApplicationStatusKey)
 }
@@ -444,37 +448,43 @@ export function formatFileSize(bytes: number | null | undefined): string {
 }
 
 export function getApplicationStatusLabel(status: string): string {
-  return isApplicationStatus(status) ? APPLICATION_STATUS_LABELS[status] : titleizeStatus(status)
+  const normalized = normalizeApplicationStatus(status)
+  return isApplicationStatus(normalized) ? APPLICATION_STATUS_LABELS[normalized] : titleizeStatus(status)
 }
 
 export function getApplicationTransitionLabel(status: string): string {
-  return isApplicationStatus(status) ? APPLICATION_TRANSITION_LABELS[status] : titleizeStatus(status)
+  const normalized = normalizeApplicationStatus(status)
+  return isApplicationStatus(normalized) ? APPLICATION_TRANSITION_LABELS[normalized] : titleizeStatus(status)
 }
 
 export function getApplicationStatusBadgeClass(
   status: string,
   variant: ApplicationStatusBadgeVariant = 'soft',
 ): string {
-  return isApplicationStatus(status)
-    ? APPLICATION_STATUS_BADGE_CLASSES[variant][status]
+  const normalized = normalizeApplicationStatus(status)
+  return isApplicationStatus(normalized)
+    ? APPLICATION_STATUS_BADGE_CLASSES[variant][normalized]
     : APPLICATION_STATUS_BADGE_FALLBACKS[variant]
 }
 
 export function getApplicationStatusDotClass(status: string): string {
-  return isApplicationStatus(status) ? APPLICATION_STATUS_DOT_CLASSES[status] : 'bg-surface-400 dark:bg-surface-500'
+  const normalized = normalizeApplicationStatus(status)
+  return isApplicationStatus(normalized) ? APPLICATION_STATUS_DOT_CLASSES[normalized] : 'bg-surface-400 dark:bg-surface-500'
 }
 
 export function getApplicationTransitionButtonClass(
   status: string,
   variant: ApplicationTransitionButtonVariant = 'solid',
 ): string {
-  return isApplicationStatus(status)
-    ? APPLICATION_TRANSITION_BUTTON_CLASSES[variant][status]
+  const normalized = normalizeApplicationStatus(status)
+  return isApplicationStatus(normalized)
+    ? APPLICATION_TRANSITION_BUTTON_CLASSES[variant][normalized]
     : APPLICATION_TRANSITION_BUTTON_FALLBACKS[variant]
 }
 
 export function getApplicationTransitionDotClass(status: string): string {
-  return isApplicationStatus(status) ? APPLICATION_TRANSITION_DOT_CLASSES[status] : 'bg-surface-400 dark:bg-surface-500'
+  const normalized = normalizeApplicationStatus(status)
+  return isApplicationStatus(normalized) ? APPLICATION_TRANSITION_DOT_CLASSES[normalized] : 'bg-surface-400 dark:bg-surface-500'
 }
 
 export function getInterviewStatusLabel(status: string): string {

--- a/tests/unit/status-display.test.ts
+++ b/tests/unit/status-display.test.ts
@@ -38,6 +38,7 @@ describe('status display helpers', () => {
     expect(getApplicationStatusBadgeClass('hired', 'ring')).toContain('ring-green-200')
     expect(getApplicationStatusBadgeClass('hired', 'subtle-ring')).toContain('ring-green-200/60')
     expect(getApplicationStatusBadgeClass('hired', 'factory')).toContain('text-success-200')
+    expect(getApplicationStatusBadgeClass(' SCREENING ', 'ring')).toContain('ring-violet-200')
     expect(getApplicationStatusBadgeClass('unknown', 'factory')).toContain('text-white/58')
   })
 

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -827,9 +827,18 @@ describe('brand-neutral theme variables', () => {
         patterns: [
           /const statusBadgeClasses:/,
           /const transitionClasses:/,
+          /function getTimelineStatusBadge/,
+          /const interviewStatusClasses:/,
+          /const jobStatusBadgeClasses:/,
+          /'bg-success-50[^']+': app\.score >= 75/,
+          /'bg-success-50[^']+': currentSummary\.score >= 75/,
           /function timeAgo/,
           /function scoreClass/,
         ],
+      },
+      {
+        path: 'app/pages/dashboard/chatbot/[[id]].vue',
+        patterns: [/function formatBytes/],
       },
       {
         path: 'app/pages/dashboard/jobs/[id]/candidates.vue',


### PR DESCRIPTION
## Summary

- revise issue #2 to capture the remaining stale display-helper duplication
- replace job detail status/interview/score badge class maps with shared `status-display` helpers
- replace chatbot attachment `formatBytes` with shared `formatFileSize`
- expand the dashboard display-helper regression guard to catch the remaining duplicate patterns

Closes #2

## Verification

- `npm run test -- tests/unit/theme-neutrality.test.ts tests/unit/status-display.test.ts`
- `npm run test:unit`
- `npm run typecheck` (exits 0; prints existing Vue language plugin warning for `vue-router/volar/sfc-route-blocks`)
- `git diff --check`