### PR TITLE
fix: address CLI parity review comments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@
 
 ## CLI parity
 
-- [ ] I checked whether this changes portal/API workflow payload shapes changed, response shapes, auth requirements, or resource coverage
+- [ ] I checked whether this changes portal/API workflow payload shapes, response shapes, auth requirements, or resource coverage
 - [ ] I updated `packages/careers-cli/src/routeCoverage.ts` when API routes were added, removed, renamed, or intentionally excluded
 - [ ] I updated `docs/CLI.md`, CLI commands, shared schemas, or CLI tests when the portal/API workflow should be agent-accessible
 - [ ] I documented the reason when a changed portal/API workflow should not be exposed through the CLI

--- a/packages/careers-cli/src/program.ts
+++ b/packages/careers-cli/src/program.ts
@@ -217,6 +217,14 @@ async function readStdinJson(io: CliIo, enabled?: boolean): Promise<unknown> {
 }
 
 function validateStdinPayload(schema: CliPayloadSchema, body: unknown): unknown {
+  if (body === undefined) {
+    throw {
+      status: 400,
+      code: 'MISSING_STDIN_PAYLOAD',
+      message: 'Pass --stdin and pipe a JSON request body for this command.',
+    }
+  }
+
   try {
     return schema.parse(body)
   } catch (error) {

--- a/scripts/cli-parity-check.ts
+++ b/scripts/cli-parity-check.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
+import { pathToFileURL } from 'node:url'
 
 const PARITY_SENSITIVE_PATTERNS = [
   /^server\/api\//,
@@ -89,6 +89,6 @@ function main(): void {
   console.log(result.message)
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main()
 }

--- a/server/api/cli/capabilities.get.ts
+++ b/server/api/cli/capabilities.get.ts
@@ -14,8 +14,6 @@ export default defineEventHandler(async (event) => {
     route: CLI_CAPABILITIES_ROUTE,
     contractVersion: CLI_API_CONTRACT_VERSION,
     minimumCliVersion: MINIMUM_SUPPORTED_CLI_VERSION,
-    CLI_API_CONTRACT_VERSION,
-    MINIMUM_SUPPORTED_CLI_VERSION,
     resourceGroups: CLI_RESOURCE_GROUPS,
     routes: cliRouteCoverage,
   }

--- a/tests/unit/cli-command-route-contracts.test.ts
+++ b/tests/unit/cli-command-route-contracts.test.ts
@@ -37,7 +37,7 @@ function expectedMethod(route: string): string {
   return METHOD_BY_SUFFIX[suffix]!
 }
 
-function expectedStaticApiFragments(route: string): string[] {
+function staticApiParts(route: string): string[] {
   const routePath = route
     .replace(/^server\/api\//, '/api/')
     .replace(/\.(delete|get|patch|post|put)\.ts$/, '')
@@ -45,24 +45,96 @@ function expectedStaticApiFragments(route: string): string[] {
 
   return routePath
     .split('/')
-    .filter((part) => part && !part.startsWith('['))
-    .map((part) => `/${part}`)
+    .filter((part) => part && !part.startsWith('[') && part !== 'index')
 }
 
-function hasDynamicRouteRepresentation(source: string, route: string): boolean {
+type RequestBlock = {
+  helper: string
+  source: string
+}
+
+function requestBlocks(source: string): RequestBlock[] {
+  const blocks: RequestBlock[] = []
+  const pattern = /request(Json|Text|FormJson|Binary)(?:<[^>]*>)?\(\{/g
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(source))) {
+    const start = match.index
+    const end = source.indexOf('\n    })', start)
+    if (end === -1) continue
+    blocks.push({
+      helper: match[1]!,
+      source: source.slice(start, end),
+    })
+  }
+  return blocks
+}
+
+function blockUsesMethod(block: RequestBlock, method: string): boolean {
+  if (block.source.includes(`method: '${method}'`)) return true
+  if (method === 'GET' && block.helper === 'Binary' && !block.source.includes('method:')) return true
+  if (method === 'POST' && block.helper === 'FormJson' && !block.source.includes('method:')) return true
+  if (method === 'GET' && block.helper === 'Json' && !block.source.includes('body,') && !block.source.includes('method:')) return true
+  if (method === 'POST' && block.helper === 'Json' && block.source.includes('body,') && !block.source.includes('method:')) return true
+  return false
+}
+
+function blockContainsParts(block: RequestBlock, parts: string[]): boolean {
+  let searchStart = 0
+  for (const part of parts) {
+    const index = block.source.indexOf(part, searchStart)
+    if (index === -1) return false
+    searchStart = index + part.length
+  }
+  return true
+}
+
+function dynamicRouteEvidence(source: string, route: string): string[] {
   if (/^server\/api\/calendar\/(google|microsoft)\/connect\.get\.ts$/.test(route)) {
-    return source.includes('/api/calendar/${normalizedProvider}/connect')
+    const provider = route.includes('/google/') ? 'google' : 'microsoft'
+    return [
+      `/api/calendar/\${normalizedProvider}/connect`,
+      provider === 'microsoft' ? `provider === 'microsoft'` : `: 'google'`,
+    ]
   }
 
   if (/^server\/api\/chatbot\/(agents|folders)\//.test(route)) {
-    return source.includes('/api/chatbot/${resource.path}')
+    const resource = route.includes('/agents/') ? 'agents' : 'folders'
+    return [
+      `/api/chatbot/\${resource.path}`,
+      `path: '${resource}'`,
+    ]
   }
 
   if (/^server\/api\/updates\/(changelog|system|version)\.get\.ts$/.test(route)) {
-    return source.includes('/api/updates/${commandConfig.path}')
+    const updatePath = route.match(/updates\/([^/]+)\.get\.ts$/)?.[1]
+    return [
+      `/api/updates/\${commandConfig.path}`,
+      `path: '${updatePath}'`,
+    ]
   }
 
-  return false
+  return []
+}
+
+function routeSpecificRequestExists(source: string, route: string): boolean {
+  const method = expectedMethod(route)
+  const dynamicEvidence = dynamicRouteEvidence(source, route)
+  if (dynamicEvidence.length > 0 && !dynamicEvidence.every((evidence) => source.includes(evidence))) {
+    return false
+  }
+
+  if (/^server\/api\/calendar\/(google|microsoft)\/connect\.get\.ts$/.test(route)) {
+    return true
+  }
+
+  const parts = staticApiParts(route)
+    .filter((part) => !['google', 'microsoft'].includes(part))
+    .filter((part) => !(/^server\/api\/chatbot\/(agents|folders)\//.test(route) && ['agents', 'folders'].includes(part)))
+    .filter((part) => !(/^server\/api\/updates\/(changelog|system|version)\.get\.ts$/.test(route) && ['changelog', 'system', 'version'].includes(part)))
+
+  return requestBlocks(source).some((block) =>
+    blockUsesMethod(block, method) && blockContainsParts(block, parts),
+  )
 }
 
 describe('CLI command route contracts', () => {
@@ -81,26 +153,8 @@ describe('CLI command route contracts', () => {
     const programSource = readFileSync(join(root, 'packages/careers-cli/src/program.ts'), 'utf8')
     const missing = cliRouteCoverage
       .filter((entry) => entry.status === 'supported')
-      .flatMap((entry) => {
-        const failures: string[] = []
-        const method = expectedMethod(entry.route)
-
-        if (!programSource.includes(`method: '${method}'`)) {
-          failures.push(`${entry.route} missing method ${method}`)
-        }
-
-        if (hasDynamicRouteRepresentation(programSource, entry.route)) {
-          return failures
-        }
-
-        for (const fragment of expectedStaticApiFragments(entry.route)) {
-          if (!programSource.includes(fragment)) {
-            failures.push(`${entry.route} missing path fragment ${fragment}`)
-          }
-        }
-
-        return failures
-      })
+      .filter((entry) => !routeSpecificRequestExists(programSource, entry.route))
+      .map((entry) => `${entry.route} missing route-specific ${expectedMethod(entry.route)} request`)
 
     expect(missing).toEqual([])
   })

--- a/tests/unit/cli-parity-changed-files.test.ts
+++ b/tests/unit/cli-parity-changed-files.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 import { evaluateCliParityEvidence } from '../../scripts/cli-parity-check'
 
@@ -27,5 +28,17 @@ describe('CLI parity changed-file guard', () => {
     expect(evaluateCliParityEvidence([
       'server/api/jobs/index.get.ts',
     ], { override: true })).toMatchObject({ ok: true })
+  })
+
+  it('runs the CLI entrypoint when invoked through tsx with a relative script path', () => {
+    expect(() => execFileSync(
+      'npx',
+      ['tsx', 'scripts/cli-parity-check.ts', '--stdin'],
+      {
+        cwd: process.cwd(),
+        input: 'server/api/jobs/index.post.ts\n',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    )).toThrow(/CLI parity evidence is required/)
   })
 })

--- a/tests/unit/cli-parity-pr-template.test.ts
+++ b/tests/unit/cli-parity-pr-template.test.ts
@@ -9,6 +9,6 @@ describe('CLI parity pull request checklist', () => {
     expect(template).toContain('CLI parity')
     expect(template).toContain('packages/careers-cli/src/routeCoverage.ts')
     expect(template).toContain('docs/CLI.md')
-    expect(template).toContain('payload shapes changed')
+    expect(template).toContain('payload shapes, response shapes, auth requirements, or resource coverage')
   })
 })

--- a/tests/unit/cli-stdin-validation.test.ts
+++ b/tests/unit/cli-stdin-validation.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { runCli } from '../../packages/careers-cli/src/program'
+
+const tempDirs: string[] = []
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'factory-careers-cli-stdin-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function writeAuthedConfig(configPath: string) {
+  writeFileSync(configPath, JSON.stringify({
+    activeProfile: 'prod',
+    profiles: {
+      prod: { baseUrl: 'https://careers.example.com', token: 'secret-token' },
+    },
+  }))
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('CLI stdin payload validation', () => {
+  it('reports a specific missing stdin payload error for stdin-only create commands', async () => {
+    const configPath = join(tempDir(), 'config.json')
+    writeAuthedConfig(configPath)
+    const stdout: string[] = []
+
+    const exitCode = await runCli(
+      ['jobs', 'create', '--yes', '--config', configPath, '--json'],
+      { stdout: (value) => stdout.push(value), stderr: () => {} },
+    )
+
+    expect(exitCode).toBe(1)
+    expect(JSON.parse(stdout[0])).toMatchObject({
+      status: 400,
+      code: 'MISSING_STDIN_PAYLOAD',
+      message: 'Pass --stdin and pipe a JSON request body for this command.',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- fix delayed Copilot review comments from #64
- normalize the parity guard entrypoint so `npx tsx scripts/cli-parity-check.ts` cannot no-op
- strengthen route contract coverage, clarify missing stdin errors, remove duplicate capabilities fields, and fix PR checklist grammar

## Validation

- `npm run test:unit`
- `npm run typecheck` (passes; existing Vue router Volar export warning still prints)
- `git diff --name-only | npx tsx scripts/cli-parity-check.ts --stdin`
