### PR TITLE
refactor: consolidate server endpoint helpers

### DIFF
--- a/server/api/applications/index.get.ts
+++ b/server/api/applications/index.get.ts
@@ -1,12 +1,10 @@
 import { eq, and, desc, inArray } from 'drizzle-orm'
 import { application, candidate, job } from '../../database/schema'
 import { applicationQuerySchema } from '../../utils/schemas/application'
-import { propertyFiltersArraySchema } from '../../utils/schemas/property'
 import {
-  entityIdsMatchingFilters,
   loadPropertyEntriesForEntities,
-  type PropertyFilter,
 } from '../../utils/properties'
+import { matchingEntityIdsForPropertyFilters, parsePropertyFiltersParam } from '../../utils/propertyFilters'
 
 /**
  * GET /api/applications
@@ -32,23 +30,9 @@ export default defineEventHandler(async (event) => {
     conditions.push(eq(application.status, query.status))
   }
 
-  // ── Custom property filters ──
-  let propertyFilters: PropertyFilter[] = []
-  if (query.propertyFilters) {
-    let raw: unknown
-    try {
-      raw = JSON.parse(query.propertyFilters)
-    } catch {
-      throw createError({ statusCode: 400, statusMessage: 'Invalid propertyFilters' })
-    }
-    const result = propertyFiltersArraySchema.safeParse(raw)
-    if (!result.success) {
-      throw createError({ statusCode: 400, statusMessage: 'Invalid propertyFilters' })
-    }
-    propertyFilters = result.data as PropertyFilter[]
-  }
+  const propertyFilters = parsePropertyFiltersParam(query.propertyFilters)
   if (propertyFilters.length > 0) {
-    const matching = await entityIdsMatchingFilters({
+    const matching = await matchingEntityIdsForPropertyFilters({
       organizationId: orgId,
       entityType: 'application',
       filters: propertyFilters,
@@ -106,4 +90,3 @@ export default defineEventHandler(async (event) => {
 
   return { data: enriched, total, page: query.page, limit: query.limit }
 })
-

--- a/server/api/candidates/index.get.ts
+++ b/server/api/candidates/index.get.ts
@@ -1,12 +1,10 @@
 import { eq, and, or, ilike, desc, sql, gte, lte, inArray } from 'drizzle-orm'
 import { candidate, application } from '../../database/schema'
 import { candidateQuerySchema } from '../../utils/schemas/candidate'
-import { propertyFiltersArraySchema } from '../../utils/schemas/property'
 import {
-  entityIdsMatchingFilters,
   loadPropertyEntriesForEntities,
-  type PropertyFilter,
 } from '../../utils/properties'
+import { matchingEntityIdsForPropertyFilters, parsePropertyFiltersParam } from '../../utils/propertyFilters'
 
 export default defineEventHandler(async (event) => {
   const session = await requirePermission(event, { candidate: ['read'] })
@@ -42,23 +40,9 @@ export default defineEventHandler(async (event) => {
     conditions.push(lte(candidate.dateOfBirth, query.dobTo))
   }
 
-  // ── Custom property filters (intersection-based) ──
-  let propertyFilters: PropertyFilter[] = []
-  if (query.propertyFilters) {
-    let raw: unknown
-    try {
-      raw = JSON.parse(query.propertyFilters)
-    } catch {
-      throw createError({ statusCode: 400, statusMessage: 'Invalid propertyFilters' })
-    }
-    const result = propertyFiltersArraySchema.safeParse(raw)
-    if (!result.success) {
-      throw createError({ statusCode: 400, statusMessage: 'Invalid propertyFilters' })
-    }
-    propertyFilters = result.data as PropertyFilter[]
-  }
+  const propertyFilters = parsePropertyFiltersParam(query.propertyFilters)
   if (propertyFilters.length > 0) {
-    const matching = await entityIdsMatchingFilters({
+    const matching = await matchingEntityIdsForPropertyFilters({
       organizationId: orgId,
       entityType: 'candidate',
       filters: propertyFilters,

--- a/server/api/documents/[id]/download.get.ts
+++ b/server/api/documents/[id]/download.get.ts
@@ -1,7 +1,8 @@
-import { eq, and } from 'drizzle-orm'
-import { z } from 'zod'
-import { GetObjectCommand } from '@aws-sdk/client-s3'
-import { document } from '../../../database/schema'
+import {
+  getDocumentIdParam,
+  loadOrgDocumentForRead,
+  streamS3Document,
+} from '../../../utils/documentStreaming'
 
 /**
  * GET /api/documents/:id/download
@@ -22,55 +23,8 @@ export default defineEventHandler(async (event) => {
   const session = await requirePermission(event, { document: ['read'] })
   const orgId = session.session.activeOrganizationId
 
-  const { id: documentId } = await getValidatedRouterParams(event, z.object({ id: z.string().uuid() }).parse)
+  const documentId = await getDocumentIdParam(event)
+  const doc = await loadOrgDocumentForRead(orgId, documentId)
 
-  // Query scoped by BOTH id AND organizationId — prevents IDOR
-  const doc = await db.query.document.findFirst({
-    where: and(
-      eq(document.id, documentId),
-      eq(document.organizationId, orgId),
-    ),
-    columns: {
-      storageKey: true,
-      originalFilename: true,
-      mimeType: true,
-    },
-  })
-
-  if (!doc) {
-    throw createError({ statusCode: 404, statusMessage: 'Document not found' })
-  }
-
-  // Fetch the object from S3
-  const s3Response = await s3Client.send(
-    new GetObjectCommand({
-      Bucket: env.S3_BUCKET,
-      Key: doc.storageKey,
-    }),
-  )
-
-  if (!s3Response.Body) {
-    throw createError({ statusCode: 500, statusMessage: 'Failed to retrieve document' })
-  }
-
-  // Stream the file directly through the server — no presigned URLs exposed
-  const encodedFilename = encodeURIComponent(doc.originalFilename)
-
-  const headers: Record<string, string> = {
-    'Content-Type': doc.mimeType,
-    // RFC 5987: ASCII fallback + UTF-8 extended filename for international characters
-    'Content-Disposition': `attachment; filename="${encodedFilename}"; filename*=UTF-8''${encodedFilename}`,
-    'Cache-Control': 'private, no-store',
-    'X-Content-Type-Options': 'nosniff',
-  }
-
-  // Forward Content-Length from S3 so browsers can show download progress
-  if (s3Response.ContentLength) {
-    headers['Content-Length'] = String(s3Response.ContentLength)
-  }
-
-  setResponseHeaders(event, headers)
-
-  // Stream the S3 body to the response
-  return s3Response.Body.transformToWebStream()
+  return streamS3Document(event, doc, { disposition: 'attachment' })
 })

--- a/server/api/documents/[id]/preview.get.ts
+++ b/server/api/documents/[id]/preview.get.ts
@@ -1,7 +1,8 @@
-import { eq, and } from 'drizzle-orm'
-import { z } from 'zod'
-import { GetObjectCommand } from '@aws-sdk/client-s3'
-import { document } from '../../../database/schema'
+import {
+  getDocumentIdParam,
+  loadOrgDocumentForRead,
+  streamS3Document,
+} from '../../../utils/documentStreaming'
 
 /**
  * GET /api/documents/:id/preview
@@ -23,24 +24,8 @@ export default defineEventHandler(async (event) => {
   const session = await requirePermission(event, { document: ['read'] })
   const orgId = session.session.activeOrganizationId
 
-  const { id: documentId } = await getValidatedRouterParams(event, z.object({ id: z.string().uuid() }).parse)
-
-  // Query scoped by BOTH id AND organizationId — prevents IDOR
-  const doc = await db.query.document.findFirst({
-    where: and(
-      eq(document.id, documentId),
-      eq(document.organizationId, orgId),
-    ),
-    columns: {
-      storageKey: true,
-      originalFilename: true,
-      mimeType: true,
-    },
-  })
-
-  if (!doc) {
-    throw createError({ statusCode: 404, statusMessage: 'Document not found' })
-  }
+  const documentId = await getDocumentIdParam(event)
+  const doc = await loadOrgDocumentForRead(orgId, documentId)
 
   // Only allow inline preview for PDFs — DOC/DOCX can contain macros
   if (doc.mimeType !== 'application/pdf') {
@@ -50,41 +35,12 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // Fetch the object from S3
-  const s3Response = await s3Client.send(
-    new GetObjectCommand({
-      Bucket: env.S3_BUCKET,
-      Key: doc.storageKey,
-    }),
-  )
-
-  if (!s3Response.Body) {
-    throw createError({ statusCode: 500, statusMessage: 'Failed to retrieve document' })
-  }
-
-  // Stream the PDF directly through the server (same-origin for iframe)
-  const encodedFilename = encodeURIComponent(doc.originalFilename)
-
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/pdf',
-    // RFC 5987: ASCII fallback + UTF-8 extended filename for international characters
-    'Content-Disposition': `inline; filename="${encodedFilename}"; filename*=UTF-8''${encodedFilename}`,
-    'Cache-Control': 'private, no-store',
+  return streamS3Document(event, doc, {
+    disposition: 'inline',
+    contentType: 'application/pdf',
     // Override global DENY — allow same-origin framing for preview iframe
-    'X-Frame-Options': 'SAMEORIGIN',
-    // Prevent MIME type sniffing
-    'X-Content-Type-Options': 'nosniff',
+    frameOptions: 'SAMEORIGIN',
     // Restrictive CSP — prevent a malicious PDF from loading external resources
-    'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'",
-  }
-
-  // Forward Content-Length from S3 so browsers can render the PDF efficiently
-  if (s3Response.ContentLength) {
-    headers['Content-Length'] = String(s3Response.ContentLength)
-  }
-
-  setResponseHeaders(event, headers)
-
-  // Stream the S3 body to the response
-  return s3Response.Body.transformToWebStream()
+    contentSecurityPolicy: "default-src 'none'; style-src 'unsafe-inline'",
+  })
 })

--- a/server/utils/documentStreaming.ts
+++ b/server/utils/documentStreaming.ts
@@ -1,0 +1,97 @@
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { GetObjectCommand } from '@aws-sdk/client-s3'
+import type { H3Event } from 'h3'
+import { document } from '../database/schema'
+
+const documentIdParamSchema = z.object({ id: z.string().uuid() })
+
+export type ReadableDocument = {
+  storageKey: string
+  originalFilename: string
+  mimeType: string
+}
+
+export async function getDocumentIdParam(event: H3Event): Promise<string> {
+  const { id } = await getValidatedRouterParams(event, documentIdParamSchema.parse)
+  return id
+}
+
+export async function loadOrgDocumentForRead(orgId: string, documentId: string): Promise<ReadableDocument> {
+  const doc = await db.query.document.findFirst({
+    where: and(
+      eq(document.id, documentId),
+      eq(document.organizationId, orgId),
+    ),
+    columns: {
+      storageKey: true,
+      originalFilename: true,
+      mimeType: true,
+    },
+  })
+
+  if (!doc) {
+    throw createError({ statusCode: 404, statusMessage: 'Document not found' })
+  }
+
+  return doc
+}
+
+export function buildDocumentStreamHeaders(opts: {
+  filename: string
+  contentType: string
+  disposition: 'attachment' | 'inline'
+  contentLength?: number
+  frameOptions?: string
+  contentSecurityPolicy?: string
+}): Record<string, string> {
+  const encodedFilename = encodeURIComponent(opts.filename)
+  const headers: Record<string, string> = {
+    'Content-Type': opts.contentType,
+    // RFC 5987: ASCII fallback + UTF-8 extended filename for international characters
+    'Content-Disposition': `${opts.disposition}; filename="${encodedFilename}"; filename*=UTF-8''${encodedFilename}`,
+    'Cache-Control': 'private, no-store',
+    'X-Content-Type-Options': 'nosniff',
+  }
+
+  if (opts.contentLength) {
+    headers['Content-Length'] = String(opts.contentLength)
+  }
+  if (opts.frameOptions) {
+    headers['X-Frame-Options'] = opts.frameOptions
+  }
+  if (opts.contentSecurityPolicy) {
+    headers['Content-Security-Policy'] = opts.contentSecurityPolicy
+  }
+
+  return headers
+}
+
+export async function streamS3Document(event: H3Event, doc: ReadableDocument, opts: {
+  disposition: 'attachment' | 'inline'
+  contentType?: string
+  frameOptions?: string
+  contentSecurityPolicy?: string
+}): Promise<ReadableStream> {
+  const s3Response = await s3Client.send(
+    new GetObjectCommand({
+      Bucket: env.S3_BUCKET,
+      Key: doc.storageKey,
+    }),
+  )
+
+  if (!s3Response.Body) {
+    throw createError({ statusCode: 500, statusMessage: 'Failed to retrieve document' })
+  }
+
+  setResponseHeaders(event, buildDocumentStreamHeaders({
+    filename: doc.originalFilename,
+    contentType: opts.contentType ?? doc.mimeType,
+    disposition: opts.disposition,
+    contentLength: s3Response.ContentLength,
+    frameOptions: opts.frameOptions,
+    contentSecurityPolicy: opts.contentSecurityPolicy,
+  }))
+
+  return s3Response.Body.transformToWebStream()
+}

--- a/server/utils/documentStreaming.ts
+++ b/server/utils/documentStreaming.ts
@@ -54,7 +54,7 @@ export function buildDocumentStreamHeaders(opts: {
     'X-Content-Type-Options': 'nosniff',
   }
 
-  if (opts.contentLength) {
+  if (opts.contentLength != null) {
     headers['Content-Length'] = String(opts.contentLength)
   }
   if (opts.frameOptions) {

--- a/server/utils/propertyFilters.ts
+++ b/server/utils/propertyFilters.ts
@@ -1,0 +1,35 @@
+import { createError } from 'h3'
+import { propertyFiltersArraySchema, type PropertyEntityType } from './schemas/property'
+import { entityIdsMatchingFilters, type PropertyFilter } from './properties'
+
+export function parsePropertyFiltersParam(value: string | undefined): PropertyFilter[] {
+  if (!value) return []
+
+  let raw: unknown
+  try {
+    raw = JSON.parse(value)
+  } catch {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid propertyFilters' })
+  }
+
+  const result = propertyFiltersArraySchema.safeParse(raw)
+  if (!result.success) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid propertyFilters' })
+  }
+
+  return result.data as PropertyFilter[]
+}
+
+export async function matchingEntityIdsForPropertyFilters(opts: {
+  organizationId: string
+  entityType: PropertyEntityType
+  filters: PropertyFilter[]
+}): Promise<Set<string> | null> {
+  if (opts.filters.length === 0) return null
+
+  return entityIdsMatchingFilters({
+    organizationId: opts.organizationId,
+    entityType: opts.entityType,
+    filters: opts.filters,
+  })
+}

--- a/tests/unit/cli-route-coverage-manifest.test.ts
+++ b/tests/unit/cli-route-coverage-manifest.test.ts
@@ -41,4 +41,13 @@ describe('CLI route coverage manifest', () => {
       }
     }
   })
+
+  it('keeps refactored DRY helper routes on their existing CLI commands', () => {
+    expect(cliRouteCoverage).toEqual(expect.arrayContaining([
+      { route: 'server/api/applications/index.get.ts', status: 'supported', command: 'applications list' },
+      { route: 'server/api/candidates/index.get.ts', status: 'supported', command: 'candidates list' },
+      { route: 'server/api/documents/[id]/download.get.ts', status: 'supported', command: 'documents download' },
+      { route: 'server/api/documents/[id]/preview.get.ts', status: 'supported', command: 'documents preview' },
+    ]))
+  })
 })

--- a/tests/unit/security-route-coverage.test.ts
+++ b/tests/unit/security-route-coverage.test.ts
@@ -115,9 +115,7 @@ describe('P0 tenant-isolation route coverage', () => {
     'server/api/applications/[id]/analyze.post.ts': ['eq(application.id, applicationId)', 'eq(application.organizationId, orgId)'],
     'server/api/applications/[id]/scores.get.ts': ['eq(application.id, applicationId)', 'eq(application.organizationId, orgId)'],
     'server/api/documents/[id].delete.ts': ['eq(document.id, documentId)', 'eq(document.organizationId, orgId)'],
-    'server/api/documents/[id]/download.get.ts': ['eq(document.id, documentId)', 'eq(document.organizationId, orgId)'],
     'server/api/documents/[id]/parse.post.ts': ['eq(document.id, documentId)', 'eq(document.organizationId, orgId)'],
-    'server/api/documents/[id]/preview.get.ts': ['eq(document.id, documentId)', 'eq(document.organizationId, orgId)'],
     'server/api/documents/parse-all.post.ts': ['eq(document.id, doc.id)', 'eq(document.organizationId, orgId)'],
     'server/api/comments/[id].patch.ts': ['eq(comment.id, id)', 'eq(comment.organizationId, orgId)'],
     'server/api/comments/[id].delete.ts': ['eq(comment.id, id)', 'eq(comment.organizationId, orgId)'],
@@ -150,6 +148,21 @@ describe('P0 tenant-isolation route coverage', () => {
       for (const snippet of snippets) {
         expect(source, `${path} missing ${snippet}`).toContain(snippet)
       }
+    }
+  })
+
+  it('keeps shared document stream lookups scoped by active organization', () => {
+    const helperSource = read('server/utils/documentStreaming.ts')
+    expect(helperSource).toContain('eq(document.id, documentId)')
+    expect(helperSource).toContain('eq(document.organizationId, orgId)')
+
+    for (const route of [
+      'server/api/documents/[id]/download.get.ts',
+      'server/api/documents/[id]/preview.get.ts',
+    ]) {
+      const source = read(route)
+      expect(source, `${route} missing shared document lookup`).toContain('loadOrgDocumentForRead(orgId, documentId)')
+      expect(source, `${route} missing document read permission`).toContain("requirePermission(event, { document: ['read'] })")
     }
   })
 

--- a/tests/unit/server-endpoint-helpers.test.ts
+++ b/tests/unit/server-endpoint-helpers.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { H3Error } from 'h3'
+import { buildDocumentStreamHeaders } from '../../server/utils/documentStreaming'
+import { parsePropertyFiltersParam } from '../../server/utils/propertyFilters'
+
+describe('document stream helpers', () => {
+  it('builds attachment headers with encoded UTF-8 filename and content length', () => {
+    const headers = buildDocumentStreamHeaders({
+      filename: 'Doug Résumé.pdf',
+      contentType: 'application/pdf',
+      disposition: 'attachment',
+      contentLength: 1536,
+    })
+
+    expect(headers).toMatchObject({
+      'Content-Type': 'application/pdf',
+      'Cache-Control': 'private, no-store',
+      'X-Content-Type-Options': 'nosniff',
+      'Content-Length': '1536',
+    })
+    expect(headers['Content-Disposition']).toContain('attachment;')
+    expect(headers['Content-Disposition']).toContain('Doug%20R%C3%A9sum%C3%A9.pdf')
+  })
+
+  it('adds preview-only frame and CSP headers for inline PDF streams', () => {
+    const headers = buildDocumentStreamHeaders({
+      filename: 'portfolio.pdf',
+      contentType: 'application/pdf',
+      disposition: 'inline',
+      frameOptions: 'SAMEORIGIN',
+      contentSecurityPolicy: "default-src 'none'",
+    })
+
+    expect(headers['Content-Disposition']).toContain('inline;')
+    expect(headers['X-Frame-Options']).toBe('SAMEORIGIN')
+    expect(headers['Content-Security-Policy']).toBe("default-src 'none'")
+    expect(headers).not.toHaveProperty('Content-Length')
+  })
+})
+
+describe('property filter helpers', () => {
+  it('parses a valid propertyFilters query string', () => {
+    const filters = parsePropertyFiltersParam(JSON.stringify([
+      { propertyDefinitionId: 'prop_1', op: 'contains', value: 'machine' },
+    ]))
+
+    expect(filters).toEqual([
+      { propertyDefinitionId: 'prop_1', op: 'contains', value: 'machine' },
+    ])
+  })
+
+  it('returns an empty list when propertyFilters is omitted', () => {
+    expect(parsePropertyFiltersParam(undefined)).toEqual([])
+  })
+
+  it('throws the existing 400 error shape for malformed JSON', () => {
+    expect(() => parsePropertyFiltersParam('{')).toThrow(H3Error)
+
+    try {
+      parsePropertyFiltersParam('{')
+    } catch (error) {
+      expect((error as H3Error).statusCode).toBe(400)
+      expect((error as H3Error).statusMessage).toBe('Invalid propertyFilters')
+    }
+  })
+
+  it('throws the existing 400 error shape for invalid filters', () => {
+    expect(() => parsePropertyFiltersParam(JSON.stringify([{ op: 'contains' }]))).toThrow(H3Error)
+  })
+})


### PR DESCRIPTION
## Summary

- Reviewed the open DRY/refactor issue set (#3, #4, #5, #6, #7).
- Fully addresses #5 by extracting shared server helpers for org-scoped document streaming and property-filter parsing/matching.
- Keeps the candidate/application list endpoints and document download/preview routes on their existing CLI commands; no route, auth, payload, or response-shape changes intended.

Closes #5

## DRY Issue Review

- #3 Candidate detail panels: still open; larger drawer/full-page component extraction.
- #4 Candidate schemas: still open; useful P2 follow-up, but separate client/server schema migration.
- #5 Server endpoint helpers: addressed here because it is P2 and security-sensitive.
- #6 Application detail UI/actions: still open; UI/composable extraction.
- #7 Table/saved-view state helpers: still open; broad dashboard-list refactor.

## Validation

- [x] CLI parity evidence found via `tests/unit/cli-route-coverage-manifest.test.ts`
- [x] `npm run test:unit` - 110 files, 714 tests passed
- [x] `npm run typecheck` - exited 0; existing Vue/Volar package-subpath warning emitted
- [x] CLI smoke tests - pre-push hook passed
- [x] `npm run ops:validate-production-env` - PASS in pre-push hook
- [x] `npm run build` - passed in pre-push hook
- [x] Multi-tenant scoping preserved by `tests/unit/security-route-coverage.test.ts`

## CLI parity

- [x] Checked changed API routes for route/auth/payload/response-shape changes. This is an internal refactor only.
- [x] Existing CLI route coverage remains: `applications list`, `candidates list`, `documents download`, and `documents preview`.
