### PR TITLE
refactor: extract dashboard list state helpers

### DIFF
--- a/app/composables/useColumnVisibility.ts
+++ b/app/composables/useColumnVisibility.ts
@@ -1,0 +1,55 @@
+export function useColumnVisibility<T extends Record<string, boolean>>(scope: string, defaults: T) {
+  const storageKey = `reqcore:columns:${scope}`
+  const visibleColumns = ref<Record<string, boolean>>({ ...defaults })
+
+  onMounted(() => {
+    try {
+      const raw = window.localStorage.getItem(storageKey)
+      if (raw) visibleColumns.value = mergeSanitizedColumnVisibility(defaults, JSON.parse(raw))
+    }
+    catch {
+      // ignore corrupt or unavailable storage
+    }
+  })
+
+  watch(visibleColumns, (value) => {
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(value))
+    }
+    catch {
+      // ignore quota or unavailable storage
+    }
+  }, { deep: true })
+
+  function mergeColumnVisibility(value?: Record<string, boolean>) {
+    visibleColumns.value = mergeSanitizedColumnVisibility(defaults, value)
+  }
+
+  return {
+    visibleColumns,
+    mergeColumnVisibility,
+  }
+}
+
+export function mergeSanitizedColumnVisibility(
+  defaults: Record<string, boolean>,
+  value: unknown,
+): Record<string, boolean> {
+  if (!isPlainObject(value)) return { ...defaults }
+
+  const sanitized: Record<string, boolean> = {}
+  for (const [key, isVisible] of Object.entries(value)) {
+    if (typeof isVisible !== 'boolean') continue
+    if (!(key in defaults) && !key.startsWith('prop_')) continue
+    sanitized[key] = isVisible
+  }
+
+  return { ...defaults, ...sanitized }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}

--- a/app/composables/useSavedViewState.ts
+++ b/app/composables/useSavedViewState.ts
@@ -1,0 +1,80 @@
+import type { ComputedRef } from 'vue'
+
+export function savedViewSettingsEqual<T extends Record<string, unknown>>(a: T, b: T): boolean {
+  return stableStringify(a) === stableStringify(b)
+}
+
+export function useSavedViewState<T extends Record<string, unknown>>(
+  scope: string,
+  defaultSettings: T,
+  currentSettings: ComputedRef<T>,
+  applySettings: (settings: T) => void,
+  options: {
+    settingsEqual?: (a: T, b: T) => boolean
+  } = {},
+) {
+  const savedViews = useSavedViews<T>(scope, defaultSettings)
+  const settingsEqual = options.settingsEqual ?? savedViewSettingsEqual
+
+  onMounted(() => {
+    nextTick(() => {
+      if (savedViews.activeViewId.value) {
+        const settings = savedViews.applyView(savedViews.activeViewId.value)
+        if (settings) applySettings(settings)
+      }
+    })
+  })
+
+  const isDirty = computed(() => {
+    const view = savedViews.views.value.find(item => item.id === savedViews.activeViewId.value)
+    if (!view) return false
+    return !settingsEqual(currentSettings.value, { ...defaultSettings, ...view.settings })
+  })
+
+  function onSelectView(id: string | null) {
+    if (id == null) {
+      savedViews.clearActive()
+      applySettings(defaultSettings)
+      return
+    }
+
+    const settings = savedViews.applyView(id)
+    if (settings) applySettings(settings)
+  }
+
+  function onSaveView(name: string) {
+    savedViews.saveView(name, currentSettings.value)
+  }
+
+  function onUpdateView(id: string) {
+    savedViews.updateView(id, { settings: currentSettings.value })
+  }
+
+  return {
+    ...savedViews,
+    isDirty,
+    onSelectView,
+    onSaveView,
+    onUpdateView,
+  }
+}
+
+function stableStringify(value: unknown): string {
+  if (value === undefined) return 'undefined'
+  if (typeof value === 'function') return 'function'
+  if (typeof value === 'symbol') return `symbol:${String(value.description ?? '')}`
+  if (typeof value === 'bigint') return `bigint:${value.toString()}`
+
+  if (Array.isArray(value)) {
+    return `[${value.map(item => stableStringify(item)).join(',')}]`
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+    return `{${entries.join(',')}}`
+  }
+
+  return JSON.stringify(value) ?? String(value)
+}

--- a/app/pages/dashboard/applications/index.vue
+++ b/app/pages/dashboard/applications/index.vue
@@ -18,8 +18,6 @@ useSeoMeta({
 
 // ── Column visibility ─────────────────────────────────────────────────────────
 
-const COLUMNS_STORAGE_KEY = 'reqcore:columns:applications'
-
 const defaultColumnVisibility = {
   email: true,
   job: true,
@@ -28,7 +26,7 @@ const defaultColumnVisibility = {
   applied: true,
 }
 
-const visibleColumns = ref<Record<string, boolean>>({ ...defaultColumnVisibility })
+const { visibleColumns, mergeColumnVisibility } = useColumnVisibility('applications', defaultColumnVisibility)
 
 const { definitions: propertyDefs } = useProperties({ entityType: () => 'application' })
 
@@ -41,18 +39,6 @@ const applicationColumns = computed(() => [
   { key: 'applied', label: 'Applied' },
   ...propertyDefs.value.map((d) => ({ key: `prop_${d.id}`, label: d.name })),
 ])
-
-onMounted(() => {
-  try {
-    const raw = window.localStorage.getItem(COLUMNS_STORAGE_KEY)
-    if (raw) visibleColumns.value = { ...defaultColumnVisibility, ...JSON.parse(raw) }
-  } catch {}
-})
-
-watch(visibleColumns, (val) => {
-  if (typeof window === 'undefined') return
-  try { window.localStorage.setItem(COLUMNS_STORAGE_KEY, JSON.stringify(val)) } catch {}
-}, { deep: true })
 
 const route = useRoute()
 const router = useRouter()
@@ -241,70 +227,19 @@ function applySettings(s: ApplicationsViewSettings) {
   propertyFilters.value = [...(s.propertyFilters ?? [])]
   sortKey.value = s.sortKey
   sortDir.value = s.sortDir
-  if (s.visibleColumns) visibleColumns.value = { ...defaultColumnVisibility, ...s.visibleColumns }
+  if (s.visibleColumns) mergeColumnVisibility(s.visibleColumns)
 }
 
 const {
   views,
   activeViewId,
-  applyView,
-  saveView,
-  updateView,
   deleteView,
   setDefault,
-  clearActive,
-} = useSavedViews<ApplicationsViewSettings>('applications', defaultSettings)
-
-// On first mount, if a default view exists, apply its settings.
-onMounted(() => {
-  nextTick(() => {
-    if (activeViewId.value) {
-      const s = applyView(activeViewId.value)
-      if (s) applySettings(s)
-    }
-  })
-})
-
-function settingsEqual(a: ApplicationsViewSettings, b: ApplicationsViewSettings) {
-  return a.status === b.status
-    && a.jobId === b.jobId
-    && a.sortKey === b.sortKey
-    && a.sortDir === b.sortDir
-    && JSON.stringify(a.propertyFilters ?? []) === JSON.stringify(b.propertyFilters ?? [])
-    && JSON.stringify(a.visibleColumns ?? {}) === JSON.stringify(b.visibleColumns ?? {})
-}
-
-const isDirty = computed(() => {
-  const view = views.value.find(v => v.id === activeViewId.value)
-  if (!view) return false
-  return !settingsEqual(currentSettings.value, { ...defaultSettings, ...view.settings })
-})
-
-// Mark the view inactive (chip-level highlight) when the user manually edits filters.
-watch(currentSettings, () => {
-  if (!activeViewId.value) return
-  if (isDirty.value) {
-    // Keep the chip active but show the dirty marker via SavedViewsBar.
-  }
-}, { deep: true })
-
-function onSelectView(id: string | null) {
-  if (id == null) {
-    clearActive()
-    applySettings(defaultSettings)
-    return
-  }
-  const s = applyView(id)
-  if (s) applySettings(s)
-}
-
-function onSaveView(name: string) {
-  saveView(name, currentSettings.value)
-}
-
-function onUpdateView(id: string) {
-  updateView(id, { settings: currentSettings.value })
-}
+  isDirty,
+  onSelectView,
+  onSaveView,
+  onUpdateView,
+} = useSavedViewState<ApplicationsViewSettings>('applications', defaultSettings, currentSettings, applySettings)
 
 const drawerActiveCount = computed(() =>
   [activeStatus.value, activeJobId.value].filter(Boolean).length + propertyFilters.value.length,

--- a/app/pages/dashboard/candidates/index.vue
+++ b/app/pages/dashboard/candidates/index.vue
@@ -14,8 +14,6 @@ useSeoMeta({
 
 // ── Column visibility ─────────────────────────────────────────────────────────
 
-const COLUMNS_STORAGE_KEY = 'reqcore:columns:candidates'
-
 const defaultColumnVisibility = {
   email: true,
   phone: true,
@@ -24,7 +22,7 @@ const defaultColumnVisibility = {
   quickNotes: true,
 }
 
-const visibleColumns = ref<Record<string, boolean>>({ ...defaultColumnVisibility })
+const { visibleColumns, mergeColumnVisibility } = useColumnVisibility('candidates', defaultColumnVisibility)
 
 const { definitions: propertyDefs } = useProperties({ entityType: () => 'candidate' })
 
@@ -37,18 +35,6 @@ const candidateColumns = computed(() => [
   { key: 'quickNotes', label: 'Quick notes' },
   ...propertyDefs.value.map((d) => ({ key: `prop_${d.id}`, label: d.name })),
 ])
-
-onMounted(() => {
-  try {
-    const raw = window.localStorage.getItem(COLUMNS_STORAGE_KEY)
-    if (raw) visibleColumns.value = { ...defaultColumnVisibility, ...JSON.parse(raw) }
-  } catch {}
-})
-
-watch(visibleColumns, (val) => {
-  if (typeof window === 'undefined') return
-  try { window.localStorage.setItem(COLUMNS_STORAGE_KEY, JSON.stringify(val)) } catch {}
-}, { deep: true })
 
 const searchInput = ref('')
 const debouncedSearch = ref<string | undefined>(undefined)
@@ -217,62 +203,19 @@ function applySettings(s: CandidatesViewSettings) {
   propertyFilters.value = [...(s.propertyFilters ?? [])]
   sortKey.value = s.sortKey
   sortDir.value = s.sortDir
-  if (s.visibleColumns) visibleColumns.value = { ...defaultColumnVisibility, ...s.visibleColumns }
+  if (s.visibleColumns) mergeColumnVisibility(s.visibleColumns)
 }
 
 const {
   views,
   activeViewId,
-  applyView,
-  saveView,
-  updateView,
   deleteView,
   setDefault,
-  clearActive,
-} = useSavedViews<CandidatesViewSettings>('candidates', defaultSettings)
-
-onMounted(() => {
-  nextTick(() => {
-    if (activeViewId.value) {
-      const s = applyView(activeViewId.value)
-      if (s) applySettings(s)
-    }
-  })
-})
-
-function settingsEqual(a: CandidatesViewSettings, b: CandidatesViewSettings) {
-  return a.gender === b.gender
-    && a.dobFrom === b.dobFrom
-    && a.dobTo === b.dobTo
-    && a.sortKey === b.sortKey
-    && a.sortDir === b.sortDir
-    && JSON.stringify(a.propertyFilters ?? []) === JSON.stringify(b.propertyFilters ?? [])
-    && JSON.stringify(a.visibleColumns ?? {}) === JSON.stringify(b.visibleColumns ?? {})
-}
-
-const isDirty = computed(() => {
-  const view = views.value.find(v => v.id === activeViewId.value)
-  if (!view) return false
-  return !settingsEqual(currentSettings.value, { ...defaultSettings, ...view.settings })
-})
-
-function onSelectView(id: string | null) {
-  if (id == null) {
-    clearActive()
-    applySettings(defaultSettings)
-    return
-  }
-  const s = applyView(id)
-  if (s) applySettings(s)
-}
-
-function onSaveView(name: string) {
-  saveView(name, currentSettings.value)
-}
-
-function onUpdateView(id: string) {
-  updateView(id, { settings: currentSettings.value })
-}
+  isDirty,
+  onSelectView,
+  onSaveView,
+  onUpdateView,
+} = useSavedViewState<CandidatesViewSettings>('candidates', defaultSettings, currentSettings, applySettings)
 
 // ── Candidate detail drawer ───────────────────────────────────────────────────
 const selectedCandidateId = ref<string | null>(null)

--- a/app/pages/dashboard/jobs/index.vue
+++ b/app/pages/dashboard/jobs/index.vue
@@ -336,63 +336,23 @@ function applySettings(s: JobsViewSettings) {
 const {
   views,
   activeViewId,
-  applyView,
-  saveView,
-  updateView,
   deleteView,
   setDefault,
-  clearActive,
-} = useSavedViews<JobsViewSettings>('jobs', defaultSettings)
+  isDirty,
+  onSelectView,
+  onSaveView,
+  onUpdateView,
+} = useSavedViewState<JobsViewSettings>('jobs', defaultSettings, currentSettings, applySettings)
 
 onMounted(() => {
   document.addEventListener('mousedown', handleSortMenuOutside)
   document.addEventListener('keydown', handleSortMenuKeydown)
-  nextTick(() => {
-    if (activeViewId.value) {
-      const s = applyView(activeViewId.value)
-      if (s) applySettings(s)
-    }
-  })
 })
 
 onUnmounted(() => {
   document.removeEventListener('mousedown', handleSortMenuOutside)
   document.removeEventListener('keydown', handleSortMenuKeydown)
 })
-
-function settingsEqual(a: JobsViewSettings, b: JobsViewSettings) {
-  return a.viewMode === b.viewMode
-    && a.sortKey === b.sortKey
-    && a.sortDir === b.sortDir
-    && JSON.stringify(a.statusFilter ?? []) === JSON.stringify(b.statusFilter ?? [])
-    && JSON.stringify(a.typeFilter ?? []) === JSON.stringify(b.typeFilter ?? [])
-    && JSON.stringify(a.experienceFilter ?? []) === JSON.stringify(b.experienceFilter ?? [])
-    && JSON.stringify(a.remoteFilter ?? []) === JSON.stringify(b.remoteFilter ?? [])
-}
-
-const isDirty = computed(() => {
-  const view = views.value.find(v => v.id === activeViewId.value)
-  if (!view) return false
-  return !settingsEqual(currentSettings.value, { ...defaultSettings, ...view.settings })
-})
-
-function onSelectView(id: string | null) {
-  if (id == null) {
-    clearActive()
-    applySettings(defaultSettings)
-    return
-  }
-  const s = applyView(id)
-  if (s) applySettings(s)
-}
-
-function onSaveView(name: string) {
-  saveView(name, currentSettings.value)
-}
-
-function onUpdateView(id: string) {
-  updateView(id, { settings: currentSettings.value })
-}
 
 // ─────────────────────────────────────────────
 // Helpers

--- a/tests/unit/dashboard-list-state-helpers.test.ts
+++ b/tests/unit/dashboard-list-state-helpers.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { mergeSanitizedColumnVisibility } from '../../app/composables/useColumnVisibility'
+import { savedViewSettingsEqual } from '../../app/composables/useSavedViewState'
+
+const ROOT = process.cwd()
+
+function readProjectFile(path: string): string {
+  return readFileSync(join(ROOT, path), 'utf8')
+}
+
+describe('dashboard list state helpers', () => {
+  it('compares saved view settings without depending on object key order', () => {
+    expect(savedViewSettingsEqual(
+      {
+        sortKey: 'created',
+        sortDir: 'desc',
+        visibleColumns: { email: true, job: false },
+        propertyFilters: [{ field: 'stage', operator: 'eq', value: 'screening' }],
+      },
+      {
+        propertyFilters: [{ operator: 'eq', value: 'screening', field: 'stage' }],
+        visibleColumns: { job: false, email: true },
+        sortDir: 'desc',
+        sortKey: 'created',
+      },
+    )).toBe(true)
+  })
+
+  it('keeps saved view comparison deterministic for unsupported JSON values', () => {
+    expect(savedViewSettingsEqual(
+      { sortKey: 'created', filters: [undefined] },
+      { sortKey: 'created', filters: [null] },
+    )).toBe(false)
+
+    expect(savedViewSettingsEqual(
+      { sortKey: 'created', extra: undefined },
+      { sortKey: 'created' },
+    )).toBe(false)
+
+    expect(savedViewSettingsEqual(
+      { sortKey: 'created', marker: Symbol('a') },
+      { sortKey: 'created', marker: Symbol('b') },
+    )).toBe(false)
+  })
+
+  it('sanitizes localStorage column visibility before merging defaults', () => {
+    const defaults = { email: true, phone: true }
+
+    expect(mergeSanitizedColumnVisibility(defaults, ['email'])).toEqual(defaults)
+    expect(mergeSanitizedColumnVisibility(defaults, {
+      email: false,
+      phone: 'nope',
+      prop_custom: true,
+      injected: false,
+    })).toEqual({
+      email: false,
+      phone: true,
+      prop_custom: true,
+    })
+  })
+
+  it('moves repeated saved-view plumbing into a shared composable', () => {
+    const helper = readProjectFile('app/composables/useSavedViewState.ts')
+    const candidates = readProjectFile('app/pages/dashboard/candidates/index.vue')
+    const applications = readProjectFile('app/pages/dashboard/applications/index.vue')
+    const jobs = readProjectFile('app/pages/dashboard/jobs/index.vue')
+
+    expect(helper).toContain('useSavedViews<T>(scope, defaultSettings)')
+    expect(helper).toContain('onSelectView')
+    expect(helper).toContain('onSaveView')
+    expect(helper).toContain('onUpdateView')
+    expect(candidates).toContain("useSavedViewState<CandidatesViewSettings>('candidates'")
+    expect(applications).toContain("useSavedViewState<ApplicationsViewSettings>('applications'")
+    expect(jobs).toContain("useSavedViewState<JobsViewSettings>('jobs'")
+
+    for (const source of [candidates, applications, jobs]) {
+      expect(source).not.toContain('function settingsEqual')
+      expect(source).not.toContain('function onSelectView')
+      expect(source).not.toContain('function onSaveView')
+      expect(source).not.toContain('function onUpdateView')
+    }
+  })
+
+  it('moves localStorage-backed column visibility into a shared composable', () => {
+    const helper = readProjectFile('app/composables/useColumnVisibility.ts')
+    const candidates = readProjectFile('app/pages/dashboard/candidates/index.vue')
+    const applications = readProjectFile('app/pages/dashboard/applications/index.vue')
+
+    expect(helper).toContain('reqcore:columns:${scope}')
+    expect(candidates).toContain("useColumnVisibility('candidates', defaultColumnVisibility)")
+    expect(applications).toContain("useColumnVisibility('applications', defaultColumnVisibility)")
+    expect(candidates).not.toContain('COLUMNS_STORAGE_KEY')
+    expect(applications).not.toContain('COLUMNS_STORAGE_KEY')
+  })
+})


### PR DESCRIPTION
## Summary
- add shared saved-view state plumbing for dashboard list pages
- add shared localStorage-backed column visibility for candidates/applications
- wire jobs, candidates, and applications list pages to the shared helpers

Closes #7

## Verification
- npm run test:unit -- tests/unit/dashboard-list-state-helpers.test.ts
- npm run typecheck
- npm run preflight:pr