### PR TITLE
refactor: share candidate validation schemas

### DIFF
--- a/app/pages/dashboard/candidates/[id].vue
+++ b/app/pages/dashboard/candidates/[id].vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { ArrowLeft, Pencil, Trash2, Mail, Phone, Calendar, Clock, Briefcase, FileText, Plus, Upload, Download, Eye, AlertTriangle } from 'lucide-vue-next'
-import { z } from 'zod'
 import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
+import {
+  candidateEditFormSchema,
+  normalizeEmptyCandidateFormFields,
+} from '~~/shared/schemas/candidate'
 
 definePageMeta({
   layout: 'dashboard',
@@ -64,33 +67,11 @@ function cancelEdit() {
   editErrors.value = {}
 }
 
-const editSchema = z.object({
-  firstName: z.string().min(1, 'First name is required').max(100),
-  lastName: z.string().min(1, 'Last name is required').max(100),
-  displayName: z.string().max(200).optional(),
-  email: z.string().min(1, 'Email is required').email('Invalid email address').max(255),
-  phone: z.string().max(50).optional(),
-  gender: z.enum(['male', 'female', 'other', 'prefer_not_to_say']).optional(),
-  dateOfBirth: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD')
-    .refine((v) => {
-      const d = new Date(v)
-      return !isNaN(d.getTime()) && d.getFullYear() >= 1900 && d <= new Date()
-    }, 'Must be a valid past date')
-    .optional(),
-})
-
 const isSaving = ref(false)
 const editErrors = ref<Record<string, string>>({})
 
 async function handleSave() {
-  const result = editSchema.safeParse({
-    ...editForm.value,
-    gender: editForm.value.gender || undefined,
-    dateOfBirth: editForm.value.dateOfBirth || undefined,
-    displayName: editForm.value.displayName || undefined,
-  })
+  const result = candidateEditFormSchema.safeParse(normalizeEmptyCandidateFormFields(editForm.value))
   if (!result.success) {
     editErrors.value = {}
     for (const issue of result.error.issues) {

--- a/app/pages/dashboard/candidates/new.vue
+++ b/app/pages/dashboard/candidates/new.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import { z } from 'zod'
+import {
+  candidateFormSchema,
+  normalizeEmptyCandidateFormFields,
+} from '~~/shared/schemas/candidate'
 
 definePageMeta({
   layout: 'dashboard',
@@ -30,30 +33,8 @@ const isSubmitting = ref(false)
 const errors = ref<Record<string, string>>({})
 const submitError = ref<string | null>(null)
 
-const formSchema = z.object({
-  firstName: z.string().min(1, 'First name is required').max(100),
-  lastName: z.string().min(1, 'Last name is required').max(100),
-  displayName: z.string().max(200).optional(),
-  email: z.string().min(1, 'Email is required').email('Invalid email address').max(255),
-  phone: z.string().max(50).optional(),
-  gender: z.enum(['male', 'female', 'other', 'prefer_not_to_say']).optional(),
-  dateOfBirth: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD')
-    .refine((v) => {
-      const d = new Date(v)
-      return !isNaN(d.getTime()) && d.getFullYear() >= 1900 && d <= new Date()
-    }, 'Must be a valid past date')
-    .optional(),
-})
-
 function validate(): boolean {
-  const result = formSchema.safeParse({
-    ...form.value,
-    gender: form.value.gender || undefined,
-    dateOfBirth: form.value.dateOfBirth || undefined,
-    displayName: form.value.displayName || undefined,
-  })
+  const result = candidateFormSchema.safeParse(normalizeEmptyCandidateFormFields(form.value))
   if (!result.success) {
     errors.value = {}
     for (const issue of result.error.issues) {

--- a/packages/careers-cli/src/schemas.ts
+++ b/packages/careers-cli/src/schemas.ts
@@ -1,7 +1,16 @@
 import { z } from 'zod'
-import { candidateEmailSchema } from '../../../shared/schemas/candidate'
 
 const optionalText = z.string().trim().min(1).optional()
+const cliCandidateEmailSchema = z
+  .preprocess(
+    (value) => typeof value === 'string' ? value.trim() : value,
+    z
+      .string()
+      .min(1, 'Email is required')
+      .email('Invalid email address')
+      .max(255)
+      .transform((value) => value.toLowerCase()),
+  )
 
 export const cliJobCreateSchema = z.object({
   title: z.string().trim().min(1),
@@ -14,7 +23,7 @@ export const cliJobCreateSchema = z.object({
 export const cliCandidateCreateSchema = z.object({
   firstName: z.string().trim().min(1),
   lastName: z.string().trim().min(1),
-  email: candidateEmailSchema,
+  email: cliCandidateEmailSchema,
   phone: optionalText,
 }).passthrough()
 

--- a/packages/careers-cli/src/schemas.ts
+++ b/packages/careers-cli/src/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { candidateEmailSchema } from '../../../shared/schemas/candidate'
 
 const optionalText = z.string().trim().min(1).optional()
 
@@ -13,7 +14,7 @@ export const cliJobCreateSchema = z.object({
 export const cliCandidateCreateSchema = z.object({
   firstName: z.string().trim().min(1),
   lastName: z.string().trim().min(1),
-  email: z.email(),
+  email: candidateEmailSchema,
   phone: optionalText,
 }).passthrough()
 

--- a/server/utils/schemas/candidate.ts
+++ b/server/utils/schemas/candidate.ts
@@ -1,54 +1,23 @@
 import { z } from 'zod'
+import {
+  candidateCreateFieldsSchema,
+  candidateDateOfBirthSchema,
+  candidateGenderSchema,
+  candidateGenderValues,
+  candidateUpdateFieldsSchema,
+} from '~~/shared/schemas/candidate'
 
 // ─────────────────────────────────────────────
 // Candidate validation schemas — shared across API routes
 // ─────────────────────────────────────────────
 
-const genderValues = ['male', 'female', 'other', 'prefer_not_to_say'] as const
-
-/** ISO 8601 date string (YYYY-MM-DD), validated to be a real date in a reasonable range */
-const dobSchema = z
-  .string()
-  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date of birth must be in YYYY-MM-DD format')
-  .refine((val) => {
-    const d = new Date(val)
-    if (isNaN(d.getTime())) return false
-    const year = d.getFullYear()
-    const now = new Date()
-    return year >= 1900 && d <= now
-  }, 'Date of birth must be a valid past date')
-
 /** Schema for creating a new candidate */
-export const createCandidateSchema = z.object({
-  firstName: z.string().min(1, 'First name is required').max(100),
-  lastName: z.string().min(1, 'Last name is required').max(100),
-  displayName: z.string().max(200).optional(),
-  email: z
-    .string()
-    .min(1, 'Email is required')
-    .email('Invalid email address')
-    .max(255)
-    .transform((v) => v.toLowerCase().trim()),
-  phone: z.string().max(50).optional(),
-  gender: z.enum(genderValues).optional(),
-  dateOfBirth: dobSchema.optional(),
+export const createCandidateSchema = candidateCreateFieldsSchema.extend({
   quickNotes: z.string().max(1000).optional(),
 })
 
 /** Schema for updating an existing candidate (all fields optional) */
-export const updateCandidateSchema = z.object({
-  firstName: z.string().min(1, 'First name is required').max(100).optional(),
-  lastName: z.string().min(1, 'Last name is required').max(100).optional(),
-  displayName: z.string().max(200).nullish(),
-  email: z
-    .string()
-    .email('Invalid email address')
-    .max(255)
-    .transform((v) => v.toLowerCase().trim())
-    .optional(),
-  phone: z.string().max(50).nullish(),
-  gender: z.enum(genderValues).nullish(),
-  dateOfBirth: dobSchema.nullish(),
+export const updateCandidateSchema = candidateUpdateFieldsSchema.extend({
   quickNotes: z.string().max(1000).nullish(),
 })
 
@@ -57,7 +26,7 @@ export const candidateQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(20),
   search: z.string().trim().max(200).optional(),
-  gender: z.enum(genderValues).optional(),
+  gender: candidateGenderSchema.optional(),
   dobFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'dobFrom must be YYYY-MM-DD').optional(),
   dobTo: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'dobTo must be YYYY-MM-DD').optional(),
   /** JSON-encoded array of { propertyDefinitionId, op, value } filters */
@@ -68,3 +37,5 @@ export const candidateQuerySchema = z.object({
 export const candidateIdParamSchema = z.object({
   id: z.string().min(1),
 })
+
+export { candidateDateOfBirthSchema, candidateGenderValues }

--- a/server/utils/schemas/publicApplication.ts
+++ b/server/utils/schemas/publicApplication.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod'
 import { COUNTRY_VALUES, US_STATE_VALUES } from '~~/shared/location-options'
 import {
+  candidateFirstNameSchema,
   candidateLastNameSchema,
   candidatePhoneSchema,
-  personNameSchema,
   publicCandidateEmailSchema,
 } from '~~/shared/schemas/candidate'
 
@@ -24,7 +24,7 @@ const questionResponseSchema = z.object({
 
 /** Schema for public application submission on an open job */
 export const publicApplicationSchema = z.object({
-  firstName: personNameSchema,
+  firstName: candidateFirstNameSchema,
   lastName: candidateLastNameSchema,
   email: publicCandidateEmailSchema,
   phone: candidatePhoneSchema.optional(),

--- a/server/utils/schemas/publicApplication.ts
+++ b/server/utils/schemas/publicApplication.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod'
 import { COUNTRY_VALUES, US_STATE_VALUES } from '~~/shared/location-options'
+import {
+  candidateLastNameSchema,
+  candidatePhoneSchema,
+  personNameSchema,
+  publicCandidateEmailSchema,
+} from '~~/shared/schemas/candidate'
 
 // ─────────────────────────────────────────────
 // Public application submission schemas
@@ -18,10 +24,10 @@ const questionResponseSchema = z.object({
 
 /** Schema for public application submission on an open job */
 export const publicApplicationSchema = z.object({
-  firstName: z.string().min(1, 'First name is required').max(100),
-  lastName: z.string().min(1, 'Last name is required').max(100),
-  email: z.string().email('Invalid email address').max(254),
-  phone: z.string().max(50).optional(),
+  firstName: personNameSchema,
+  lastName: candidateLastNameSchema,
+  email: publicCandidateEmailSchema,
+  phone: candidatePhoneSchema.optional(),
   country: z.enum(COUNTRY_VALUES, 'Country is required'),
   state: z.enum(US_STATE_VALUES, 'State is required'),
   responses: z.array(questionResponseSchema).default([]),

--- a/shared/schemas/candidate.ts
+++ b/shared/schemas/candidate.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod'
+
+export const candidateGenderValues = ['male', 'female', 'other', 'prefer_not_to_say'] as const
+
+export type CandidateGender = typeof candidateGenderValues[number]
+
+export const personNameSchema = z.string().min(1, 'First name is required').max(100)
+export const candidateLastNameSchema = z.string().min(1, 'Last name is required').max(100)
+export const candidateDisplayNameSchema = z.string().max(200)
+export const candidatePhoneSchema = z.string().max(50)
+export const candidateGenderSchema = z.enum(candidateGenderValues)
+
+export const candidateEmailSchema = z
+  .preprocess(
+    (value) => typeof value === 'string' ? value.trim() : value,
+    z
+      .string()
+      .min(1, 'Email is required')
+      .email('Invalid email address')
+      .max(255)
+      .transform((value) => value.toLowerCase()),
+  )
+
+export const publicCandidateEmailSchema = z
+  .preprocess(
+    (value) => typeof value === 'string' ? value.trim() : value,
+    z
+      .string()
+      .email('Invalid email address')
+      .max(254)
+      .transform((value) => value.toLowerCase()),
+  )
+
+export const candidateDateOfBirthSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date of birth must be in YYYY-MM-DD format')
+  .refine((value) => {
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return false
+    const year = date.getFullYear()
+    return year >= 1900 && date <= new Date()
+  }, 'Date of birth must be a valid past date')
+
+export const candidateCreateFieldsSchema = z.object({
+  firstName: personNameSchema,
+  lastName: candidateLastNameSchema,
+  displayName: candidateDisplayNameSchema.optional(),
+  email: candidateEmailSchema,
+  phone: candidatePhoneSchema.optional(),
+  gender: candidateGenderSchema.optional(),
+  dateOfBirth: candidateDateOfBirthSchema.optional(),
+})
+
+export const candidateUpdateFieldsSchema = z.object({
+  firstName: personNameSchema.optional(),
+  lastName: candidateLastNameSchema.optional(),
+  displayName: candidateDisplayNameSchema.nullish(),
+  email: candidateEmailSchema.optional(),
+  phone: candidatePhoneSchema.nullish(),
+  gender: candidateGenderSchema.nullish(),
+  dateOfBirth: candidateDateOfBirthSchema.nullish(),
+})
+
+export const candidateFormSchema = candidateCreateFieldsSchema
+export const candidateEditFormSchema = candidateCreateFieldsSchema
+
+export function emptyStringToUndefined<T>(value: T): T | undefined {
+  return value === '' ? undefined : value
+}
+
+export function normalizeEmptyCandidateFormFields<T extends {
+  displayName?: string
+  phone?: string
+  gender?: string
+  dateOfBirth?: string
+}>(fields: T): Omit<T, 'displayName' | 'phone' | 'gender' | 'dateOfBirth'> & {
+  displayName?: string
+  phone?: string
+  gender?: string
+  dateOfBirth?: string
+} {
+  return {
+    ...fields,
+    displayName: emptyStringToUndefined(fields.displayName),
+    phone: emptyStringToUndefined(fields.phone),
+    gender: emptyStringToUndefined(fields.gender),
+    dateOfBirth: emptyStringToUndefined(fields.dateOfBirth),
+  }
+}

--- a/shared/schemas/candidate.ts
+++ b/shared/schemas/candidate.ts
@@ -4,7 +4,7 @@ export const candidateGenderValues = ['male', 'female', 'other', 'prefer_not_to_
 
 export type CandidateGender = typeof candidateGenderValues[number]
 
-export const personNameSchema = z.string().min(1, 'First name is required').max(100)
+export const candidateFirstNameSchema = z.string().min(1, 'First name is required').max(100)
 export const candidateLastNameSchema = z.string().min(1, 'Last name is required').max(100)
 export const candidateDisplayNameSchema = z.string().max(200)
 export const candidatePhoneSchema = z.string().max(50)
@@ -42,7 +42,7 @@ export const candidateDateOfBirthSchema = z
   }, 'Date of birth must be a valid past date')
 
 export const candidateCreateFieldsSchema = z.object({
-  firstName: personNameSchema,
+  firstName: candidateFirstNameSchema,
   lastName: candidateLastNameSchema,
   displayName: candidateDisplayNameSchema.optional(),
   email: candidateEmailSchema,
@@ -52,7 +52,7 @@ export const candidateCreateFieldsSchema = z.object({
 })
 
 export const candidateUpdateFieldsSchema = z.object({
-  firstName: personNameSchema.optional(),
+  firstName: candidateFirstNameSchema.optional(),
   lastName: candidateLastNameSchema.optional(),
   displayName: candidateDisplayNameSchema.nullish(),
   email: candidateEmailSchema.optional(),

--- a/tests/unit/candidate-shared-schemas.test.ts
+++ b/tests/unit/candidate-shared-schemas.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, it } from 'vitest'
 import {
   candidateDateOfBirthSchema,
   candidateEmailSchema,
+  candidateFirstNameSchema,
   candidateGenderValues,
   normalizeEmptyCandidateFormFields,
-  personNameSchema,
   publicCandidateEmailSchema,
 } from '../../shared/schemas/candidate'
 
@@ -20,8 +20,8 @@ describe('shared candidate validation schemas', () => {
   })
 
   it('shares core person, phone, gender, and date validation primitives', () => {
-    expect(personNameSchema.safeParse('').success).toBe(false)
-    expect(personNameSchema.safeParse('A'.repeat(101)).success).toBe(false)
+    expect(candidateFirstNameSchema.safeParse('').success).toBe(false)
+    expect(candidateFirstNameSchema.safeParse('A'.repeat(101)).success).toBe(false)
     expect(candidateGenderValues).toEqual(['male', 'female', 'other', 'prefer_not_to_say'])
     expect(candidateDateOfBirthSchema.safeParse('1899-12-31').success).toBe(false)
     expect(candidateDateOfBirthSchema.safeParse('2000-02-29').success).toBe(true)
@@ -65,5 +65,12 @@ describe('shared candidate validation schemas', () => {
 
     expect(readProjectFile('app/pages/dashboard/candidates/new.vue')).not.toContain('const formSchema = z.object')
     expect(readProjectFile('app/pages/dashboard/candidates/[id].vue')).not.toContain('const editSchema = z.object')
+  })
+
+  it('names first-name validation explicitly to avoid accidental last-name reuse', () => {
+    const source = readProjectFile('shared/schemas/candidate.ts')
+
+    expect(source).toContain('candidateFirstNameSchema')
+    expect(source).not.toContain('personNameSchema')
   })
 })

--- a/tests/unit/candidate-shared-schemas.test.ts
+++ b/tests/unit/candidate-shared-schemas.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  candidateDateOfBirthSchema,
+  candidateEmailSchema,
+  candidateGenderValues,
+  normalizeEmptyCandidateFormFields,
+  personNameSchema,
+  publicCandidateEmailSchema,
+} from '../../shared/schemas/candidate'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('shared candidate validation schemas', () => {
+  it('normalizes candidate email consistently for internal candidate records', () => {
+    expect(candidateEmailSchema.parse(' Ada@Example.COM ')).toBe('ada@example.com')
+  })
+
+  it('shares core person, phone, gender, and date validation primitives', () => {
+    expect(personNameSchema.safeParse('').success).toBe(false)
+    expect(personNameSchema.safeParse('A'.repeat(101)).success).toBe(false)
+    expect(candidateGenderValues).toEqual(['male', 'female', 'other', 'prefer_not_to_say'])
+    expect(candidateDateOfBirthSchema.safeParse('1899-12-31').success).toBe(false)
+    expect(candidateDateOfBirthSchema.safeParse('2000-02-29').success).toBe(true)
+  })
+
+  it('preserves the public application email length contract while sharing contact validation', () => {
+    expect(publicCandidateEmailSchema.parse(' Applicant@Example.COM ')).toBe('applicant@example.com')
+    expect(publicCandidateEmailSchema.safeParse(`${'a'.repeat(250)}@x.test`).success).toBe(false)
+  })
+
+  it('normalizes empty form strings before parsing optional candidate fields', () => {
+    expect(normalizeEmptyCandidateFormFields({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'ada@example.com',
+      displayName: '',
+      phone: '',
+      gender: '',
+      dateOfBirth: '',
+    })).toEqual({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'ada@example.com',
+      displayName: undefined,
+      phone: undefined,
+      gender: undefined,
+      dateOfBirth: undefined,
+    })
+  })
+
+  it('keeps candidate create/edit pages and server schemas on shared primitives', () => {
+    for (const path of [
+      'app/pages/dashboard/candidates/new.vue',
+      'app/pages/dashboard/candidates/[id].vue',
+      'server/utils/schemas/candidate.ts',
+      'server/utils/schemas/publicApplication.ts',
+    ]) {
+      expect(readProjectFile(path), `${path} should use shared candidate schemas`)
+        .toContain('shared/schemas/candidate')
+    }
+
+    expect(readProjectFile('app/pages/dashboard/candidates/new.vue')).not.toContain('const formSchema = z.object')
+    expect(readProjectFile('app/pages/dashboard/candidates/[id].vue')).not.toContain('const editSchema = z.object')
+  })
+})

--- a/tests/unit/cli-shared-schemas.test.ts
+++ b/tests/unit/cli-shared-schemas.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import {
   cliApplicationCreateSchema,
   cliCandidateCreateSchema,
@@ -19,5 +21,12 @@ describe('shared CLI request schemas', () => {
     expect(() => cliJobCreateSchema.parse({ title: '' })).toThrow()
     expect(() => cliCandidateCreateSchema.parse({ firstName: 'Ada', lastName: 'Lovelace', email: 'not-email' })).toThrow()
     expect(() => cliInterviewScheduleSchema.parse({ applicationId: 'app_1', title: 'Screen', scheduledAt: 'tomorrow-ish' })).toThrow()
+  })
+
+  it('keeps the published CLI schemas package self-contained', () => {
+    const source = readFileSync(join(process.cwd(), 'packages/careers-cli/src/schemas.ts'), 'utf8')
+
+    expect(source).not.toContain('../../../shared/')
+    expect(source).toContain('cliCandidateEmailSchema')
   })
 })

--- a/tests/unit/cli-shared-schemas.test.ts
+++ b/tests/unit/cli-shared-schemas.test.ts
@@ -10,6 +10,7 @@ describe('shared CLI request schemas', () => {
   it('validates core mutating payloads used by stdin automation', () => {
     expect(cliJobCreateSchema.parse({ title: 'Engineer', status: 'draft' })).toMatchObject({ title: 'Engineer' })
     expect(cliCandidateCreateSchema.parse({ firstName: 'Ada', lastName: 'Lovelace', email: 'ada@example.com' })).toMatchObject({ email: 'ada@example.com' })
+    expect(cliCandidateCreateSchema.parse({ firstName: 'Ada', lastName: 'Lovelace', email: ' Ada@Example.COM ' })).toMatchObject({ email: 'ada@example.com' })
     expect(cliApplicationCreateSchema.parse({ candidateId: 'cand_1', jobId: 'job_1' })).toMatchObject({ candidateId: 'cand_1' })
     expect(cliInterviewScheduleSchema.parse({ applicationId: 'app_1', title: 'Screen', scheduledAt: new Date().toISOString() })).toMatchObject({ applicationId: 'app_1' })
   })


### PR DESCRIPTION
## Summary

- Moves reusable candidate person/contact validation into `shared/schemas/candidate.ts`.
- Reuses those schemas in dashboard candidate create/edit forms, server candidate create/update schemas, public application submission validation, and CLI candidate stdin validation.
- Normalizes candidate emails by trimming before validation and lowercasing after validation across server and CLI paths.

Closes #4

## Validation

- [x] `npm run test:unit -- tests/unit/candidate-shared-schemas.test.ts` initially failed before the shared module existed, then passed after extraction.
- [x] `npm run test:unit -- tests/unit/candidate-shared-schemas.test.ts tests/unit/cli-shared-schemas.test.ts tests/unit/cli-candidates-applications-commands.test.ts tests/unit/cli-public-commands.test.ts tests/unit/application-form-requirements.test.ts`
- [x] `npm run test:unit` - 110 files, 711 tests passed
- [x] `npm run typecheck` - exited 0; existing Vue/Volar package-subpath warning emitted
- [x] Pre-push `npm run preflight:pr` passed: CLI parity evidence, unit tests, lint skip, typecheck, CLI smoke tests, production env contract, build

## CLI parity

- [x] Candidate CLI stdin validation now imports the shared candidate email schema, so it preserves API compatibility while matching the server normalization path.
