### PR TITLE
fix: make SSO settings page SSR-safe

### DIFF
--- a/app/pages/dashboard/settings/sso.vue
+++ b/app/pages/dashboard/settings/sso.vue
@@ -215,8 +215,7 @@ async function handleDelete(id: string) {
 const copiedProviderId = ref<string | null>(null)
 
 function getCallbackUrl(providerId: string) {
-  const base = window.location.origin
-  return `${base}/api/auth/sso/callback/${providerId}`
+  return `${siteOrigin.value}/api/auth/sso/callback/${providerId}`
 }
 
 async function copyCallbackUrl(providerId: string) {

--- a/tests/unit/sso-security.test.ts
+++ b/tests/unit/sso-security.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { registerSsoSchema } from '../../server/utils/ssoSecurity'
 
 /**
@@ -304,6 +306,14 @@ describe('SSO callback URL construction', () => {
     // Provider IDs are already restricted to [a-z0-9-] so no encoding needed
     const url = getCallbackUrl('https://app.reqcore.com', 'my-company-123')
     expect(url).not.toContain('%')
+  })
+
+  it('keeps settings page callback URL rendering SSR-safe', () => {
+    const source = readFileSync(join(process.cwd(), 'app/pages/dashboard/settings/sso.vue'), 'utf8')
+    const helper = source.match(/function getCallbackUrl[\s\S]*?\n}/)?.[0] ?? ''
+
+    expect(helper).toContain('siteOrigin.value')
+    expect(helper).not.toContain('window.location')
   })
 })
 


### PR DESCRIPTION
## Summary
- Fix the production SSO settings 500 by avoiding direct window.location access during SSR
- Reuse the existing server-safe siteOrigin computed value for callback URL display/copying
- Add a regression test that keeps getCallbackUrl SSR-safe

## Root cause
Render production logs showed the remaining 500 was not the database migration. The migrated column exists, but SSR crashed on /dashboard/settings/sso with:

`TypeError: Cannot read properties of undefined (reading 'location')`

from `getCallbackUrl` reading `window.location.origin` during server render.

## Verification
- `npm run test:unit -- tests/unit/sso-security.test.ts`
- `npm run typecheck`
- `npm run build`
- push preflight: full `npm run test:unit`, production env contract, typecheck, build