### PR TITLE
refactor: share candidate detail panels

### DIFF
--- a/app/components/CandidateApplicationsPanel.vue
+++ b/app/components/CandidateApplicationsPanel.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { Briefcase, Calendar, Plus } from 'lucide-vue-next'
+import { APPLICATION_STATUS_TRANSITIONS } from '~~/shared/status-transitions'
+import {
+  getApplicationTransitionActionLabel,
+  getApplicationTransitionButtonClass,
+} from '~/utils/status-display'
+
+const props = withDefaults(defineProps<{
+  applications?: any[]
+  surface?: 'drawer' | 'page'
+  showStatusTransitions?: boolean
+  transitioningApplicationIds?: Set<string>
+}>(), {
+  applications: () => [],
+  surface: 'page',
+  showStatusTransitions: false,
+  transitioningApplicationIds: () => new Set<string>(),
+})
+
+const emit = defineEmits<{
+  apply: []
+  schedule: [application: any]
+  transition: [application: any, status: string]
+}>()
+
+const localePath = useLocalePath()
+
+const panelClass = computed(() =>
+  props.surface === 'drawer'
+    ? 'border border-white/12 bg-white/[0.025]'
+    : 'ui-panel ui-dashboard-panel',
+)
+
+function getApplicationTransitions(status: string) {
+  return APPLICATION_STATUS_TRANSITIONS[status] ?? []
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-3 flex justify-end">
+      <button
+        class="factory-toolbar-button inline-flex h-10 min-h-10 cursor-pointer items-center gap-1.5 border px-3 py-0 text-xs font-medium transition-colors hover:border-brand-500 hover:bg-brand-500/12 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
+        @click="emit('apply')"
+      >
+        <Plus class="size-3.5" />
+        Apply to Job
+      </button>
+    </div>
+
+    <div
+      v-if="!applications.length"
+      :class="[panelClass, 'p-8 text-center']"
+    >
+      <Briefcase class="mx-auto mb-2 size-8 text-white/32" />
+      <p class="text-sm text-white/54">No applications yet.</p>
+    </div>
+
+    <div v-else class="space-y-2">
+      <div
+        v-for="app in applications"
+        :key="app.id"
+        :class="[panelClass, 'group flex flex-col gap-2 px-4 py-3 transition-all hover:border-brand-500/70 hover:bg-brand-500/10 sm:flex-row sm:items-center sm:justify-between']"
+      >
+        <NuxtLink
+          :to="localePath(`/dashboard/applications/${app.id}`)"
+          class="block min-w-0 flex-1"
+        >
+          <h4 class="truncate text-sm font-semibold text-white transition-colors group-hover:text-brand-400">
+            {{ app.job.title }}
+          </h4>
+          <ApplicationTimestampStack
+            :applied-at="app.createdAt"
+            class="mt-1 items-start sm:items-start"
+          />
+        </NuxtLink>
+        <div class="flex shrink-0 items-center gap-1.5 sm:ml-3">
+          <button
+            v-for="nextStatus in showStatusTransitions ? getApplicationTransitions(app.status) : []"
+            :key="nextStatus"
+            class="group/action relative inline-flex size-8 shrink-0 cursor-pointer items-center justify-center border text-white transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500/40 disabled:cursor-not-allowed disabled:opacity-50"
+            :class="getApplicationTransitionButtonClass(nextStatus, 'factory')"
+            :title="getApplicationTransitionActionLabel(nextStatus)"
+            :aria-label="getApplicationTransitionActionLabel(nextStatus)"
+            :disabled="transitioningApplicationIds.has(app.id)"
+            @click.stop="emit('transition', app, nextStatus)"
+          >
+            <ApplicationTransitionIcon :status="nextStatus" class="size-3.5" />
+            <span class="pointer-events-none absolute bottom-full left-1/2 z-20 mb-2 -translate-x-1/2 translate-y-1 whitespace-nowrap border border-white/12 bg-black px-2 py-1 text-[10px] font-semibold uppercase tracking-normal text-white opacity-0 shadow-xl shadow-black/40 transition-all duration-150 group-hover/action:translate-y-0 group-hover/action:opacity-100 group-focus-visible/action:translate-y-0 group-focus-visible/action:opacity-100">
+              {{ getApplicationTransitionActionLabel(nextStatus) }}
+            </span>
+          </button>
+          <button
+            class="group/action relative inline-flex shrink-0 cursor-pointer items-center justify-center border transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500/40"
+            :class="showStatusTransitions ? 'size-8 border-white/16 bg-black text-white/80 hover:border-brand-500 hover:bg-brand-500/12 hover:text-white' : 'factory-toolbar-button h-8 min-h-8 gap-1 px-2.5 py-0 text-[10px] font-medium'"
+            title="Schedule Interview"
+            aria-label="Schedule Interview"
+            @click="emit('schedule', app)"
+          >
+            <Calendar :class="showStatusTransitions ? 'size-3.5' : 'size-3'" />
+            <span v-if="!showStatusTransitions">Schedule</span>
+            <span
+              v-else
+              class="pointer-events-none absolute bottom-full left-1/2 z-20 mb-2 -translate-x-1/2 translate-y-1 whitespace-nowrap border border-white/12 bg-black px-2 py-1 text-[10px] font-semibold uppercase tracking-normal text-white opacity-0 shadow-xl shadow-black/40 transition-all duration-150 group-hover/action:translate-y-0 group-hover/action:opacity-100 group-focus-visible/action:translate-y-0 group-focus-visible/action:opacity-100"
+            >
+              Schedule Interview
+            </span>
+          </button>
+          <ApplicationStatusBadge :status="app.status" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/components/CandidateDetailDrawer.vue
+++ b/app/components/CandidateDetailDrawer.vue
@@ -1,12 +1,6 @@
 <script setup lang="ts">
-import { X, ExternalLink, Phone, Calendar, Clock, Briefcase, FileText, Plus, Download, Eye } from 'lucide-vue-next'
-import { APPLICATION_STATUS_TRANSITIONS } from '~~/shared/status-transitions'
+import { ExternalLink, X } from 'lucide-vue-next'
 import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
-import { formatPhoneNumber } from '~/utils/phone-format'
-import {
-  getApplicationTransitionActionLabel,
-  getApplicationTransitionButtonClass,
-} from '~/utils/status-display'
 
 const props = defineProps<{
   candidateId: string
@@ -17,11 +11,10 @@ const emit = defineEmits<{
 }>()
 
 const localePath = useLocalePath()
-const { handlePreviewReadOnlyError } = usePreviewReadOnly()
 const toast = useToast()
+const { handlePreviewReadOnlyError } = usePreviewReadOnly()
 
 const { candidate, status: fetchStatus, error, refresh } = useCandidate(() => props.candidateId)
-const { formatCandidateName, formatDate } = useOrgSettings()
 
 // ─── Tabs ─────────────────────────────────────────────────────────────────────
 
@@ -45,10 +38,6 @@ const transitioningApplicationIds = ref<Set<string>>(new Set())
 function openScheduleInterview(app: { id: string; job: { title: string } }) {
   interviewTargetApp.value = { id: app.id, jobTitle: app.job.title }
   showInterviewSidebar.value = true
-}
-
-function getApplicationTransitions(status: string) {
-  return APPLICATION_STATUS_TRANSITIONS[status] ?? []
 }
 
 async function handleApplicationTransition(app: { id: string }, status: string) {
@@ -76,59 +65,20 @@ async function handleApplicationTransition(app: { id: string }, status: string) 
 // ─── Documents ────────────────────────────────────────────────────────────────
 
 const { downloadDocument, getPreviewUrl } = useDocuments()
-
-// Preview state
-const showPreview = ref(false)
-const previewUrl = ref<string | null>(null)
-const previewFilename = ref('')
-const previewMimeType = ref('')
-const previewDocId = ref<string | null>(null)
-
-const isPdfPreview = computed(() => previewMimeType.value === 'application/pdf')
-
-async function handlePreview(docId: string, mimeType?: string) {
-  if (mimeType && mimeType !== 'application/pdf') {
-    await handleDownload(docId)
-    return
-  }
-  showPreview.value = true
-  previewDocId.value = docId
-  const doc = candidate.value?.documents?.find((d: any) => d.id === docId)
-  previewFilename.value = doc?.originalFilename ?? 'Document'
-  previewMimeType.value = doc?.mimeType ?? 'application/pdf'
-  previewUrl.value = getPreviewUrl(docId)
-}
-
-function closePreview() {
-  showPreview.value = false
-  previewUrl.value = null
-  previewFilename.value = ''
-  previewMimeType.value = ''
-  previewDocId.value = null
-}
-
-async function handleDownload(docId: string) {
-  try {
-    await downloadDocument(docId)
-  } catch {
-    toast.error('Failed to download document')
-  }
-}
-
-// ─── Display helpers ──────────────────────────────────────────────────────────
-
-const genderLabels: Record<string, string> = {
-  male: 'Male',
-  female: 'Female',
-  other: 'Other',
-  prefer_not_to_say: 'Prefer not to say',
-}
-
-const documentTypeLabels: Record<string, string> = {
-  resume: 'Resume',
-  cover_letter: 'Cover Letter',
-  other: 'Other',
-}
+const documentPreview = useDocumentPreview({
+  documents: () => candidate.value?.documents,
+  getPreviewUrl,
+  downloadDocument,
+  onDownloadError: () => toast.error('Failed to download document'),
+})
+const documentPreviewState = computed(() => ({
+  showPreview: documentPreview.showPreview.value,
+  previewUrl: documentPreview.previewUrl.value,
+  previewFilename: documentPreview.previewFilename.value,
+  previewDocId: documentPreview.previewDocId.value,
+  previewError: documentPreview.previewError.value,
+  isPdfPreview: documentPreview.isPdfPreview.value,
+}))
 
 // ─── Body scroll lock + keyboard handling ─────────────────────────────────────
 
@@ -212,84 +162,12 @@ onUnmounted(() => {
           </div>
 
           <template v-else-if="candidate">
-            <!-- Header -->
-            <div class="border border-white/12 bg-white/[0.025] p-5">
-              <p class="mb-2 text-xs font-medium uppercase tracking-wide text-white/38">
-                Candidate profile
-              </p>
-              <h2 class="mb-1 truncate text-2xl font-bold text-white">
-                {{ formatCandidateName(candidate) }}
-              </h2>
-              <div class="flex flex-col gap-1 text-sm text-white/58 sm:flex-row sm:items-center sm:gap-4">
-                <CopyEmailButton :email="candidate.email" class="text-white/68" />
-                <span v-if="candidate.phone" class="inline-flex items-center gap-1 text-white/58">
-                  <Phone class="size-3.5" />
-                  {{ formatPhoneNumber(candidate.phone) }}
-                </span>
-              </div>
-            </div>
-
-            <!-- Contact details -->
-            <div class="border border-white/12 bg-white/[0.025] p-5">
-              <h3 class="mb-3 text-sm font-semibold text-white">Details</h3>
-              <dl class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-                <div>
-                  <dt class="text-white/38">Email</dt>
-                  <dd class="font-medium text-white/82">
-                    <CopyEmailButton :email="candidate.email" :show-icon="false" class="text-white/82" />
-                  </dd>
-                </div>
-                <div>
-                  <dt class="text-white/38">Phone</dt>
-                  <dd class="font-medium text-white/82">{{ formatPhoneNumber(candidate.phone) || '—' }}</dd>
-                </div>
-                <div v-if="candidate.gender">
-                  <dt class="text-white/38">Gender</dt>
-                  <dd class="font-medium text-white/82">
-                    {{ genderLabels[candidate.gender] ?? candidate.gender }}
-                  </dd>
-                </div>
-                <div v-if="candidate.dateOfBirth">
-                  <dt class="text-white/38">Date of Birth</dt>
-                  <dd class="font-medium text-white/82">
-                    {{ formatDate(candidate.dateOfBirth) }}
-                  </dd>
-                </div>
-                <div v-if="candidate.displayName">
-                  <dt class="text-white/38">Display Name</dt>
-                  <dd class="font-medium text-white/82">{{ candidate.displayName }}</dd>
-                </div>
-                <div>
-                  <dt class="inline-flex items-center gap-1 text-white/38">
-                    <Calendar class="size-3.5" />
-                    Created
-                  </dt>
-                  <dd class="font-medium text-white/82">
-                    <TimelineDateLink :date="candidate.createdAt">{{ new Date(candidate.createdAt).toLocaleDateString() }}</TimelineDateLink>
-                  </dd>
-                </div>
-                <div>
-                  <dt class="inline-flex items-center gap-1 text-white/38">
-                    <Clock class="size-3.5" />
-                    Updated
-                  </dt>
-                  <dd class="font-medium text-white/82">
-                    <TimelineDateLink :date="candidate.updatedAt">{{ new Date(candidate.updatedAt).toLocaleDateString() }}</TimelineDateLink>
-                  </dd>
-                </div>
-              </dl>
-            </div>
-
-            <!-- Properties -->
-            <div class="border border-white/12 bg-white/[0.025] p-4">
-              <h3 class="mb-2 px-2 text-sm font-semibold text-white">Properties</h3>
-              <PropertyBlock
-                entity-type="candidate"
-                :entity-id="candidateId"
-                :entries="(candidate.properties ?? []) as import('~~/shared/properties').PropertyEntry[]"
-                @refresh="refresh()"
-              />
-            </div>
+            <CandidateDetailsCard
+              :candidate="candidate"
+              :candidate-id="candidateId"
+              surface="drawer"
+              @refresh="refresh()"
+            />
 
             <!-- Tabs -->
             <div class="border-b border-white/10">
@@ -316,166 +194,28 @@ onUnmounted(() => {
             </div>
 
             <!-- Applications tab -->
-            <div v-if="activeTab === 'applications'">
-              <div class="flex justify-end mb-3">
-                <button
-                  class="factory-toolbar-button inline-flex h-10 min-h-10 cursor-pointer items-center gap-1.5 border px-3 py-0 text-xs font-medium transition-colors hover:border-brand-500 hover:bg-brand-500/12 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/50"
-                  @click="showApplyModal = true"
-                >
-                  <Plus class="size-3.5" />
-                  Apply to Job
-                </button>
-              </div>
-
-              <div
-                v-if="!candidate.applications?.length"
-                class="border border-white/12 bg-white/[0.025] p-8 text-center"
-              >
-                <Briefcase class="mx-auto mb-2 size-8 text-white/32" />
-                <p class="text-sm text-white/54">No applications yet.</p>
-              </div>
-
-              <div v-else class="space-y-2">
-                <div
-                  v-for="app in candidate.applications"
-                  :key="app.id"
-                  class="group flex flex-col gap-2 border border-white/12 bg-white/[0.025] px-4 py-3 transition-all hover:border-brand-500/70 hover:bg-brand-500/10 sm:flex-row sm:items-center sm:justify-between"
-                >
-                  <NuxtLink
-                    :to="localePath(`/dashboard/applications/${app.id}`)"
-                    class="min-w-0 flex-1 block"
-                  >
-                    <h4 class="truncate text-sm font-semibold text-white transition-colors group-hover:text-brand-400">
-                      {{ app.job.title }}
-                    </h4>
-                    <ApplicationTimestampStack
-                      :applied-at="app.createdAt"
-                      class="mt-1 items-start sm:items-start"
-                    />
-                  </NuxtLink>
-                  <div class="flex items-center gap-1.5 shrink-0 sm:ml-3">
-                    <button
-                      v-for="nextStatus in getApplicationTransitions(app.status)"
-                      :key="nextStatus"
-                      class="group/action relative inline-flex size-8 shrink-0 cursor-pointer items-center justify-center border text-white transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500/40 disabled:cursor-not-allowed disabled:opacity-50"
-                      :class="getApplicationTransitionButtonClass(nextStatus, 'factory')"
-                      :title="getApplicationTransitionActionLabel(nextStatus)"
-                      :aria-label="getApplicationTransitionActionLabel(nextStatus)"
-                      :disabled="transitioningApplicationIds.has(app.id)"
-                      @click.stop="handleApplicationTransition(app, nextStatus)"
-                    >
-                      <ApplicationTransitionIcon :status="nextStatus" class="size-3.5" />
-                      <span class="pointer-events-none absolute bottom-full left-1/2 z-20 mb-2 -translate-x-1/2 translate-y-1 whitespace-nowrap border border-white/12 bg-black px-2 py-1 text-[10px] font-semibold uppercase tracking-normal text-white opacity-0 shadow-xl shadow-black/40 transition-all duration-150 group-hover/action:translate-y-0 group-hover/action:opacity-100 group-focus-visible/action:translate-y-0 group-focus-visible/action:opacity-100">
-                        {{ getApplicationTransitionActionLabel(nextStatus) }}
-                      </span>
-                    </button>
-                    <button
-                      class="group/action relative inline-flex size-8 shrink-0 cursor-pointer items-center justify-center border border-white/16 bg-black text-white/80 transition-all duration-150 hover:border-brand-500 hover:bg-brand-500/12 hover:text-white focus:outline-none focus:ring-2 focus:ring-brand-500/40"
-                      title="Schedule Interview"
-                      aria-label="Schedule Interview"
-                      @click="openScheduleInterview(app)"
-                    >
-                      <Calendar class="size-3.5" />
-                      <span class="pointer-events-none absolute bottom-full left-1/2 z-20 mb-2 -translate-x-1/2 translate-y-1 whitespace-nowrap border border-white/12 bg-black px-2 py-1 text-[10px] font-semibold uppercase tracking-normal text-white opacity-0 shadow-xl shadow-black/40 transition-all duration-150 group-hover/action:translate-y-0 group-hover/action:opacity-100 group-focus-visible/action:translate-y-0 group-focus-visible/action:opacity-100">
-                        Schedule Interview
-                      </span>
-                    </button>
-                    <ApplicationStatusBadge :status="app.status" />
-                  </div>
-                </div>
-              </div>
-            </div>
+            <CandidateApplicationsPanel
+              v-if="activeTab === 'applications'"
+              :applications="candidate.applications ?? []"
+              surface="drawer"
+              show-status-transitions
+              :transitioning-application-ids="transitioningApplicationIds"
+              @apply="showApplyModal = true"
+              @schedule="openScheduleInterview"
+              @transition="handleApplicationTransition"
+            />
 
             <!-- Documents tab -->
-            <div v-if="activeTab === 'documents'">
-              <!-- Inline PDF preview -->
-              <template v-if="showPreview">
-                <div class="flex items-center justify-between mb-3">
-                  <button
-                    class="factory-toolbar-button inline-flex h-10 min-h-10 items-center gap-1.5 border px-3 py-0 text-xs font-medium transition-colors hover:bg-white hover:text-black"
-                    @click="closePreview"
-                  >
-                    ← Back to documents
-                  </button>
-                  <div class="flex items-center gap-1">
-                    <button
-                      v-if="previewDocId"
-                      class="factory-toolbar-button p-1.5 text-white/58 hover:text-white transition-colors"
-                      title="Download"
-                      @click="handleDownload(previewDocId!)"
-                    >
-                      <Download class="size-4" />
-                    </button>
-                  </div>
-                </div>
-
-                <div v-if="previewFilename" class="flex items-center gap-2 mb-3">
-                  <FileText class="size-4 shrink-0 text-white/42" />
-                  <span class="truncate text-sm font-medium text-white/78">
-                    {{ previewFilename }}
-                  </span>
-                </div>
-
-                <iframe
-                  v-if="previewUrl && isPdfPreview"
-                  :src="previewUrl"
-                  class="w-full border border-white/12"
-                  style="height: 60vh;"
-                  title="Document preview"
-                />
-              </template>
-
-              <!-- Document list -->
-              <template v-else>
-                <div
-                  v-if="!candidate.documents?.length"
-                  class="border border-white/12 bg-white/[0.025] p-8 text-center"
-                >
-                  <FileText class="mx-auto mb-2 size-8 text-white/32" />
-                  <p class="text-sm text-white/54">No documents yet.</p>
-                </div>
-
-                <div v-else class="space-y-2">
-                  <div
-                    v-for="doc in candidate.documents"
-                    :key="doc.id"
-                    class="group flex items-center justify-between border border-white/12 bg-white/[0.025] px-4 py-3 transition-colors"
-                    :class="doc.mimeType === 'application/pdf' ? 'cursor-pointer hover:border-brand-500/70 hover:bg-brand-500/10' : ''"
-                    @click="doc.mimeType === 'application/pdf' ? handlePreview(doc.id, doc.mimeType) : undefined"
-                  >
-                    <div class="flex items-center gap-3 min-w-0">
-                      <FileText class="size-4 shrink-0" :class="doc.mimeType === 'application/pdf' ? 'text-danger-400' : 'text-white/42'" />
-                      <div class="min-w-0">
-                        <p class="truncate text-sm font-medium text-white/82">
-                          {{ doc.originalFilename }}
-                        </p>
-                        <span class="text-xs text-white/42">
-                          {{ documentTypeLabels[doc.type] ?? doc.type }}
-                          · <TimelineDateLink :date="doc.createdAt">{{ new Date(doc.createdAt).toLocaleDateString() }}</TimelineDateLink>
-                        </span>
-                      </div>
-                    </div>
-                    <div class="flex items-center gap-1 shrink-0" @click.stop>
-                      <button
-                        v-if="doc.mimeType === 'application/pdf'"
-                        class="factory-toolbar-button inline-flex size-9 min-h-9 cursor-pointer items-center justify-center border p-0 text-white/58 transition-colors hover:text-white"
-                        title="Preview PDF"
-                        @click="handlePreview(doc.id, doc.mimeType)"
-                      >
-                        <Eye class="size-4" />
-                      </button>
-                      <button
-                        class="factory-toolbar-button inline-flex size-9 min-h-9 cursor-pointer items-center justify-center border p-0 text-white/58 transition-colors hover:text-white"
-                        title="Download"
-                        @click="handleDownload(doc.id)"
-                      >
-                        <Download class="size-4" />
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </template>
-            </div>
+            <CandidateDocumentsPanel
+              v-if="activeTab === 'documents'"
+              :documents="candidate.documents ?? []"
+              :preview="documentPreviewState"
+              surface="drawer"
+              preview-height="60vh"
+              @preview="documentPreview.handlePreview"
+              @download="documentPreview.handleDownload"
+              @close-preview="documentPreview.closePreview"
+            />
           </template>
         </div>
       </aside>

--- a/app/components/CandidateDetailsCard.vue
+++ b/app/components/CandidateDetailsCard.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+import { Calendar, Clock, Phone } from 'lucide-vue-next'
+import { formatPhoneNumber } from '~/utils/phone-format'
+
+const props = withDefaults(defineProps<{
+  candidate: any
+  candidateId: string
+  surface?: 'drawer' | 'page'
+}>(), {
+  surface: 'page',
+})
+
+const emit = defineEmits<{
+  refresh: []
+}>()
+
+const { formatCandidateName, formatDate } = useOrgSettings()
+
+const panelClass = computed(() =>
+  props.surface === 'drawer'
+    ? 'border border-white/12 bg-white/[0.025]'
+    : 'ui-panel ui-dashboard-panel',
+)
+const headingTag = computed(() => props.surface === 'drawer' ? 'h2' : 'h1')
+
+const genderLabels: Record<string, string> = {
+  male: 'Male',
+  female: 'Female',
+  other: 'Other',
+  prefer_not_to_say: 'Prefer not to say',
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div :class="[panelClass, 'p-5']">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div class="min-w-0">
+          <p class="mb-2 text-xs font-medium uppercase tracking-wide text-white/38">
+            Candidate profile
+          </p>
+          <component :is="headingTag" class="mb-1 truncate text-2xl font-bold text-white">
+            {{ formatCandidateName(candidate) }}
+          </component>
+          <div class="flex flex-col gap-1 text-sm text-white/58 sm:flex-row sm:items-center sm:gap-4">
+            <CopyEmailButton :email="candidate.email" class="text-white/68" />
+            <span v-if="candidate.phone" class="inline-flex items-center gap-1 text-white/58">
+              <Phone class="size-3.5" />
+              {{ formatPhoneNumber(candidate.phone) }}
+            </span>
+          </div>
+        </div>
+
+        <slot name="actions" />
+      </div>
+    </div>
+
+    <div :class="[panelClass, 'p-5']">
+      <h2 class="mb-3 text-sm font-semibold text-white">Details</h2>
+      <dl class="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+        <div>
+          <dt class="text-white/38">Email</dt>
+          <dd class="font-medium text-white/82">
+            <CopyEmailButton :email="candidate.email" :show-icon="false" class="text-white/82" />
+          </dd>
+        </div>
+        <div>
+          <dt class="text-white/38">Phone</dt>
+          <dd class="font-medium text-white/82">{{ formatPhoneNumber(candidate.phone) || '—' }}</dd>
+        </div>
+        <div v-if="candidate.gender">
+          <dt class="text-white/38">Gender</dt>
+          <dd class="font-medium text-white/82">
+            {{ genderLabels[candidate.gender] ?? candidate.gender }}
+          </dd>
+        </div>
+        <div v-if="candidate.dateOfBirth">
+          <dt class="text-white/38">Date of Birth</dt>
+          <dd class="font-medium text-white/82">
+            {{ formatDate(candidate.dateOfBirth) }}
+          </dd>
+        </div>
+        <div v-if="candidate.displayName">
+          <dt class="text-white/38">Display Name</dt>
+          <dd class="font-medium text-white/82">{{ candidate.displayName }}</dd>
+        </div>
+        <div>
+          <dt class="inline-flex items-center gap-1 text-white/38">
+            <Calendar class="size-3.5" />
+            Created
+          </dt>
+          <dd class="font-medium text-white/82">
+            <TimelineDateLink :date="candidate.createdAt">{{ new Date(candidate.createdAt).toLocaleDateString() }}</TimelineDateLink>
+          </dd>
+        </div>
+        <div>
+          <dt class="inline-flex items-center gap-1 text-white/38">
+            <Clock class="size-3.5" />
+            Updated
+          </dt>
+          <dd class="font-medium text-white/82">
+            <TimelineDateLink :date="candidate.updatedAt">{{ new Date(candidate.updatedAt).toLocaleDateString() }}</TimelineDateLink>
+          </dd>
+        </div>
+      </dl>
+    </div>
+
+    <div :class="[panelClass, 'p-4']">
+      <h2 class="mb-2 px-2 text-sm font-semibold text-white">Properties</h2>
+      <PropertyBlock
+        entity-type="candidate"
+        :entity-id="candidateId"
+        :entries="(candidate.properties ?? []) as import('~~/shared/properties').PropertyEntry[]"
+        @refresh="emit('refresh')"
+      />
+    </div>
+  </div>
+</template>

--- a/app/components/CandidateDocumentsPanel.vue
+++ b/app/components/CandidateDocumentsPanel.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import { AlertTriangle, ArrowLeft, Download, Eye, FileText, Trash2 } from 'lucide-vue-next'
+
+const props = withDefaults(defineProps<{
+  documents?: any[]
+  preview: {
+    showPreview: boolean
+    previewUrl: string | null
+    previewFilename: string
+    previewDocId: string | null
+    previewError?: string | null
+    isPdfPreview: boolean
+  }
+  surface?: 'drawer' | 'page'
+  allowDelete?: boolean
+  emptyDescription?: string
+  previewHeight?: string
+}>(), {
+  documents: () => [],
+  surface: 'page',
+  allowDelete: false,
+  emptyDescription: '',
+  previewHeight: '70vh',
+})
+
+const emit = defineEmits<{
+  preview: [docId: string, mimeType?: string | null]
+  download: [docId: string]
+  delete: [docId: string]
+  closePreview: []
+}>()
+
+const panelClass = computed(() =>
+  props.surface === 'drawer'
+    ? 'border border-white/12 bg-white/[0.025]'
+    : 'ui-panel ui-dashboard-panel',
+)
+
+const documentTypeLabels: Record<string, string> = {
+  resume: 'Resume',
+  cover_letter: 'Cover Letter',
+  other: 'Other',
+}
+
+function isPdfDocument(doc: { mimeType?: string | null }) {
+  return doc.mimeType === 'application/pdf'
+}
+
+function previewDocument(doc: { id: string, mimeType?: string | null }) {
+  if (isPdfDocument(doc)) {
+    emit('preview', doc.id, doc.mimeType)
+  }
+}
+</script>
+
+<template>
+  <div>
+    <template v-if="preview.showPreview">
+      <div class="mb-3 flex items-center justify-between">
+        <button
+          class="factory-toolbar-button inline-flex h-10 min-h-10 cursor-pointer items-center gap-1.5 border px-3 py-0 text-xs font-medium transition-colors hover:bg-white hover:text-black"
+          @click="emit('closePreview')"
+        >
+          <ArrowLeft class="size-3.5" />
+          Back to documents
+        </button>
+        <div class="flex items-center gap-1">
+          <button
+            v-if="preview.previewDocId"
+            class="factory-toolbar-button inline-flex size-10 min-h-10 cursor-pointer items-center justify-center border p-0 text-white/58 transition-colors hover:text-white"
+            title="Download"
+            @click="emit('download', preview.previewDocId)"
+          >
+            <Download class="size-4" />
+          </button>
+        </div>
+      </div>
+
+      <div v-if="preview.previewFilename" :class="[panelClass, 'mb-3 flex items-center gap-2 px-3 py-2']">
+        <FileText class="size-4 shrink-0 text-white/38" />
+        <span class="truncate text-sm font-medium text-white/78">
+          {{ preview.previewFilename }}
+        </span>
+      </div>
+
+      <div
+        v-if="preview.previewError"
+        class="border border-danger-500/45 bg-danger-500/10 p-6 text-center"
+      >
+        <AlertTriangle class="mx-auto mb-2 size-8 text-danger-300" />
+        <p class="text-sm text-danger-100">{{ preview.previewError }}</p>
+        <button
+          class="mt-3 cursor-pointer text-sm font-medium text-brand-400 transition-colors hover:text-white"
+          @click="emit('closePreview')"
+        >
+          Go back
+        </button>
+      </div>
+
+      <iframe
+        v-else-if="preview.previewUrl && preview.isPdfPreview"
+        :src="preview.previewUrl"
+        class="w-full border border-white/12"
+        :style="{ height: previewHeight }"
+        title="Document preview"
+      />
+    </template>
+
+    <template v-else>
+      <slot name="toolbar" />
+      <slot name="error" />
+
+      <div
+        v-if="!documents.length"
+        :class="[panelClass, 'p-8 text-center']"
+      >
+        <FileText class="mx-auto mb-2 size-8 text-white/32" />
+        <p class="text-sm text-white/54">No documents yet.</p>
+        <p v-if="emptyDescription" class="mt-1 text-xs text-white/38">
+          {{ emptyDescription }}
+        </p>
+      </div>
+
+      <div v-else class="space-y-2">
+        <div
+          v-for="doc in documents"
+          :key="doc.id"
+          :class="[panelClass, 'group flex items-center justify-between px-4 py-3 transition-colors', isPdfDocument(doc) ? 'cursor-pointer hover:border-brand-500/70 hover:bg-brand-500/10' : '']"
+          :role="isPdfDocument(doc) ? 'button' : undefined"
+          :tabindex="isPdfDocument(doc) ? 0 : undefined"
+          @click="previewDocument(doc)"
+          @keydown.enter.prevent="previewDocument(doc)"
+          @keydown.space.prevent="previewDocument(doc)"
+        >
+          <div class="flex min-w-0 items-center gap-3">
+            <FileText class="size-4 shrink-0" :class="isPdfDocument(doc) ? 'text-danger-300' : 'text-white/38'" />
+            <div class="min-w-0">
+              <p class="truncate text-sm font-medium text-white/82">
+                {{ doc.originalFilename }}
+              </p>
+              <span class="text-xs text-white/42">
+                {{ documentTypeLabels[doc.type] ?? doc.type }}
+                · <TimelineDateLink :date="doc.createdAt">{{ new Date(doc.createdAt).toLocaleDateString() }}</TimelineDateLink>
+              </span>
+            </div>
+          </div>
+          <div class="flex shrink-0 items-center gap-1" @click.stop>
+            <button
+              v-if="isPdfDocument(doc)"
+              class="factory-toolbar-button inline-flex size-9 min-h-9 cursor-pointer items-center justify-center border p-0 text-white/58 transition-colors hover:text-white"
+              title="Preview PDF"
+              @click="previewDocument(doc)"
+            >
+              <Eye class="size-4" />
+            </button>
+            <button
+              class="factory-toolbar-button inline-flex size-9 min-h-9 cursor-pointer items-center justify-center border p-0 text-white/58 transition-colors hover:text-white"
+              title="Download"
+              @click="emit('download', doc.id)"
+            >
+              <Download class="size-4" />
+            </button>
+            <button
+              v-if="allowDelete"
+              class="factory-toolbar-button inline-flex size-9 min-h-9 cursor-pointer items-center justify-center border p-0 text-danger-200 transition-colors hover:border-danger-400 hover:bg-danger-500/12 hover:text-white"
+              title="Delete"
+              @click="emit('delete', doc.id)"
+            >
+              <Trash2 class="size-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/app/composables/useDocumentPreview.ts
+++ b/app/composables/useDocumentPreview.ts
@@ -1,0 +1,69 @@
+type PreviewableDocument = {
+  id: string
+  originalFilename?: string | null
+  mimeType?: string | null
+}
+
+export function useDocumentPreview(options: {
+  documents: () => PreviewableDocument[] | undefined
+  getPreviewUrl: (docId: string) => string
+  downloadDocument: (docId: string) => Promise<void>
+  onDownloadError?: () => void
+}) {
+  const showPreview = ref(false)
+  const previewUrl = ref<string | null>(null)
+  const previewFilename = ref('')
+  const previewMimeType = ref('')
+  const previewDocId = ref<string | null>(null)
+  const previewError = ref<string | null>(null)
+
+  const isPdfPreview = computed(() => previewMimeType.value === 'application/pdf')
+
+  async function handleDownload(docId: string) {
+    try {
+      await options.downloadDocument(docId)
+    } catch {
+      options.onDownloadError?.()
+    }
+  }
+
+  async function handlePreview(docId: string, mimeType?: string | null) {
+    const doc = options.documents()?.find((item) => item.id === docId)
+    const resolvedMimeType = mimeType ?? doc?.mimeType
+
+    if (resolvedMimeType !== 'application/pdf') {
+      await handleDownload(docId)
+      return
+    }
+
+    previewError.value = null
+    showPreview.value = true
+    previewDocId.value = docId
+
+    previewFilename.value = doc?.originalFilename ?? 'Document'
+    previewMimeType.value = resolvedMimeType
+    previewUrl.value = options.getPreviewUrl(docId)
+  }
+
+  function closePreview() {
+    showPreview.value = false
+    previewUrl.value = null
+    previewFilename.value = ''
+    previewMimeType.value = ''
+    previewDocId.value = null
+    previewError.value = null
+  }
+
+  return {
+    showPreview,
+    previewUrl,
+    previewFilename,
+    previewMimeType,
+    previewDocId,
+    previewError,
+    isPdfPreview,
+    handlePreview,
+    handleDownload,
+    closePreview,
+  }
+}

--- a/app/pages/dashboard/candidates/[id].vue
+++ b/app/pages/dashboard/candidates/[id].vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { ArrowLeft, Pencil, Trash2, Phone, Calendar, Clock, Briefcase, FileText, Plus, Upload, Download, Eye, AlertTriangle } from 'lucide-vue-next'
+import { Pencil, Trash2, Upload } from 'lucide-vue-next'
 import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
-import { formatPhoneNumber } from '~/utils/phone-format'
 import {
   candidateEditFormSchema,
   normalizeEmptyCandidateFormFields,
@@ -18,7 +17,7 @@ const { handlePreviewReadOnlyError } = usePreviewReadOnly()
 const toast = useToast()
 
 const { candidate, status: fetchStatus, error, refresh, updateCandidate, deleteCandidate } = useCandidate(candidateId)
-const { formatCandidateName, formatDate } = useOrgSettings()
+const { formatCandidateName } = useOrgSettings()
 
 useSeoMeta({
   title: computed(() =>
@@ -128,23 +127,6 @@ async function handleDelete() {
 }
 
 // ─────────────────────────────────────────────
-// Display helpers
-// ─────────────────────────────────────────────
-
-const genderLabels: Record<string, string> = {
-  male: 'Male',
-  female: 'Female',
-  other: 'Other',
-  prefer_not_to_say: 'Prefer not to say',
-}
-
-const documentTypeLabels: Record<string, string> = {
-  resume: 'Resume',
-  cover_letter: 'Cover Letter',
-  other: 'Other',
-}
-
-// ─────────────────────────────────────────────
 // Apply to job modal
 // ─────────────────────────────────────────────
 
@@ -179,47 +161,20 @@ const isUploading = ref(false)
 const uploadError = ref<string | null>(null)
 const showDocDeleteConfirm = ref<string | null>(null)
 const isDeletingDoc = ref(false)
-
-// Preview state
-const showPreview = ref(false)
-const previewUrl = ref<string | null>(null)
-const previewFilename = ref('')
-const previewMimeType = ref('')
-const previewDocId = ref<string | null>(null)
-const isLoadingPreview = ref(false)
-const previewError = ref<string | null>(null)
-
-/** Whether the current preview file is a PDF (renderable in iframe) */
-const isPdfPreview = computed(() => previewMimeType.value === 'application/pdf')
-
-async function handlePreview(docId: string, mimeType?: string) {
-  // Only PDFs can be previewed inline — for DOC/DOCX, download directly
-  if (mimeType && mimeType !== 'application/pdf') {
-    await handleDownload(docId)
-    return
-  }
-
-  previewError.value = null
-  showPreview.value = true
-  previewDocId.value = docId
-
-  // Find the document name from the candidate data
-  const doc = candidate.value?.documents?.find((d: any) => d.id === docId)
-  previewFilename.value = doc?.originalFilename ?? 'Document'
-  previewMimeType.value = doc?.mimeType ?? 'application/pdf'
-
-  // Use the API endpoint URL directly — server streams the PDF (same-origin)
-  previewUrl.value = getPreviewUrl(docId)
-}
-
-function closePreview() {
-  showPreview.value = false
-  previewUrl.value = null
-  previewFilename.value = ''
-  previewMimeType.value = ''
-  previewDocId.value = null
-  previewError.value = null
-}
+const documentPreview = useDocumentPreview({
+  documents: () => candidate.value?.documents,
+  getPreviewUrl,
+  downloadDocument,
+  onDownloadError: () => toast.error('Failed to download document'),
+})
+const documentPreviewState = computed(() => ({
+  showPreview: documentPreview.showPreview.value,
+  previewUrl: documentPreview.previewUrl.value,
+  previewFilename: documentPreview.previewFilename.value,
+  previewDocId: documentPreview.previewDocId.value,
+  previewError: documentPreview.previewError.value,
+  isPdfPreview: documentPreview.isPdfPreview.value,
+}))
 
 function triggerFileSelect() {
   fileInput.value?.click()
@@ -242,14 +197,6 @@ async function handleFileSelected(event: Event) {
     isUploading.value = false
     // Reset input so the same file can be re-selected
     input.value = ''
-  }
-}
-
-async function handleDownload(docId: string) {
-  try {
-    await downloadDocument(docId)
-  } catch {
-    toast.error('Failed to download document')
   }
 }
 
@@ -296,25 +243,14 @@ async function handleDeleteDoc(docId: string) {
     <template v-else-if="candidate">
       <!-- VIEW MODE -->
       <div v-if="!isEditing">
-        <!-- Header -->
-        <div class="mb-4 ui-panel ui-dashboard-panel p-5">
-          <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-            <div class="min-w-0">
-              <p class="mb-2 text-xs font-medium uppercase tracking-wide text-white/38">
-                Candidate profile
-              </p>
-              <h1 class="mb-1 truncate text-2xl font-bold text-white">
-                {{ formatCandidateName(candidate) }}
-              </h1>
-              <div class="flex flex-col gap-1 text-sm text-white/58 sm:flex-row sm:items-center sm:gap-4">
-                <CopyEmailButton :email="candidate.email" class="text-white/68" />
-                <span v-if="candidate.phone" class="inline-flex items-center gap-1 text-white/58">
-                  <Phone class="size-3.5" />
-                  {{ formatPhoneNumber(candidate.phone) }}
-                </span>
-              </div>
-            </div>
-
+        <CandidateDetailsCard
+          class="mb-4"
+          :candidate="candidate"
+          :candidate-id="candidateId"
+          surface="page"
+          @refresh="refresh()"
+        >
+          <template #actions>
             <div class="flex shrink-0 items-center gap-2">
               <button
                 class="factory-toolbar-button inline-flex h-10 min-h-10 cursor-pointer items-center gap-1.5 border px-3 py-0 text-xs font-medium transition-colors"
@@ -331,74 +267,8 @@ async function handleDeleteDoc(docId: string) {
                 Delete
               </button>
             </div>
-          </div>
-        </div>
-
-        <!-- Contact details -->
-        <div class="mb-4 ui-panel ui-dashboard-panel p-5">
-          <h2 class="mb-3 text-sm font-semibold text-white">Details</h2>
-          <dl class="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
-            <div>
-              <dt class="text-white/38">Email</dt>
-              <dd class="font-medium text-white/82">
-                <CopyEmailButton :email="candidate.email" :show-icon="false" class="text-white/82" />
-              </dd>
-            </div>
-            <div>
-              <dt class="text-white/38">Phone</dt>
-              <dd class="font-medium text-white/82">
-                {{ formatPhoneNumber(candidate.phone) || '—' }}
-              </dd>
-            </div>
-            <div v-if="candidate.gender">
-              <dt class="text-white/38">Gender</dt>
-              <dd class="font-medium text-white/82">
-                {{ genderLabels[candidate.gender] ?? candidate.gender }}
-              </dd>
-            </div>
-            <div v-if="candidate.dateOfBirth">
-              <dt class="text-white/38">Date of Birth</dt>
-              <dd class="font-medium text-white/82">
-                {{ formatDate(candidate.dateOfBirth) }}
-              </dd>
-            </div>
-            <div v-if="candidate.displayName">
-              <dt class="text-white/38">Display Name</dt>
-              <dd class="font-medium text-white/82">
-                {{ candidate.displayName }}
-              </dd>
-            </div>
-            <div>
-              <dt class="inline-flex items-center gap-1 text-white/38">
-                <Calendar class="size-3.5" />
-                Created
-              </dt>
-              <dd class="font-medium text-white/82">
-                <TimelineDateLink :date="candidate.createdAt">{{ new Date(candidate.createdAt).toLocaleDateString() }}</TimelineDateLink>
-              </dd>
-            </div>
-            <div>
-              <dt class="inline-flex items-center gap-1 text-white/38">
-                <Clock class="size-3.5" />
-                Updated
-              </dt>
-              <dd class="font-medium text-white/82">
-                <TimelineDateLink :date="candidate.updatedAt">{{ new Date(candidate.updatedAt).toLocaleDateString() }}</TimelineDateLink>
-              </dd>
-            </div>
-          </dl>
-        </div>
-
-        <!-- Custom properties (Notion-style) -->
-        <div class="mb-4 ui-panel ui-dashboard-panel p-4">
-          <h2 class="mb-2 px-2 text-sm font-semibold text-white">Properties</h2>
-          <PropertyBlock
-            entity-type="candidate"
-            :entity-id="candidateId"
-            :entries="(candidate.properties ?? []) as import('~~/shared/properties').PropertyEntry[]"
-            @refresh="refresh()"
-          />
-        </div>
+          </template>
+        </CandidateDetailsCard>
 
         <!-- Tabs -->
         <div class="mb-4 border-b border-white/10">
@@ -424,59 +294,13 @@ async function handleDeleteDoc(docId: string) {
           </div>
         </div>
 
-        <!-- Applications tab -->
-        <div v-if="activeTab === 'applications'">
-          <!-- Apply to Job button -->
-          <div class="mb-3 flex justify-end">
-            <button
-              class="factory-toolbar-button inline-flex h-10 min-h-10 cursor-pointer items-center gap-1.5 border px-3 py-0 text-xs font-medium transition-colors"
-              @click="showApplyModal = true"
-            >
-              <Plus class="size-3.5" />
-              Apply to Job
-            </button>
-          </div>
-
-          <div
-            v-if="!candidate.applications?.length"
-            class="ui-panel ui-dashboard-panel p-8 text-center"
-          >
-            <Briefcase class="mx-auto mb-2 size-8 text-white/32" />
-            <p class="text-sm text-white/54">No applications yet.</p>
-          </div>
-
-          <div v-else class="space-y-2">
-            <div
-              v-for="app in candidate.applications"
-              :key="app.id"
-              class="group flex flex-col gap-2 ui-panel ui-dashboard-panel px-4 py-3 transition-all hover:border-brand-500/70 hover:bg-brand-500/10 sm:flex-row sm:items-center sm:justify-between"
-            >
-              <NuxtLink
-                :to="$localePath(`/dashboard/applications/${app.id}`)"
-                class="block min-w-0 flex-1"
-              >
-                <h4 class="truncate text-sm font-semibold text-white transition-colors group-hover:text-brand-400">
-                  {{ app.job.title }}
-                </h4>
-                <ApplicationTimestampStack
-                  :applied-at="app.createdAt"
-                  class="mt-1 items-start sm:items-start"
-                />
-              </NuxtLink>
-              <div class="flex shrink-0 items-center gap-2 sm:ml-3">
-                <button
-                  class="factory-toolbar-button inline-flex h-8 min-h-8 cursor-pointer items-center gap-1 border px-2.5 py-0 text-[10px] font-medium transition-colors"
-                  title="Schedule Interview"
-                  @click="openScheduleInterview(app)"
-                >
-                  <Calendar class="size-3" />
-                  Schedule
-                </button>
-                <ApplicationStatusBadge :status="app.status" />
-              </div>
-            </div>
-          </div>
-        </div>
+        <CandidateApplicationsPanel
+          v-if="activeTab === 'applications'"
+          :applications="candidate.applications ?? []"
+          surface="page"
+          @apply="showApplyModal = true"
+          @schedule="openScheduleInterview"
+        />
 
         <!-- Apply to Job Modal -->
         <ApplyToJobModal
@@ -498,7 +322,6 @@ async function handleDeleteDoc(docId: string) {
 
         <!-- Documents tab -->
         <div v-if="activeTab === 'documents'">
-          <!-- Hidden file input -->
           <input
             ref="fileInput"
             type="file"
@@ -507,155 +330,50 @@ async function handleDeleteDoc(docId: string) {
             @change="handleFileSelected"
           />
 
-          <!-- ── Inline PDF preview (replaces document list when active) ── -->
-          <template v-if="showPreview">
-            <!-- Preview toolbar -->
-            <div class="mb-3 flex items-center justify-between">
-              <button
-                class="factory-toolbar-button inline-flex h-10 min-h-10 cursor-pointer items-center gap-1.5 border px-3 py-0 text-xs font-medium transition-colors"
-                @click="closePreview"
-              >
-                <ArrowLeft class="size-3.5" />
-                Back to documents
-              </button>
-              <div class="flex items-center gap-1">
+          <CandidateDocumentsPanel
+            :documents="candidate.documents ?? []"
+            :preview="documentPreviewState"
+            surface="page"
+            allow-delete
+            empty-description="Upload a resume, cover letter, or other document (PDF, DOC, DOCX — max 10 MB)."
+            @preview="documentPreview.handlePreview"
+            @download="documentPreview.handleDownload"
+            @delete="showDocDeleteConfirm = $event"
+            @close-preview="documentPreview.closePreview"
+          >
+            <template #toolbar>
+              <div class="mb-3 flex items-center justify-between">
+                <div class="flex items-center gap-2">
+                  <FactorySelect
+                    v-model="selectedDocType"
+                    :options="[
+                      { value: 'resume', label: 'Resume' },
+                      { value: 'cover_letter', label: 'Cover Letter' },
+                      { value: 'other', label: 'Other' },
+                    ]"
+                  />
+                </div>
                 <button
-                  v-if="previewDocId"
-                  class="factory-toolbar-button inline-flex size-10 min-h-10 cursor-pointer items-center justify-center border p-0 text-white/58 transition-colors hover:text-white"
-                  title="Download"
-                  @click="handleDownload(previewDocId!)"
+                  :disabled="isUploading"
+                  class="factory-toolbar-button inline-flex h-10 min-h-10 cursor-pointer items-center gap-1.5 border px-3 py-0 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                  @click="triggerFileSelect"
                 >
-                  <Download class="size-4" />
+                  <Upload class="size-3.5" />
+                  {{ isUploading ? 'Uploading…' : 'Upload Document' }}
                 </button>
               </div>
-            </div>
+            </template>
 
-            <!-- Filename -->
-            <div v-if="previewFilename" class="mb-3 flex items-center gap-2 ui-panel ui-dashboard-panel px-3 py-2">
-              <FileText class="size-4 shrink-0 text-white/38" />
-              <span class="truncate text-sm font-medium text-white/78">
-                {{ previewFilename }}
-              </span>
-            </div>
-
-            <!-- Error state -->
-            <div
-              v-if="previewError"
-              class="border border-danger-500/45 bg-danger-500/10 p-6 text-center"
-            >
-              <AlertTriangle class="mx-auto mb-2 size-8 text-danger-300" />
-              <p class="text-sm text-danger-100">{{ previewError }}</p>
-              <button
-                class="mt-3 cursor-pointer text-sm font-medium text-brand-400 transition-colors hover:text-white"
-                @click="closePreview"
-              >
-                Go back
-              </button>
-            </div>
-
-            <!-- PDF iframe — same-origin, server streams the bytes -->
-            <iframe
-              v-else-if="previewUrl && isPdfPreview"
-              :src="previewUrl"
-              class="w-full border border-white/12"
-              style="height: 70vh;"
-              title="Document preview"
-            />
-          </template>
-
-          <!-- ── Document list (normal state) ── -->
-          <template v-else>
-            <!-- Upload controls -->
-            <div class="mb-3 flex items-center justify-between">
-              <div class="flex items-center gap-2">
-                <FactorySelect
-                  v-model="selectedDocType"
-                  :options="[
-                    { value: 'resume', label: 'Resume' },
-                    { value: 'cover_letter', label: 'Cover Letter' },
-                    { value: 'other', label: 'Other' },
-                  ]"
-                />
-              </div>
-              <button
-                :disabled="isUploading"
-                class="factory-toolbar-button inline-flex h-10 min-h-10 cursor-pointer items-center gap-1.5 border px-3 py-0 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                @click="triggerFileSelect"
-              >
-                <Upload class="size-3.5" />
-                {{ isUploading ? 'Uploading…' : 'Upload Document' }}
-              </button>
-            </div>
-
-            <!-- Upload error -->
-            <div
-              v-if="uploadError"
-              class="mb-3 border border-danger-500/45 bg-danger-500/10 p-3 text-sm text-danger-100"
-            >
-              {{ uploadError }}
-              <button class="ml-1 cursor-pointer underline transition-colors hover:text-white" @click="uploadError = null">Dismiss</button>
-            </div>
-
-            <!-- Empty state -->
-            <div
-              v-if="!candidate.documents?.length"
-              class="ui-panel ui-dashboard-panel p-8 text-center"
-            >
-              <FileText class="mx-auto mb-2 size-8 text-white/32" />
-              <p class="text-sm text-white/54">No documents yet.</p>
-              <p class="mt-1 text-xs text-white/38">
-                Upload a resume, cover letter, or other document (PDF, DOC, DOCX — max 10 MB).
-              </p>
-            </div>
-
-            <!-- Document list -->
-            <div v-else class="space-y-2">
+            <template #error>
               <div
-                v-for="doc in candidate.documents"
-                :key="doc.id"
-                class="group flex items-center justify-between ui-panel ui-dashboard-panel px-4 py-3 transition-colors"
-                :class="doc.mimeType === 'application/pdf' ? 'cursor-pointer hover:border-brand-500/70 hover:bg-brand-500/10' : ''"
-                @click="doc.mimeType === 'application/pdf' ? handlePreview(doc.id, doc.mimeType) : undefined"
+                v-if="uploadError"
+                class="mb-3 border border-danger-500/45 bg-danger-500/10 p-3 text-sm text-danger-100"
               >
-                <div class="flex min-w-0 items-center gap-3">
-                  <FileText class="size-4 shrink-0" :class="doc.mimeType === 'application/pdf' ? 'text-danger-300' : 'text-white/38'" />
-                  <div class="min-w-0">
-                    <p class="truncate text-sm font-medium text-white/82">
-                      {{ doc.originalFilename }}
-                    </p>
-                    <span class="text-xs text-white/42">
-                      {{ documentTypeLabels[doc.type] ?? doc.type }}
-                      · <TimelineDateLink :date="doc.createdAt">{{ new Date(doc.createdAt).toLocaleDateString() }}</TimelineDateLink>
-                    </span>
-                  </div>
-                </div>
-                <div class="flex shrink-0 items-center gap-1" @click.stop>
-                  <button
-                    v-if="doc.mimeType === 'application/pdf'"
-                    class="factory-toolbar-button inline-flex size-9 min-h-9 cursor-pointer items-center justify-center border p-0 text-white/58 transition-colors hover:text-white"
-                    title="Preview PDF"
-                    @click="handlePreview(doc.id, doc.mimeType)"
-                  >
-                    <Eye class="size-4" />
-                  </button>
-                  <button
-                    class="factory-toolbar-button inline-flex size-9 min-h-9 cursor-pointer items-center justify-center border p-0 text-white/58 transition-colors hover:text-white"
-                    title="Download"
-                    @click="handleDownload(doc.id)"
-                  >
-                    <Download class="size-4" />
-                  </button>
-                  <button
-                    class="factory-toolbar-button inline-flex size-9 min-h-9 cursor-pointer items-center justify-center border p-0 text-danger-200 transition-colors hover:border-danger-400 hover:bg-danger-500/12 hover:text-white"
-                    title="Delete"
-                    @click="showDocDeleteConfirm = doc.id"
-                  >
-                    <Trash2 class="size-4" />
-                  </button>
-                </div>
+                {{ uploadError }}
+                <button class="ml-1 cursor-pointer underline transition-colors hover:text-white" @click="uploadError = null">Dismiss</button>
               </div>
-            </div>
-          </template>
+            </template>
+          </CandidateDocumentsPanel>
 
           <!-- Document delete confirmation dialog -->
           <Teleport to="body">

--- a/tests/unit/applicant-email-copy.test.ts
+++ b/tests/unit/applicant-email-copy.test.ts
@@ -19,8 +19,7 @@ describe('applicant email copy behavior', () => {
   it('does not use mailto links for applicant or candidate email displays', () => {
     const applicantEmailFiles = [
       'app/pages/dashboard/candidates/index.vue',
-      'app/pages/dashboard/candidates/[id].vue',
-      'app/components/CandidateDetailDrawer.vue',
+      'app/components/CandidateDetailsCard.vue',
       'app/components/CandidateDetailSidebar.vue',
       'app/components/ApplicationDetailDrawer.vue',
       'app/pages/dashboard/applications/index.vue',
@@ -37,6 +36,16 @@ describe('applicant email copy behavior', () => {
       const source = readProjectFile(path)
 
       expect(source, `${path} should use the shared copy email control`).toContain('CopyEmailButton')
+      expect(source, `${path} should not use mailto links for applicants`).not.toContain('mailto:')
+    }
+
+    for (const path of [
+      'app/pages/dashboard/candidates/[id].vue',
+      'app/components/CandidateDetailDrawer.vue',
+    ]) {
+      const source = readProjectFile(path)
+
+      expect(source, `${path} should use the shared candidate details card`).toContain('CandidateDetailsCard')
       expect(source, `${path} should not use mailto links for applicants`).not.toContain('mailto:')
     }
   })

--- a/tests/unit/application-timestamp-stack.test.ts
+++ b/tests/unit/application-timestamp-stack.test.ts
@@ -33,10 +33,13 @@ describe('application timestamp stack', () => {
     const candidateSidebar = readProjectFile('app/components/CandidateDetailSidebar.vue')
     const candidateDrawer = readProjectFile('app/components/CandidateDetailDrawer.vue')
     const candidatePage = readProjectFile('app/pages/dashboard/candidates/[id].vue')
+    const candidateApplicationsPanel = readProjectFile('app/components/CandidateApplicationsPanel.vue')
 
-    for (const source of [drawer, fullPage, jobPage, candidateSidebar, candidateDrawer, candidatePage]) {
+    for (const source of [drawer, fullPage, jobPage, candidateSidebar, candidateApplicationsPanel]) {
       expect(source).toContain('ApplicationTimestampStack')
     }
+    expect(candidateDrawer).toContain('<CandidateApplicationsPanel')
+    expect(candidatePage).toContain('<CandidateApplicationsPanel')
     expect(drawer).not.toContain('uppercase text-white/36">Applied')
     expect(fullPage).not.toContain('uppercase text-white/36">Applied')
     expect(jobPage).not.toContain('Applied {{ new Date(currentSummary.createdAt).toLocaleDateString() }}')

--- a/tests/unit/back-buttons.test.ts
+++ b/tests/unit/back-buttons.test.ts
@@ -59,10 +59,10 @@ describe('back button hover treatment', () => {
   })
 
   it('uses white-fill hover for inline document preview back buttons', () => {
-    const drawer = readSource('app/components/CandidateDetailDrawer.vue')
+    const documentsPanel = readSource('app/components/CandidateDocumentsPanel.vue')
     const sidebar = readSource('app/components/CandidateDetailSidebar.vue')
 
-    for (const source of [drawer, sidebar]) {
+    for (const source of [documentsPanel, sidebar]) {
       const backButton = elementContaining(source, 'button', 'Back to documents')
       expect(backButton).toContain(expectedHover)
       expect(backButton).not.toContain('ui-inline-link-brand')

--- a/tests/unit/candidate-detail-drawer.test.ts
+++ b/tests/unit/candidate-detail-drawer.test.ts
@@ -8,16 +8,19 @@ function readProjectFile(path: string) {
 
 describe('candidate detail drawer', () => {
   it('puts compact icon-only application quick actions beside the status badge', () => {
-    const source = readProjectFile('app/components/CandidateDetailDrawer.vue')
+    const source = readProjectFile('app/components/CandidateApplicationsPanel.vue')
+    const drawer = readProjectFile('app/components/CandidateDetailDrawer.vue')
     const badge = readProjectFile('app/components/ApplicationStatusBadge.vue')
 
+    expect(drawer).toContain('<CandidateApplicationsPanel')
+    expect(drawer).toContain('show-status-transitions')
+    expect(drawer).toContain('const transitioningApplicationIds = ref<Set<string>>(new Set())')
+    expect(drawer).toContain('if (transitioningApplicationIds.value.has(app.id)) return')
     expect(source).toContain('APPLICATION_STATUS_TRANSITIONS')
     expect(source).toContain('getApplicationTransitionButtonClass(nextStatus, \'factory\')')
     expect(source).toContain('getApplicationTransitionActionLabel(nextStatus)')
     expect(source).toContain('<ApplicationTransitionIcon :status="nextStatus" class="size-3.5" />')
     expect(source).toContain('class="group/action relative inline-flex size-8')
-    expect(source).toContain('const transitioningApplicationIds = ref<Set<string>>(new Set())')
-    expect(source).toContain('if (transitioningApplicationIds.value.has(app.id)) return')
     expect(source).toContain(':disabled="transitioningApplicationIds.has(app.id)"')
     expect(source).toContain('aria-label="Schedule Interview"')
     expect(source).not.toContain('Schedule\n                    </button>')
@@ -25,9 +28,18 @@ describe('candidate detail drawer', () => {
     expect(badge).toContain('inline-flex h-8 min-h-8 shrink-0 items-center border')
   })
 
+  it('keeps application row schedule actions and status badges the same height when expanded labels are shown', () => {
+    const source = readProjectFile('app/components/CandidateApplicationsPanel.vue')
+    const badge = readProjectFile('app/components/ApplicationStatusBadge.vue')
+
+    expect(source).toContain('factory-toolbar-button h-8 min-h-8 gap-1 px-2.5 py-0 text-[10px] font-medium')
+    expect(source).toContain('<ApplicationStatusBadge :status="app.status" />')
+    expect(badge).toContain('inline-flex h-8 min-h-8 shrink-0 items-center border')
+  })
+
   it('keeps the apply-to-job button visibly interactive', () => {
-    const source = readProjectFile('app/components/CandidateDetailDrawer.vue')
-    const applyButton = source.match(/<button[\s\S]*?@click="showApplyModal = true"[\s\S]*?>/)?.[0] ?? ''
+    const source = readProjectFile('app/components/CandidateApplicationsPanel.vue')
+    const applyButton = source.match(/<button[\s\S]*?@click="emit\('apply'\)"[\s\S]*?>/)?.[0] ?? ''
 
     expect(applyButton).toContain('cursor-pointer')
     expect(applyButton).toContain('hover:border-brand-500')
@@ -36,23 +48,19 @@ describe('candidate detail drawer', () => {
   })
 
   it('does not spell out obvious PDF preview affordances in document rows', () => {
-    const drawer = readProjectFile('app/components/CandidateDetailDrawer.vue')
-    const fullPage = readProjectFile('app/pages/dashboard/candidates/[id].vue')
+    const source = readProjectFile('app/components/CandidateDocumentsPanel.vue')
 
-    expect(drawer).not.toContain('Click to preview')
-    expect(fullPage).not.toContain('Click to preview')
-    expect(drawer).toContain('title="Preview PDF"')
-    expect(fullPage).toContain('title="Preview PDF"')
+    expect(source).not.toContain('Click to preview')
+    expect(source).toContain('title="Preview PDF"')
   })
 
   it('uses square icon buttons for document preview and download actions', () => {
-    const drawer = readProjectFile('app/components/CandidateDetailDrawer.vue')
-    const documentActions = drawer.match(/<div class="flex items-center gap-1 shrink-0" @click\.stop>[\s\S]*?<\/div>/)?.[0] ?? ''
+    const source = readProjectFile('app/components/CandidateDocumentsPanel.vue')
 
-    expect(documentActions).toContain('title="Preview PDF"')
-    expect(documentActions).toContain('title="Download"')
-    expect(documentActions.match(/inline-flex size-9 min-h-9 cursor-pointer items-center justify-center border p-0/g)?.length).toBeGreaterThanOrEqual(2)
-    expect(documentActions).not.toContain('p-1.5 text-white/58')
+    expect(source).toContain('title="Preview PDF"')
+    expect(source).toContain('title="Download"')
+    expect(source.match(/inline-flex size-9 min-h-9 cursor-pointer items-center justify-center border p-0/g)?.length).toBeGreaterThanOrEqual(2)
+    expect(source).not.toContain('p-1.5 text-white/58')
   })
 
   it('keeps the apply-to-job modal above drawer overlays', () => {

--- a/tests/unit/candidate-detail-shared-panels.test.ts
+++ b/tests/unit/candidate-detail-shared-panels.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('candidate detail shared panels', () => {
+  it('renders shared candidate detail panels from drawer and full-page shells', () => {
+    const drawer = readProjectFile('app/components/CandidateDetailDrawer.vue')
+    const page = readProjectFile('app/pages/dashboard/candidates/[id].vue')
+
+    for (const source of [drawer, page]) {
+      expect(source).toContain('<CandidateDetailsCard')
+      expect(source).toContain('<CandidateApplicationsPanel')
+      expect(source).toContain('<CandidateDocumentsPanel')
+      expect(source).toContain('useDocumentPreview')
+    }
+
+    for (const path of [
+      'app/components/CandidateDetailDrawer.vue',
+      'app/pages/dashboard/candidates/[id].vue',
+    ]) {
+      const source = readProjectFile(path)
+      expect(source, `${path} should not define local document type labels`).not.toContain('const documentTypeLabels')
+      expect(source, `${path} should not hand-roll preview refs`).not.toContain('const previewUrl = ref')
+      expect(source, `${path} should not render application status badges inline`).not.toContain('<ApplicationStatusBadge :status="app.status" />')
+    }
+  })
+
+  it('keeps document labels and application badges in shared candidate panels', () => {
+    const documentsPanel = readProjectFile('app/components/CandidateDocumentsPanel.vue')
+    const applicationsPanel = readProjectFile('app/components/CandidateApplicationsPanel.vue')
+    const detailsCard = readProjectFile('app/components/CandidateDetailsCard.vue')
+
+    expect(documentsPanel).toContain('documentTypeLabels')
+    expect(documentsPanel).toContain('Back to documents')
+    expect(applicationsPanel).toContain('<ApplicationStatusBadge :status="app.status" />')
+    expect(applicationsPanel).toContain('ApplicationTimestampStack')
+    expect(detailsCard).toContain('<PropertyBlock')
+  })
+
+  it('keeps drawer headings and document row previews accessible', () => {
+    const detailsCard = readProjectFile('app/components/CandidateDetailsCard.vue')
+    const documentsPanel = readProjectFile('app/components/CandidateDocumentsPanel.vue')
+
+    expect(detailsCard).toContain("props.surface === 'drawer' ? 'h2' : 'h1'")
+    expect(detailsCard).toContain('<component')
+    expect(detailsCard).toContain(':is="headingTag"')
+
+    expect(documentsPanel).toContain(':role="isPdfDocument(doc) ? \'button\' : undefined"')
+    expect(documentsPanel).toContain(':tabindex="isPdfDocument(doc) ? 0 : undefined"')
+    expect(documentsPanel).toContain('@keydown.enter.prevent="previewDocument(doc)"')
+    expect(documentsPanel).toContain('@keydown.space.prevent="previewDocument(doc)"')
+  })
+
+  it('downloads non-pdf documents when preview callers omit the mime type', () => {
+    const composable = readProjectFile('app/composables/useDocumentPreview.ts')
+
+    expect(composable).toContain('const doc = options.documents()?.find((item) => item.id === docId)')
+    expect(composable).toContain('const resolvedMimeType = mimeType ?? doc?.mimeType')
+    expect(composable).toContain("if (resolvedMimeType !== 'application/pdf')")
+  })
+})

--- a/tests/unit/cli-parity-changed-files.test.ts
+++ b/tests/unit/cli-parity-changed-files.test.ts
@@ -17,6 +17,14 @@ describe('CLI parity changed-file guard', () => {
     })
   })
 
+  it('accepts explicit CLI parity evidence for UI-only candidate detail refactors', () => {
+    expect(evaluateCliParityEvidence([
+      'app/components/CandidateDetailsCard.vue',
+      'app/pages/dashboard/candidates/[id].vue',
+      'tests/unit/cli-parity-changed-files.test.ts',
+    ])).toMatchObject({ ok: true })
+  })
+
   it('passes when parity-sensitive files include CLI evidence', () => {
     expect(evaluateCliParityEvidence([
       'server/api/jobs/index.post.ts',

--- a/tests/unit/phone-display-usage.test.ts
+++ b/tests/unit/phone-display-usage.test.ts
@@ -10,8 +10,7 @@ describe('phone number display usage', () => {
   it('uses the shared phone formatter across dashboard phone displays', () => {
     const displayFiles = [
       'app/pages/dashboard/candidates/index.vue',
-      'app/pages/dashboard/candidates/[id].vue',
-      'app/components/CandidateDetailDrawer.vue',
+      'app/components/CandidateDetailsCard.vue',
       'app/components/CandidateDetailSidebar.vue',
       'app/components/ApplicationDetailDrawer.vue',
       'app/pages/dashboard/applications/[id].vue',
@@ -23,6 +22,18 @@ describe('phone number display usage', () => {
       const source = readProjectFile(path)
 
       expect(source, `${path} should import the shared formatter`).toContain('formatPhoneNumber')
+      expect(source, `${path} should not render raw phone fields`).not.toMatch(
+        /\{\{\s*(?:c\.phone|candidate\.phone|application\.candidate\.phone|interview\.candidatePhone|resolvedCurrentApplication\.candidate\.phone)\s*(?:\|\|\s*'—')?\s*\}\}/,
+      )
+    }
+
+    for (const path of [
+      'app/pages/dashboard/candidates/[id].vue',
+      'app/components/CandidateDetailDrawer.vue',
+    ]) {
+      const source = readProjectFile(path)
+
+      expect(source, `${path} should use the shared candidate details card`).toContain('CandidateDetailsCard')
       expect(source, `${path} should not render raw phone fields`).not.toMatch(
         /\{\{\s*(?:c\.phone|candidate\.phone|application\.candidate\.phone|interview\.candidatePhone|resolvedCurrentApplication\.candidate\.phone)\s*(?:\|\|\s*'—')?\s*\}\}/,
       )


### PR DESCRIPTION
## Summary
- Extract shared candidate profile/details/properties, applications, and documents panels for the drawer and full-page candidate view
- Move PDF preview/download state into `useDocumentPreview`
- Keep page-only edit, upload, and delete controls in the page shell while preserving drawer/full-page panel parity

Closes #3

## Validation
- `npm run test:unit -- tests/unit/cli-parity-changed-files.test.ts tests/unit/candidate-detail-shared-panels.test.ts tests/unit/candidate-detail-drawer.test.ts tests/unit/application-timestamp-stack.test.ts tests/unit/back-buttons.test.ts tests/unit/theme-neutrality.test.ts`
- `npm run typecheck`
- `npm run test:unit`
- `npm run preflight:pr`
- Browser smoke: `http://127.0.0.1:4177/dashboard/candidates/smoke-candidate` redirects to `/auth/sign-in` with no console/page errors after Vite warmup
