### PR TITLE
test: cover SSO auto-provisioning

### DIFF
--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -14,6 +14,7 @@ import {
   normalizeTrustedOrigin,
   uniqueTrustedOrigins,
 } from "./authOrigins";
+import { createEnterpriseSsoOptions } from "./ssoProvisioning";
 import * as schema from "../database/schema";
 
 type Auth = ReturnType<typeof betterAuth>;
@@ -406,37 +407,34 @@ function getAuth(): Auth {
         // Each organization can register their own Identity Provider (Okta,
         // Azure AD, Google Workspace, etc.). Users are auto-provisioned into
         // the linked organization on first SSO login.
-        sso({
-          // Auto-provision SSO users into the linked organization
-          organizationProvisioning: {
-            disabled: false,
-            defaultRole: "member",
-          },
-          // Run provisioning on every login to keep profile data in sync
-          provisionUserOnEveryLogin: true,
-          provisionUser: async ({ user, userInfo, token, provider }) => {
-            // Sync name/image from IdP on each login
-            const providerName = typeof userInfo.name === "string" ? userInfo.name : null;
-            const providerImage = typeof userInfo.image === "string" ? userInfo.image : null;
-            const microsoftImage = await fetchMicrosoftSsoProfileImage({
-              accessToken: token?.accessToken,
-              providerIssuer: provider.issuer,
-              userId: user.id,
-            });
-            const nextImage = microsoftImage || providerImage;
+        sso(
+          createEnterpriseSsoOptions({
+            provisionUser: async ({ user, userInfo, token, provider }) => {
+              // Sync name/image from IdP on each login
+              const providerName =
+                typeof userInfo.name === "string" ? userInfo.name : null;
+              const providerImage =
+                typeof userInfo.image === "string" ? userInfo.image : null;
+              const microsoftImage = await fetchMicrosoftSsoProfileImage({
+                accessToken: token?.accessToken,
+                providerIssuer: provider.issuer,
+                userId: user.id,
+              });
+              const nextImage = microsoftImage || providerImage;
 
-            if (providerName || nextImage) {
-              await db
-                .update(schema.user)
-                .set({
-                  ...(providerName ? { name: providerName } : {}),
-                  ...(nextImage ? { image: nextImage } : {}),
-                  updatedAt: new Date(),
-                })
-                .where(eq(schema.user.id, user.id));
-            }
-          },
-        }),
+              if (providerName || nextImage) {
+                await db
+                  .update(schema.user)
+                  .set({
+                    ...(providerName ? { name: providerName } : {}),
+                    ...(nextImage ? { image: nextImage } : {}),
+                    updatedAt: new Date(),
+                  })
+                  .where(eq(schema.user.id, user.id));
+              }
+            },
+          }),
+        ),
       ],
     }) as unknown as Auth;
   }

--- a/server/utils/ssoProvisioning.ts
+++ b/server/utils/ssoProvisioning.ts
@@ -1,0 +1,20 @@
+import type { SSOOptions } from "@better-auth/sso";
+
+export const enterpriseSsoOrganizationProvisioning = {
+  disabled: false,
+  defaultRole: "member",
+} as const satisfies NonNullable<SSOOptions["organizationProvisioning"]>;
+
+export const enterpriseSsoProvisionUserOnEveryLogin = true;
+
+export type EnterpriseSsoProvisionUser = NonNullable<SSOOptions["provisionUser"]>;
+
+export function createEnterpriseSsoOptions(
+  options: { provisionUser: EnterpriseSsoProvisionUser },
+): SSOOptions {
+  return {
+    organizationProvisioning: enterpriseSsoOrganizationProvisioning,
+    provisionUserOnEveryLogin: enterpriseSsoProvisionUserOnEveryLogin,
+    provisionUser: options.provisionUser,
+  };
+}

--- a/tests/unit/sso-auth-config.test.ts
+++ b/tests/unit/sso-auth-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { enterpriseSsoOrganizationProvisioning } from '../../server/utils/ssoProvisioning'
 
 /**
  * SSO auth configuration tests.
@@ -147,17 +148,10 @@ describe('SSO profile mapping', () => {
 
 describe('SSO enterprise provisioning config', () => {
   it('configures default member role for auto-provisioned users', () => {
-    // This tests our configuration intent — the actual Better Auth SSO plugin
-    // consumes these values. Documenting them here as executable specs.
-    const provisioningConfig = {
-      disabled: false,
-      defaultRole: 'member',
-    }
-
-    expect(provisioningConfig.disabled).toBe(false)
-    expect(provisioningConfig.defaultRole).toBe('member')
+    expect(enterpriseSsoOrganizationProvisioning.disabled).toBe(false)
+    expect(enterpriseSsoOrganizationProvisioning.defaultRole).toBe('member')
     // Security: new SSO users must NOT be provisioned as admin/owner
-    expect(provisioningConfig.defaultRole).not.toBe('admin')
-    expect(provisioningConfig.defaultRole).not.toBe('owner')
+    expect(enterpriseSsoOrganizationProvisioning.defaultRole).not.toBe('admin')
+    expect(enterpriseSsoOrganizationProvisioning.defaultRole).not.toBe('owner')
   })
 })

--- a/tests/unit/sso-auto-provisioning.test.ts
+++ b/tests/unit/sso-auto-provisioning.test.ts
@@ -1,0 +1,58 @@
+import { sso } from "@better-auth/sso";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createEnterpriseSsoOptions,
+  enterpriseSsoOrganizationProvisioning,
+  enterpriseSsoProvisionUserOnEveryLogin,
+} from "../../server/utils/ssoProvisioning";
+
+describe("enterprise SSO auto-provisioning", () => {
+  it("uses the real app SSO options to auto-provision org members only", () => {
+    const provisionUser = vi.fn();
+    const options = createEnterpriseSsoOptions({ provisionUser });
+
+    expect(options.organizationProvisioning).toEqual({
+      disabled: false,
+      defaultRole: "member",
+    });
+    expect(options.organizationProvisioning?.defaultRole).not.toBe("admin");
+    expect(options.organizationProvisioning?.defaultRole).not.toBe("owner");
+    expect(options.provisionUserOnEveryLogin).toBe(true);
+    expect(options.provisionUser).toBe(provisionUser);
+  });
+
+  it("wires those options into Better Auth SSO callback endpoints", () => {
+    const plugin = sso(createEnterpriseSsoOptions({ provisionUser: vi.fn() }));
+
+    expect(plugin.id).toBe("sso");
+    expect(plugin.endpoints).toHaveProperty("callbackSSO");
+    expect(plugin.endpoints).toHaveProperty("callbackSSOShared");
+    expect(plugin.endpoints).toHaveProperty("callbackSSOSAML");
+  });
+
+  it("keeps app provisioning constants locked to member-only org access", () => {
+    expect(enterpriseSsoOrganizationProvisioning.disabled).toBe(false);
+    expect(enterpriseSsoOrganizationProvisioning.defaultRole).toBe("member");
+    expect(enterpriseSsoProvisionUserOnEveryLogin).toBe(true);
+  });
+
+  it("matches the installed Better Auth SSO contract for SSO-created org membership", () => {
+    const betterAuthSsoSource = readFileSync(
+      join(process.cwd(), "node_modules/@better-auth/sso/dist/index.mjs"),
+      "utf8",
+    );
+
+    expect(betterAuthSsoSource).toContain("async function assignOrganizationFromProvider");
+    expect(betterAuthSsoSource).toContain("if (!provider.organizationId) return");
+    expect(betterAuthSsoSource).toContain("if (provisioningOptions?.disabled) return");
+    expect(betterAuthSsoSource).toContain('model: "member"');
+    expect(betterAuthSsoSource).toContain("organizationId: provider.organizationId");
+    expect(betterAuthSsoSource).toContain("userId: user.id");
+    expect(betterAuthSsoSource).toContain('provisioningOptions?.defaultRole || "member"');
+    expect(betterAuthSsoSource).toContain(
+      "provisioningOptions: options?.organizationProvisioning",
+    );
+  });
+});

--- a/tests/unit/sso-auto-provisioning.test.ts
+++ b/tests/unit/sso-auto-provisioning.test.ts
@@ -1,12 +1,14 @@
 import { sso } from "@better-auth/sso";
+import { createRequire } from "node:module";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   createEnterpriseSsoOptions,
   enterpriseSsoOrganizationProvisioning,
   enterpriseSsoProvisionUserOnEveryLogin,
 } from "../../server/utils/ssoProvisioning";
+
+const require = createRequire(import.meta.url);
 
 describe("enterprise SSO auto-provisioning", () => {
   it("uses the real app SSO options to auto-provision org members only", () => {
@@ -39,20 +41,19 @@ describe("enterprise SSO auto-provisioning", () => {
   });
 
   it("matches the installed Better Auth SSO contract for SSO-created org membership", () => {
-    const betterAuthSsoSource = readFileSync(
-      join(process.cwd(), "node_modules/@better-auth/sso/dist/index.mjs"),
-      "utf8",
-    );
+    const betterAuthSsoSource = readFileSync(require.resolve("@better-auth/sso"), "utf8");
 
-    expect(betterAuthSsoSource).toContain("async function assignOrganizationFromProvider");
-    expect(betterAuthSsoSource).toContain("if (!provider.organizationId) return");
-    expect(betterAuthSsoSource).toContain("if (provisioningOptions?.disabled) return");
-    expect(betterAuthSsoSource).toContain('model: "member"');
-    expect(betterAuthSsoSource).toContain("organizationId: provider.organizationId");
-    expect(betterAuthSsoSource).toContain("userId: user.id");
-    expect(betterAuthSsoSource).toContain('provisioningOptions?.defaultRole || "member"');
-    expect(betterAuthSsoSource).toContain(
-      "provisioningOptions: options?.organizationProvisioning",
+    expect(betterAuthSsoSource).toMatch(/assignOrganizationFromProvider/);
+    expect(betterAuthSsoSource).toMatch(/provider\.organizationId\)\s*return/);
+    expect(betterAuthSsoSource).toMatch(/provisioningOptions\?\.disabled\)\s*return/);
+    expect(betterAuthSsoSource).toMatch(/model:\s*["']member["']/);
+    expect(betterAuthSsoSource).toMatch(/organizationId:\s*provider\.organizationId/);
+    expect(betterAuthSsoSource).toMatch(/userId:\s*user\.id/);
+    expect(betterAuthSsoSource).toMatch(
+      /provisioningOptions\?\.defaultRole\s*\|\|\s*["']member["']/,
+    );
+    expect(betterAuthSsoSource).toMatch(
+      /provisioningOptions:\s*options\?\.organizationProvisioning/,
     );
   });
 });

--- a/tests/unit/sso-security.test.ts
+++ b/tests/unit/sso-security.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { registerSsoSchema } from '../../server/utils/ssoSecurity'
+import { enterpriseSsoOrganizationProvisioning } from '../../server/utils/ssoProvisioning'
 
 /**
  * SSO Security-focused tests.
@@ -169,14 +170,9 @@ describe('SSO organization isolation — cross-org access prevention', () => {
 
 describe('SSO auto-provisioning security', () => {
   it('new SSO users are provisioned with "member" role only', () => {
-    const provisioningConfig = {
-      disabled: false,
-      defaultRole: 'member' as const,
-    }
-
-    expect(provisioningConfig.defaultRole).toBe('member')
-    expect(provisioningConfig.defaultRole).not.toBe('owner')
-    expect(provisioningConfig.defaultRole).not.toBe('admin')
+    expect(enterpriseSsoOrganizationProvisioning.defaultRole).toBe('member')
+    expect(enterpriseSsoOrganizationProvisioning.defaultRole).not.toBe('owner')
+    expect(enterpriseSsoOrganizationProvisioning.defaultRole).not.toBe('admin')
   })
 
   it('provisioned users cannot bypass role hierarchy', () => {


### PR DESCRIPTION
## Summary
- expose the enterprise SSO provisioning options through a tiny pure utility consumed by auth wiring
- add tests that import the real app SSO options and verify member-only provisioning
- add a dependency contract check for Better Auth SSO callback behavior that creates org membership from linked providers

## Verification
- npx vitest run tests/unit/sso-auto-provisioning.test.ts tests/unit/sso-auth-config.test.ts tests/unit/sso-security.test.ts
- npm run test:unit
- npm run typecheck (exits 0; existing Vue resolver warning still prints)
- push preflight: unit tests, typecheck, CLI smoke, production env contract, build
