### PR TITLE
fix: tolerate pending signup allowlist migration

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -150,6 +150,7 @@ Some routes intentionally remain outside the deterministic CLI surface:
 Server API coverage is tracked in `packages/careers-cli/src/routeCoverage.ts`. The unit test `tests/unit/cli-route-coverage-manifest.test.ts` walks `server/api` and fails if a route is missing from the manifest, if a supported route lacks a CLI command, or if an excluded/internal route lacks a reason. When adding or changing a portal/API workflow, update the CLI command surface or record the explicit exclusion in that manifest.
 
 `org update-settings --stdin --yes` accepts the same JSON payload as `/api/org-settings`, including `signupAllowedDomains` for owner-managed signup domain allowlists. The server still enforces owner-only updates and requires each domain to match a configured SSO provider or organization-level calendar integration.
+When a deployment has not yet applied the `signup_allowed_domains` migration, `org settings` keeps the same response shape and returns `signupAllowedDomains: []`; saving that field is unavailable until the migration is applied.
 
 ## Examples
 

--- a/server/api/org-settings/index.get.ts
+++ b/server/api/org-settings/index.get.ts
@@ -1,6 +1,6 @@
 import { eq } from 'drizzle-orm'
 import { orgSettings } from '../../database/schema'
-import { hasPostgresErrorCode } from '../../utils/signupDomainAllowlist'
+import { hasPostgresErrorCode, hasSignupAllowedDomainsColumn } from '../../utils/signupDomainAllowlist'
 
 export default defineEventHandler(async (event) => {
   const session = await requirePermission(event, { organization: ['read'] })
@@ -13,15 +13,23 @@ export default defineEventHandler(async (event) => {
     signupAllowedDomains?: string[]
   } | undefined
 
+  const includeSignupAllowedDomains = await hasSignupAllowedDomainsColumn()
+
   try {
     settings = await db.query.orgSettings.findFirst({
       where: eq(orgSettings.organizationId, orgId),
-      columns: {
-        nameDisplayFormat: true,
-        dateFormat: true,
-        defaultSalaryUnit: true,
-        signupAllowedDomains: true,
-      },
+      columns: includeSignupAllowedDomains
+        ? {
+            nameDisplayFormat: true,
+            dateFormat: true,
+            defaultSalaryUnit: true,
+            signupAllowedDomains: true,
+          }
+        : {
+            nameDisplayFormat: true,
+            dateFormat: true,
+            defaultSalaryUnit: true,
+          },
     })
   }
   catch (error) {

--- a/server/api/org-settings/index.patch.ts
+++ b/server/api/org-settings/index.patch.ts
@@ -1,13 +1,21 @@
 import { eq } from 'drizzle-orm'
 import { orgSettings } from '../../database/schema'
 import { updateOrgSettingsSchema } from '../../utils/schemas/orgSettings'
-import { assertSignupDomainAllowlistUpdateAllowed } from '../../utils/signupDomainAllowlist'
+import { assertSignupDomainAllowlistUpdateAllowed, hasSignupAllowedDomainsColumn } from '../../utils/signupDomainAllowlist'
 
 export default defineEventHandler(async (event) => {
   const session = await requirePermission(event, { organization: ['update'] })
   const orgId = session.session.activeOrganizationId
 
   const body = await readValidatedBody(event, updateOrgSettingsSchema.parse)
+  const includeSignupAllowedDomains = await hasSignupAllowedDomainsColumn()
+
+  if (body.signupAllowedDomains !== undefined && !includeSignupAllowedDomains) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'Signup domain allowlists are pending a database migration.',
+    })
+  }
 
   if (body.signupAllowedDomains !== undefined) {
     await assertSignupDomainAllowlistUpdateAllowed({
@@ -26,7 +34,7 @@ export default defineEventHandler(async (event) => {
       dateFormat: body.dateFormat ?? 'mdy',
       calendarSyncInterviewers: body.calendarSyncInterviewers ?? false,
       defaultSalaryUnit: body.defaultSalaryUnit ?? 'YEAR',
-      signupAllowedDomains: body.signupAllowedDomains ?? [],
+      ...(includeSignupAllowedDomains && { signupAllowedDomains: body.signupAllowedDomains ?? [] }),
     })
     .onConflictDoUpdate({
       target: orgSettings.organizationId,
@@ -35,17 +43,24 @@ export default defineEventHandler(async (event) => {
         ...(body.dateFormat !== undefined && { dateFormat: body.dateFormat }),
         ...(body.calendarSyncInterviewers !== undefined && { calendarSyncInterviewers: body.calendarSyncInterviewers }),
         ...(body.defaultSalaryUnit !== undefined && { defaultSalaryUnit: body.defaultSalaryUnit }),
-        ...(body.signupAllowedDomains !== undefined && { signupAllowedDomains: body.signupAllowedDomains }),
+        ...(includeSignupAllowedDomains && body.signupAllowedDomains !== undefined && { signupAllowedDomains: body.signupAllowedDomains }),
         updatedAt: new Date(),
       },
     })
-    .returning({
-      nameDisplayFormat: orgSettings.nameDisplayFormat,
-      dateFormat: orgSettings.dateFormat,
-      calendarSyncInterviewers: orgSettings.calendarSyncInterviewers,
-      defaultSalaryUnit: orgSettings.defaultSalaryUnit,
-      signupAllowedDomains: orgSettings.signupAllowedDomains,
-    })
+    .returning(includeSignupAllowedDomains
+      ? {
+          nameDisplayFormat: orgSettings.nameDisplayFormat,
+          dateFormat: orgSettings.dateFormat,
+          calendarSyncInterviewers: orgSettings.calendarSyncInterviewers,
+          defaultSalaryUnit: orgSettings.defaultSalaryUnit,
+          signupAllowedDomains: orgSettings.signupAllowedDomains,
+        }
+      : {
+          nameDisplayFormat: orgSettings.nameDisplayFormat,
+          dateFormat: orgSettings.dateFormat,
+          calendarSyncInterviewers: orgSettings.calendarSyncInterviewers,
+          defaultSalaryUnit: orgSettings.defaultSalaryUnit,
+        })
 
   if (!result) {
     throw createError({ statusCode: 500, statusMessage: 'Failed to save settings' })
@@ -53,5 +68,8 @@ export default defineEventHandler(async (event) => {
 
   logApiRequest(event, session, 'org_settings.updated', {})
 
-  return result
+  return {
+    ...result,
+    signupAllowedDomains: 'signupAllowedDomains' in result ? result.signupAllowedDomains : [],
+  }
 })

--- a/server/utils/signupDomainAllowlist.ts
+++ b/server/utils/signupDomainAllowlist.ts
@@ -12,6 +12,8 @@ import {
   normalizeSignupDomain,
 } from '~~/shared/signup-domains'
 
+let signupAllowedDomainsColumnExistsPromise: Promise<boolean> | undefined
+
 function emailDomain(value: string | null | undefined): string | null {
   if (!value) return null
   return extractSignupEmailDomain(value)
@@ -24,9 +26,26 @@ export function hasPostgresErrorCode(error: unknown, code: string): boolean {
   return false
 }
 
+export async function hasSignupAllowedDomainsColumn(): Promise<boolean> {
+  signupAllowedDomainsColumnExistsPromise ??= db
+    .execute<{ exists: boolean }>(sql`
+      SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'org_settings'
+          AND column_name = 'signup_allowed_domains'
+      ) AS exists
+    `)
+    .then(result => result[0]?.exists === true)
+
+  return signupAllowedDomainsColumnExistsPromise
+}
+
 export async function isSignupEmailAllowedByAnyOrgAllowlist(email: unknown): Promise<boolean> {
   const domain = extractSignupEmailDomain(email)
   if (!domain) return false
+  if (!(await hasSignupAllowedDomainsColumn())) return false
 
   try {
     const [match] = await db
@@ -115,6 +134,8 @@ export async function assertSignupDomainAllowlistUpdateAllowed(options: {
 }
 
 export async function getOrgSignupAllowedDomains(organizationId: string): Promise<string[]> {
+  if (!(await hasSignupAllowedDomainsColumn())) return []
+
   const settings = await db.query.orgSettings.findFirst({
     where: eq(orgSettings.organizationId, organizationId),
     columns: { signupAllowedDomains: true },


### PR DESCRIPTION
## Summary
- make org settings GET/PATCH tolerate deployments where `org_settings.signup_allowed_domains` has not been migrated yet
- return an empty allowlist shape until the column exists, and block saving allowlists with a clear 503 instead of a raw database error
- document the CLI/org-settings behavior while the migration is pending

## Root cause
Production does not have the `org_settings.signup_allowed_domains` column yet. Runtime migrations are skipped in the deployed environment, and the configured app database role is not the owner of `org_settings`, so it cannot apply the additive migration itself.

## Tests
- `npm run test:unit -- tests/unit/signup-domain-allowlist.test.ts tests/unit/org-default-salary-unit.test.ts tests/unit/security-route-coverage.test.ts tests/unit/cli-documentation.test.ts tests/unit/cli-parity-changed-files.test.ts`
- `npm run typecheck`
- pre-push PR preflight: full unit suite, typecheck, CLI smoke, production env contract, build
