### PR TITLE
docs: add keyboard acceptance checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,16 @@
 - [ ] I updated `docs/CLI.md`, CLI commands, shared schemas, or CLI tests when the portal/API workflow should be agent-accessible
 - [ ] I documented the reason when a changed portal/API workflow should not be exposed through the CLI
 
+## Keyboard / accessibility acceptance
+
+- [ ] Visible focus is preserved for every interactive control I touched
+- [ ] No core action in this change is pointer-only
+- [ ] `Escape` behavior is intentional for transient UI I changed
+- [ ] Focus restores to the invoking control after closing modals/popovers/drawers
+- [ ] Any modal I changed traps focus correctly while open
+- [ ] Any custom listbox/menu/combobox behavior still works from the keyboard
+- [ ] New custom controls include keyboard-focused tests where applicable
+
 ## DCO
 
 - [ ] All commits in this PR are signed off (`Signed-off-by`) via `git commit -s`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,18 @@ This adds a `Signed-off-by:` line to your commit message. Pull requests fail CI 
 - [ ] I did not introduce tenant-scope or auth regressions.
 - [ ] All commits are DCO signed (`git commit -s`).
 
+### Keyboard and accessibility acceptance checks
+
+For UI work, verify the interaction path without a mouse before opening the PR:
+
+- [ ] Visible focus is preserved for every interactive control.
+- [ ] No core action is pointer-only; keyboard users can reach and trigger it.
+- [ ] `Escape` closes or cancels transient UI only when that behavior is expected.
+- [ ] Focus returns to the triggering control after closing a modal, popover, or drawer.
+- [ ] Modal dialogs trap focus while open and do not leak tab order behind the overlay.
+- [ ] Custom listbox, menu, and combobox patterns support the expected arrow-key and selection behavior.
+- [ ] New custom controls ship with keyboard-focused tests, not just pointer-path checks.
+
 ## Coding and Product Conventions
 
 - Follow Nuxt 4 `app/` + root `server/` structure.


### PR DESCRIPTION
## Summary
- add a keyboard-focused acceptance checklist to the PR template
- mirror the same expectations in CONTRIBUTING so UI contributors see them before opening a PR
- cover visible focus, pointer-only actions, Escape semantics, focus restore, modal trap behavior, listbox/menu keyboard behavior, and keyboard-focused tests

## Validation
- docs-only change; reviewed updated markdown for checklist coverage and consistency

Closes #54