### PR TITLE
refactor: share application detail actions

### DIFF
--- a/app/components/ApplicationDetailDrawer.vue
+++ b/app/components/ApplicationDetailDrawer.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import { X, ExternalLink, User, Briefcase, Calendar, Clock, FileText, MessageSquare, Brain, Loader2 } from 'lucide-vue-next'
-import { APPLICATION_STATUS_TRANSITIONS } from '~~/shared/status-transitions'
-import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
 import {
   getApplicationTransitionActionLabel,
   getApplicationTransitionButtonClass,
 } from '~/utils/status-display'
 import { formatPhoneNumber } from '~/utils/phone-format'
+import { formatResponseValue } from '~/utils/application-response-format'
 
 const props = defineProps<{
   applicationId: string
@@ -17,8 +16,6 @@ const emit = defineEmits<{
 }>()
 
 const localePath = useLocalePath()
-const { handlePreviewReadOnlyError } = usePreviewReadOnly()
-const toast = useToast()
 
 const { application, status: fetchStatus, error, refresh, updateApplication } = useApplication(() => props.applicationId)
 const { isScoringApplication, scoreApplicationCandidate } = useApplicationScoring()
@@ -51,54 +48,18 @@ const scoringSummaryFallback = computed(() => {
   return 'Run analysis to generate an AI scoring summary.'
 })
 
-// ─── Status transitions ───────────────────────────────────────────────────────
-
-const allowedTransitions = computed(() => {
-  if (!application.value) return []
-  return APPLICATION_STATUS_TRANSITIONS[application.value.status] ?? []
-})
-
-const isTransitioning = ref(false)
 const showInterviewSidebar = ref(false)
 
-async function handleTransition(newStatus: string) {
-  isTransitioning.value = true
-  try {
-    await updateApplication({ status: newStatus as any })
-  } catch (err: any) {
-    if (handlePreviewReadOnlyError(err)) return
-    toast.error('Failed to update status', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
-  } finally {
-    isTransitioning.value = false
-  }
-}
+const { allowedTransitions, isTransitioning, transitionToStatus } = useApplicationStatusActions({
+  application,
+  updateStatus: status => updateApplication({ status: status as any }),
+})
 
-// ─── Notes editing ────────────────────────────────────────────────────────────
-
-const isEditingNotes = ref(false)
-const notesInput = ref('')
-const isSavingNotes = ref(false)
-const notesTextarea = ref<HTMLTextAreaElement | null>(null)
-
-async function startEditNotes() {
-  notesInput.value = application.value?.notes ?? ''
-  isEditingNotes.value = true
-  await nextTick()
-  notesTextarea.value?.focus()
-}
-
-async function saveNotes() {
-  isSavingNotes.value = true
-  try {
-    await updateApplication({ notes: notesInput.value || null })
-    isEditingNotes.value = false
-  } catch (err: any) {
-    if (handlePreviewReadOnlyError(err)) return
-    toast.error('Failed to save notes', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
-  } finally {
-    isSavingNotes.value = false
-  }
-}
+const { isEditingNotes, notesInput, isSavingNotes, notesTextarea, startEditNotes, saveNotes } = useEditableApplicationNotes({
+  application,
+  focusOnEdit: true,
+  save: notes => updateApplication({ notes }),
+})
 
 async function scoreCurrentApplication() {
   if (!application.value) return
@@ -108,14 +69,6 @@ async function scoreCurrentApplication() {
     source: 'application_detail_drawer',
   })
   await refreshScoring()
-}
-
-// ─── Display helpers ──────────────────────────────────────────────────────────
-
-function formatResponseValue(value: unknown): string {
-  if (Array.isArray(value)) return value.join(', ')
-  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
-  return String(value ?? '—')
 }
 
 // ─── Body scroll lock + keyboard handling ─────────────────────────────────────
@@ -240,7 +193,7 @@ onUnmounted(() => {
                   :disabled="isTransitioning"
                   class="inline-flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap px-2.5 py-1.5 text-[10px] font-semibold uppercase leading-none tracking-normal transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500/40 disabled:cursor-not-allowed disabled:opacity-50"
                   :class="getApplicationTransitionButtonClass(nextStatus, 'factory')"
-                  @click="handleTransition(nextStatus)"
+                  @click="transitionToStatus(nextStatus)"
                 >
                   <ApplicationTransitionIcon :status="nextStatus" />
                   {{ getApplicationTransitionActionLabel(nextStatus) }}

--- a/app/components/CandidateDetailSidebar.vue
+++ b/app/components/CandidateDetailSidebar.vue
@@ -10,6 +10,7 @@ import {
   getApplicationTransitionLabel,
 } from '~/utils/status-display'
 import { formatPhoneNumber } from '~/utils/phone-format'
+import { formatResponseValue } from '~/utils/application-response-format'
 
 const props = defineProps<{
   applicationId: string
@@ -78,70 +79,44 @@ watch(candidateId, (id) => {
 
 const documents = computed(() => candidateData.value?.documents ?? [])
 
-// ─────────────────────────────────────────────
-// Status transitions
-// ─────────────────────────────────────────────
-import { APPLICATION_STATUS_TRANSITIONS } from '~~/shared/status-transitions'
+async function updateApplicationStatus(status: string) {
+  await $fetch(`/api/applications/${props.applicationId}` as string, {
+    method: 'PATCH',
+    body: { status },
+  })
+}
 
-const allowedTransitions = computed(() => {
-  if (!application.value) return []
-  return APPLICATION_STATUS_TRANSITIONS[application.value.status] ?? []
-})
+async function updateApplicationNotes(notes: string | null) {
+  await $fetch(`/api/applications/${props.applicationId}` as string, {
+    method: 'PATCH',
+    body: { notes },
+  })
+}
 
-const isTransitioning = ref(false)
-
-async function handleTransition(newStatus: string) {
-  isTransitioning.value = true
-  try {
-    await $fetch(`/api/applications/${props.applicationId}`, {
-      method: 'PATCH',
-      body: { status: newStatus },
-    })
+const { allowedTransitions, isTransitioning, transitionToStatus } = useApplicationStatusActions({
+  application,
+  updateStatus: updateApplicationStatus,
+  trackTransition: ({ fromStatus, toStatus }) => {
     track('sidebar_status_changed', {
       application_id: props.applicationId,
-      from_status: application.value?.status,
-      to_status: newStatus,
+      from_status: fromStatus,
+      to_status: toStatus,
     })
+  },
+  afterTransition: async () => {
     await refresh()
     emit('updated')
-  } catch (err: any) {
-    if (handlePreviewReadOnlyError(err)) return
-    toast.error('Failed to update status', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
-  } finally {
-    isTransitioning.value = false
-  }
-}
+  },
+})
 
-// ─────────────────────────────────────────────
-// Notes editing
-// ─────────────────────────────────────────────
-
-const isEditingNotes = ref(false)
-const notesInput = ref('')
-const isSavingNotes = ref(false)
-
-function startEditNotes() {
-  notesInput.value = application.value?.notes ?? ''
-  isEditingNotes.value = true
-}
-
-async function saveNotes() {
-  isSavingNotes.value = true
-  try {
-    await $fetch(`/api/applications/${props.applicationId}`, {
-      method: 'PATCH',
-      body: { notes: notesInput.value || null },
-    })
+const { isEditingNotes, notesInput, isSavingNotes, startEditNotes, saveNotes } = useEditableApplicationNotes({
+  application,
+  save: updateApplicationNotes,
+  afterSave: async () => {
     await refresh()
     emit('updated')
-    isEditingNotes.value = false
-  } catch (err: any) {
-    if (handlePreviewReadOnlyError(err)) return
-    toast.error('Failed to save notes', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
-  } finally {
-    isSavingNotes.value = false
-  }
-}
+  },
+})
 
 // ─────────────────────────────────────────────
 // Documents — upload, download, preview, delete
@@ -394,16 +369,6 @@ watch(() => props.applicationId, () => {
   closePreview()
 })
 
-// ─────────────────────────────────────────────
-// Display helpers
-// ─────────────────────────────────────────────
-
-function formatResponseValue(value: unknown): string {
-  if (Array.isArray(value)) return value.join(', ')
-  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
-  return String(value ?? '—')
-}
-
 const responsesCount = computed(() => application.value?.responses?.length ?? 0)
 
 // ─────────────────────────────────────────────
@@ -566,7 +531,7 @@ function formatInterviewDate(dateStr: string) {
                   :disabled="isTransitioning"
                   class="ui-button inline-flex items-center gap-1.5 px-3 py-1.5 text-sm disabled:opacity-50"
                   :class="getApplicationTransitionButtonClass(nextStatus)"
-                  @click="handleTransition(nextStatus)"
+                  @click="transitionToStatus(nextStatus)"
                 >
                   <ApplicationTransitionIcon :status="nextStatus" />
                   {{ getApplicationTransitionLabel(nextStatus) }}

--- a/app/components/CandidateDetailSidebar.vue
+++ b/app/components/CandidateDetailSidebar.vue
@@ -80,14 +80,14 @@ watch(candidateId, (id) => {
 const documents = computed(() => candidateData.value?.documents ?? [])
 
 async function updateApplicationStatus(status: string) {
-  await $fetch(`/api/applications/${props.applicationId}` as string, {
+  await $fetch(`/api/applications/${props.applicationId}`, {
     method: 'PATCH',
     body: { status },
   })
 }
 
 async function updateApplicationNotes(notes: string | null) {
-  await $fetch(`/api/applications/${props.applicationId}` as string, {
+  await $fetch(`/api/applications/${props.applicationId}`, {
     method: 'PATCH',
     body: { notes },
   })

--- a/app/composables/useApplicationStatusActions.ts
+++ b/app/composables/useApplicationStatusActions.ts
@@ -1,0 +1,57 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { computed, ref, toValue } from 'vue'
+import { APPLICATION_STATUS_TRANSITIONS } from '~~/shared/status-transitions'
+
+type ApplicationWithStatus = {
+  status?: string | null
+}
+
+type TransitionContext = {
+  fromStatus?: string | null
+  toStatus: string
+}
+
+type UseApplicationStatusActionsOptions = {
+  application: MaybeRefOrGetter<ApplicationWithStatus | null | undefined>
+  updateStatus: (status: string) => Promise<unknown>
+  afterTransition?: (context: TransitionContext) => Promise<unknown> | unknown
+  trackTransition?: (context: TransitionContext) => void
+}
+
+export function useApplicationStatusActions(options: UseApplicationStatusActionsOptions) {
+  const { handlePreviewReadOnlyError } = usePreviewReadOnly()
+  const toast = useToast()
+
+  const allowedTransitions = computed(() => {
+    const status = toValue(options.application)?.status
+    if (!status) return []
+    return APPLICATION_STATUS_TRANSITIONS[status as keyof typeof APPLICATION_STATUS_TRANSITIONS] ?? []
+  })
+
+  const isTransitioning = ref(false)
+
+  async function transitionToStatus(newStatus: string) {
+    const context = {
+      fromStatus: toValue(options.application)?.status,
+      toStatus: newStatus,
+    }
+
+    isTransitioning.value = true
+    try {
+      await options.updateStatus(newStatus)
+      options.trackTransition?.(context)
+      await options.afterTransition?.(context)
+    } catch (err: any) {
+      if (handlePreviewReadOnlyError(err)) return
+      toast.error('Failed to update status', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
+    } finally {
+      isTransitioning.value = false
+    }
+  }
+
+  return {
+    allowedTransitions,
+    isTransitioning,
+    transitionToStatus,
+  }
+}

--- a/app/composables/useEditableApplicationNotes.ts
+++ b/app/composables/useEditableApplicationNotes.ts
@@ -1,0 +1,56 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { nextTick, ref, toValue } from 'vue'
+
+type ApplicationWithNotes = {
+  notes?: string | null
+}
+
+type UseEditableApplicationNotesOptions = {
+  application: MaybeRefOrGetter<ApplicationWithNotes | null | undefined>
+  save: (notes: string | null) => Promise<unknown>
+  afterSave?: () => Promise<unknown> | unknown
+  focusOnEdit?: boolean
+}
+
+export function useEditableApplicationNotes(options: UseEditableApplicationNotesOptions) {
+  const { handlePreviewReadOnlyError } = usePreviewReadOnly()
+  const toast = useToast()
+
+  const isEditingNotes = ref(false)
+  const notesInput = ref('')
+  const isSavingNotes = ref(false)
+  const notesTextarea = ref<HTMLTextAreaElement | null>(null)
+
+  async function startEditNotes() {
+    notesInput.value = toValue(options.application)?.notes ?? ''
+    isEditingNotes.value = true
+
+    if (options.focusOnEdit) {
+      await nextTick()
+      notesTextarea.value?.focus()
+    }
+  }
+
+  async function saveNotes() {
+    isSavingNotes.value = true
+    try {
+      await options.save(notesInput.value || null)
+      await options.afterSave?.()
+      isEditingNotes.value = false
+    } catch (err: any) {
+      if (handlePreviewReadOnlyError(err)) return
+      toast.error('Failed to save notes', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
+    } finally {
+      isSavingNotes.value = false
+    }
+  }
+
+  return {
+    isEditingNotes,
+    notesInput,
+    isSavingNotes,
+    notesTextarea,
+    startEditNotes,
+    saveNotes,
+  }
+}

--- a/app/pages/dashboard/applications/[id].vue
+++ b/app/pages/dashboard/applications/[id].vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { User, Briefcase, Calendar, Clock, FileText, MessageSquare, Brain, Loader2 } from 'lucide-vue-next'
-import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
 import {
   getApplicationTransitionActionLabel,
   getApplicationTransitionButtonClass,
 } from '~/utils/status-display'
 import { formatPhoneNumber } from '~/utils/phone-format'
+import { formatResponseValue } from '~/utils/application-response-format'
 
 definePageMeta({
   layout: 'dashboard',
@@ -14,8 +14,6 @@ definePageMeta({
 
 const route = useRoute()
 const applicationId = route.params.id as string
-const { handlePreviewReadOnlyError } = usePreviewReadOnly()
-const toast = useToast()
 
 type ApplicationScoresResponse = {
   compositeScore: number | null
@@ -64,17 +62,6 @@ useSeoMeta({
   ),
 })
 
-// ─────────────────────────────────────────────
-// Status transitions
-// ─────────────────────────────────────────────
-import { APPLICATION_STATUS_TRANSITIONS } from '~~/shared/status-transitions'
-
-const allowedTransitions = computed(() => {
-  if (!application.value) return []
-  return APPLICATION_STATUS_TRANSITIONS[application.value.status] ?? []
-})
-
-const isTransitioning = ref(false)
 const showInterviewSidebar = ref(false)
 const scoringSummary = computed(() => {
   const summary = scoringData.value?.latestRun?.summary
@@ -88,46 +75,16 @@ const scoringSummaryFallback = computed(() => {
   return 'Run analysis to generate an AI scoring summary.'
 })
 
-async function handleTransition(newStatus: string) {
-  isTransitioning.value = true
-  try {
-    await updateApplication({ status: newStatus as any })
-  } catch (err: any) {
-    if (handlePreviewReadOnlyError(err)) return
-    toast.error('Failed to update status', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
-  } finally {
-    isTransitioning.value = false
-  }
-}
+const { allowedTransitions, isTransitioning, transitionToStatus } = useApplicationStatusActions({
+  application,
+  updateStatus: status => updateApplication({ status: status as any }),
+})
 
-// ─────────────────────────────────────────────
-// Notes editing
-// ─────────────────────────────────────────────
-
-const isEditingNotes = ref(false)
-const notesInput = ref('')
-const isSavingNotes = ref(false)
-const notesTextarea = ref<HTMLTextAreaElement | null>(null)
-
-async function startEditNotes() {
-  notesInput.value = application.value?.notes ?? ''
-  isEditingNotes.value = true
-  await nextTick()
-  notesTextarea.value?.focus()
-}
-
-async function saveNotes() {
-  isSavingNotes.value = true
-  try {
-    await updateApplication({ notes: notesInput.value || null })
-    isEditingNotes.value = false
-  } catch (err: any) {
-    if (handlePreviewReadOnlyError(err)) return
-    toast.error('Failed to save notes', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
-  } finally {
-    isSavingNotes.value = false
-  }
-}
+const { isEditingNotes, notesInput, isSavingNotes, notesTextarea, startEditNotes, saveNotes } = useEditableApplicationNotes({
+  application,
+  focusOnEdit: true,
+  save: notes => updateApplication({ notes }),
+})
 
 async function scoreCurrentApplication() {
   if (!application.value) return
@@ -139,15 +96,6 @@ async function scoreCurrentApplication() {
   await refreshScoring()
 }
 
-// ─────────────────────────────────────────────
-// Display helpers
-// ─────────────────────────────────────────────
-
-function formatResponseValue(value: unknown): string {
-  if (Array.isArray(value)) return value.join(', ')
-  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
-  return String(value ?? '—')
-}
 </script>
 
 <template>
@@ -216,7 +164,7 @@ function formatResponseValue(value: unknown): string {
             :disabled="isTransitioning"
             class="inline-flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap px-2.5 py-1.5 text-[10px] font-semibold uppercase leading-none tracking-normal transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500/40 disabled:cursor-not-allowed disabled:opacity-50"
             :class="getApplicationTransitionButtonClass(nextStatus, 'factory')"
-            @click="handleTransition(nextStatus)"
+            @click="transitionToStatus(nextStatus)"
           >
             <ApplicationTransitionIcon :status="nextStatus" />
             {{ getApplicationTransitionActionLabel(nextStatus) }}

--- a/app/utils/application-response-format.ts
+++ b/app/utils/application-response-format.ts
@@ -1,0 +1,5 @@
+export function formatResponseValue(value: unknown): string {
+  if (Array.isArray(value)) return value.join(', ')
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  return String(value ?? '—')
+}

--- a/tests/unit/application-detail-actions.test.ts
+++ b/tests/unit/application-detail-actions.test.ts
@@ -10,6 +10,10 @@ function readProjectFile(path: string) {
   return readFileSync(projectPath(path), 'utf-8')
 }
 
+function compactSource(source: string) {
+  return source.replace(/\s+/g, ' ')
+}
+
 const applicationDetailSurfaces = [
   'app/components/ApplicationDetailDrawer.vue',
   'app/pages/dashboard/applications/[id].vue',
@@ -41,9 +45,9 @@ describe('application detail shared actions', () => {
     expect(editableNotes).toContain('handlePreviewReadOnlyError')
     expect(editableNotes).toContain('Failed to save notes')
 
-    expect(responseFormat).toContain('formatResponseValue')
-    expect(responseFormat).toContain("Array.isArray(value)")
-    expect(responseFormat).toContain("value ? 'Yes' : 'No'")
+    expect(responseFormat).toMatch(/export\s+function\s+formatResponseValue\s*\(\s*value\s*:\s*unknown\s*\)\s*:\s*string/)
+    expect(responseFormat).toMatch(/Array\.isArray\s*\(\s*value\s*\)/)
+    expect(compactSource(responseFormat)).toMatch(/typeof value === ['"]boolean['"].*value \? ['"]Yes['"] : ['"]No['"]/)
   })
 
   it('uses the shared composables on every application detail surface', () => {
@@ -59,7 +63,7 @@ describe('application detail shared actions', () => {
       expect(source, `${path} should not define local note input state`).not.toContain('const notesInput = ref')
       expect(source, `${path} should not define local save handler`).not.toContain('function saveNotes')
       expect(source, `${path} should not define local response formatting`).not.toContain('function formatResponseValue(value')
-      expect(source, `${path} should call the shared transition handler`).toContain('@click="transitionToStatus(nextStatus)"')
+      expect(source, `${path} should call the shared transition handler`).toMatch(/@click=["']transitionToStatus\([^)]*Status[^)]*\)["']/)
     }
   })
 })

--- a/tests/unit/application-detail-actions.test.ts
+++ b/tests/unit/application-detail-actions.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function projectPath(path: string) {
+  return fileURLToPath(new URL(`../../${path}`, import.meta.url))
+}
+
+function readProjectFile(path: string) {
+  return readFileSync(projectPath(path), 'utf-8')
+}
+
+const applicationDetailSurfaces = [
+  'app/components/ApplicationDetailDrawer.vue',
+  'app/pages/dashboard/applications/[id].vue',
+  'app/components/CandidateDetailSidebar.vue',
+]
+
+describe('application detail shared actions', () => {
+  it('centralizes status transitions and editable notes in shared composables', () => {
+    expect(existsSync(projectPath('app/composables/useApplicationStatusActions.ts'))).toBe(true)
+    expect(existsSync(projectPath('app/composables/useEditableApplicationNotes.ts'))).toBe(true)
+    expect(existsSync(projectPath('app/utils/application-response-format.ts'))).toBe(true)
+
+    const statusActions = readProjectFile('app/composables/useApplicationStatusActions.ts')
+    const editableNotes = readProjectFile('app/composables/useEditableApplicationNotes.ts')
+    const responseFormat = readProjectFile('app/utils/application-response-format.ts')
+
+    expect(statusActions).toContain('APPLICATION_STATUS_TRANSITIONS')
+    expect(statusActions).toContain('allowedTransitions')
+    expect(statusActions).toContain('isTransitioning')
+    expect(statusActions).toContain('transitionToStatus')
+    expect(statusActions).toContain('handlePreviewReadOnlyError')
+    expect(statusActions).toContain('Failed to update status')
+
+    expect(editableNotes).toContain('isEditingNotes')
+    expect(editableNotes).toContain('notesInput')
+    expect(editableNotes).toContain('isSavingNotes')
+    expect(editableNotes).toContain('startEditNotes')
+    expect(editableNotes).toContain('saveNotes')
+    expect(editableNotes).toContain('handlePreviewReadOnlyError')
+    expect(editableNotes).toContain('Failed to save notes')
+
+    expect(responseFormat).toContain('formatResponseValue')
+    expect(responseFormat).toContain("Array.isArray(value)")
+    expect(responseFormat).toContain("value ? 'Yes' : 'No'")
+  })
+
+  it('uses the shared composables on every application detail surface', () => {
+    for (const path of applicationDetailSurfaces) {
+      const source = readProjectFile(path)
+
+      expect(source, `${path} should use shared status actions`).toContain('useApplicationStatusActions')
+      expect(source, `${path} should use shared editable notes`).toContain('useEditableApplicationNotes')
+      expect(source, `${path} should not define local status transitions`).not.toContain('APPLICATION_STATUS_TRANSITIONS')
+      expect(source, `${path} should not define local transition state`).not.toContain('const isTransitioning = ref')
+      expect(source, `${path} should not define local transition handler`).not.toContain('function handleTransition')
+      expect(source, `${path} should not define local note editing state`).not.toContain('const isEditingNotes = ref')
+      expect(source, `${path} should not define local note input state`).not.toContain('const notesInput = ref')
+      expect(source, `${path} should not define local save handler`).not.toContain('function saveNotes')
+      expect(source, `${path} should not define local response formatting`).not.toContain('function formatResponseValue(value')
+      expect(source, `${path} should call the shared transition handler`).toContain('@click="transitionToStatus(nextStatus)"')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add shared status transition and editable notes composables for application detail views
- wire the drawer, full-page detail view, and candidate sidebar through the shared actions
- move duplicated application response formatting into a shared utility
- add a source-level guard test so the duplication does not creep back in

Closes #6

## Validation
- `npm run test:unit -- tests/unit/application-detail-actions.test.ts`
- `npm run test:unit -- tests/unit/application-detail-actions.test.ts tests/unit/application-transition-icons.test.ts tests/unit/candidate-detail-drawer.test.ts tests/unit/status-display.test.ts`
- `npm run typecheck`
- `npm run preflight:pr`
