### PR TITLE
fix: surface action errors as toasts

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -38,12 +38,9 @@ jobs:
 
       - name: Check CLI parity evidence
         id: cli_parity
-        shell: bash
-        run: |
-          set -euo pipefail
-          base_ref="${{ github.base_ref || 'main' }}"
-          git fetch --no-tags --depth=1 origin "$base_ref"
-          git diff --name-only "origin/${base_ref}"...HEAD | npx tsx scripts/cli-parity-check.ts --stdin
+        run: npm run preflight:cli-parity
+        env:
+          PR_PREFLIGHT_BASE_REF: origin/${{ github.base_ref || 'main' }}
 
       - name: Run unit tests
         id: tests

--- a/app/components/ApplyCandidateModal.vue
+++ b/app/components/ApplyCandidateModal.vue
@@ -38,14 +38,13 @@ const { data: candidateData, status: searchStatus } = useFetch('/api/candidates'
 const candidates = computed(() => candidateData.value?.data ?? [])
 const { handlePreviewReadOnlyError } = usePreviewReadOnly()
 const { formatCandidateName } = useOrgSettings()
+const toast = useToast()
 
 // Apply candidate
 const isApplying = ref(false)
-const applyError = ref('')
 
 async function applyCandidate(candidateId: string) {
   isApplying.value = true
-  applyError.value = ''
   try {
     await $fetch('/api/applications', {
       method: 'POST',
@@ -54,7 +53,7 @@ async function applyCandidate(candidateId: string) {
     emit('created')
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
-    applyError.value = err.data?.statusMessage ?? 'Failed to apply candidate'
+    toast.error('Failed to apply candidate', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
   } finally {
     isApplying.value = false
   }
@@ -96,11 +95,6 @@ async function applyCandidate(candidateId: string) {
             reserve-expanded-space
             tone="inverse"
           />
-        </div>
-
-        <!-- Error -->
-        <div v-if="applyError" class="mx-5 mt-3 border border-danger-500/35 bg-danger-950/50 p-3 text-sm leading-6 text-danger-100">
-          {{ applyError }}
         </div>
 
         <!-- Candidate list -->

--- a/app/components/ApplyToJobModal.vue
+++ b/app/components/ApplyToJobModal.vue
@@ -20,14 +20,13 @@ const { data: jobData, status: jobFetchStatus } = useFetch('/api/jobs', {
 
 const jobs = computed(() => jobData.value?.data ?? [])
 const { handlePreviewReadOnlyError } = usePreviewReadOnly()
+const toast = useToast()
 
 // Apply to job
 const isApplying = ref(false)
-const applyError = ref('')
 
 async function applyToJob(jobId: string) {
   isApplying.value = true
-  applyError.value = ''
   try {
     await $fetch('/api/applications', {
       method: 'POST',
@@ -36,7 +35,7 @@ async function applyToJob(jobId: string) {
     emit('created')
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
-    applyError.value = err.data?.statusMessage ?? 'Failed to apply to job'
+    toast.error('Failed to apply to job', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
   } finally {
     isApplying.value = false
   }
@@ -68,11 +67,6 @@ async function applyToJob(jobId: string) {
           >
             <X class="size-4" />
           </button>
-        </div>
-
-        <!-- Error -->
-        <div v-if="applyError" class="ui-alert ui-alert-danger mx-5 mt-5">
-          {{ applyError }}
         </div>
 
         <!-- Job list -->

--- a/app/components/CandidateDetailSidebar.vue
+++ b/app/components/CandidateDetailSidebar.vue
@@ -152,7 +152,6 @@ const { uploadDocument, downloadDocument, getPreviewUrl, deleteDocument } = useD
 const fileInput = ref<HTMLInputElement | null>(null)
 const selectedDocType = ref<'resume' | 'cover_letter' | 'other'>('resume')
 const isUploading = ref(false)
-const uploadError = ref<string | null>(null)
 const showDocDeleteConfirm = ref<string | null>(null)
 const isDeletingDoc = ref(false)
 const reparsingDocId = ref<string | null>(null)
@@ -182,14 +181,13 @@ async function handleFileSelected(event: Event) {
   const file = input.files?.[0]
   if (!file || !candidateId.value) return
 
-  uploadError.value = null
   isUploading.value = true
 
   try {
     await uploadDocument(candidateId.value, file, selectedDocType.value)
     await refreshCandidate()
   } catch (err: any) {
-    uploadError.value = err.data?.statusMessage ?? err.statusMessage ?? 'Upload failed'
+    toast.error('Upload failed', { message: err.data?.statusMessage ?? err.statusMessage, statusCode: err.data?.statusCode ?? err.statusCode })
   } finally {
     isUploading.value = false
     input.value = ''
@@ -386,7 +384,6 @@ watch(activeTab, (tab) => {
 watch(() => props.applicationId, () => {
   isEditingNotes.value = false
   activeTab.value = 'overview'
-  uploadError.value = null
   showDocDeleteConfirm.value = null
   timelineItems.value = []
   timelineLoaded.value = false
@@ -856,15 +853,6 @@ function formatInterviewDate(dateStr: string) {
                   <Upload class="size-3.5" />
                   {{ isUploading ? 'Uploading…' : 'Upload Document' }}
                 </button>
-              </div>
-
-              <!-- Upload error -->
-              <div
-                v-if="uploadError"
-                class="ui-alert ui-alert-danger p-3 text-sm"
-              >
-                {{ uploadError }}
-                <button class="ui-inline-link-brand ml-1" @click="uploadError = null">Dismiss</button>
               </div>
 
               <!-- Empty state -->

--- a/app/components/FeedbackModal.vue
+++ b/app/components/FeedbackModal.vue
@@ -5,6 +5,8 @@ const emit = defineEmits<{
   (e: 'close'): void
 }>()
 
+const toast = useToast()
+
 // ── Form state ────────────────────────────────
 const feedbackType = ref<'bug' | 'feature'>('bug')
 const title = ref('')
@@ -190,7 +192,7 @@ async function handleSubmit() {
     })
     successUrl.value = result.issueUrl
   } catch (err: any) {
-    submitError.value = err.data?.statusMessage ?? 'Failed to submit feedback. Please try again.'
+    toast.error('Failed to submit feedback', { message: err.data?.statusMessage ?? 'Please try again.', statusCode: err.data?.statusCode })
   } finally {
     isSubmitting.value = false
   }

--- a/app/components/InterviewEmailModal.vue
+++ b/app/components/InterviewEmailModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import {
   X, Mail, Send, ChevronDown, Eye, Pencil, FileText,
-  Check, AlertCircle, Plus, Trash2, Save, Sparkles,
+  Check, Plus, Trash2, Save, Sparkles,
 } from 'lucide-vue-next'
 import type { Interview } from '~/composables/useInterviews'
 import type { EmailTemplate } from '~/composables/useEmailTemplates'
@@ -15,6 +15,7 @@ const emit = defineEmits<{
   sent: []
 }>()
 
+const toast = useToast()
 const { templates, createTemplate, deleteTemplate, sendInvitation } = useEmailTemplates()
 const { formatPersonName } = useOrgSettings()
 
@@ -26,7 +27,6 @@ const activeTab = ref<Tab>('template')
 const selectedTemplateId = ref<string>('system-standard')
 const showPreview = ref(false)
 const isSending = ref(false)
-const sendError = ref('')
 const sendSuccess = ref(false)
 
 // Custom email state
@@ -39,7 +39,6 @@ const newTemplateName = ref('')
 const newTemplateSubject = ref('')
 const newTemplateBody = ref('')
 const isSavingTemplate = ref(false)
-const templateSaveError = ref('')
 
 // ─── Computed ─────────────────────────────────────────────────────
 const allTemplates = computed(() => [
@@ -88,7 +87,6 @@ const previewBody = computed(() => {
 
 // ─── Actions ──────────────────────────────────────────────────────
 async function handleSend() {
-  sendError.value = ''
   isSending.value = true
 
   try {
@@ -100,16 +98,15 @@ async function handleSend() {
     sendSuccess.value = true
     setTimeout(() => emit('sent'), 1500)
   } catch (err: any) {
-    sendError.value = err?.data?.statusMessage ?? err?.message ?? 'Failed to send invitation email'
+    toast.error('Failed to send invitation email', { message: err?.data?.statusMessage ?? err?.message, statusCode: err?.data?.statusCode })
   } finally {
     isSending.value = false
   }
 }
 
 async function handleSaveTemplate() {
-  templateSaveError.value = ''
   if (!newTemplateName.value.trim() || !newTemplateSubject.value.trim() || !newTemplateBody.value.trim()) {
-    templateSaveError.value = 'All fields are required'
+    toast.error('All fields are required')
     return
   }
 
@@ -125,7 +122,7 @@ async function handleSaveTemplate() {
     newTemplateSubject.value = ''
     newTemplateBody.value = ''
   } catch (err: any) {
-    templateSaveError.value = err?.data?.statusMessage ?? 'Failed to save template'
+    toast.error('Failed to save template', { message: err?.data?.statusMessage, statusCode: err?.data?.statusCode })
   } finally {
     isSavingTemplate.value = false
   }
@@ -218,12 +215,6 @@ const canSend = computed(() => {
                 {{ tab.label }}
               </button>
             </div>
-          </div>
-
-          <!-- Error -->
-          <div v-if="sendError" class="ui-alert ui-alert-danger mx-4 sm:mx-6 mt-4 flex items-start gap-2.5">
-            <AlertCircle class="size-4 shrink-0 mt-0.5" />
-            {{ sendError }}
           </div>
 
           <!-- Tab content -->
@@ -367,9 +358,6 @@ const canSend = computed(() => {
               <!-- New template form -->
               <div v-if="showNewTemplateForm" class="ui-panel-muted ui-email-modal-template-form">
                 <h4 class="text-sm font-semibold text-surface-800 dark:text-surface-200">Create Template</h4>
-                <div v-if="templateSaveError" class="ui-alert ui-alert-danger p-2.5 text-xs">
-                  {{ templateSaveError }}
-                </div>
                 <input
                   v-model="newTemplateName"
                   type="text"

--- a/app/components/InterviewScheduleSidebar.vue
+++ b/app/components/InterviewScheduleSidebar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import {
   X, Calendar, Clock, MapPin, Users, ChevronLeft, ChevronRight,
-  Plus, AlertCircle, Mail, ChevronDown, RefreshCw, Globe,
+  Plus, Mail, ChevronDown, RefreshCw, Globe,
   Send, UserPlus, Bell, Pencil, CheckCircle2, ExternalLink,
   ArrowRight, Eye, Video,
 } from 'lucide-vue-next'
@@ -21,6 +21,8 @@ const emit = defineEmits<{
   close: []
   scheduled: [createdInterview?: { id: string; googleCalendarEventLink?: string | null }]
 }>()
+
+const toast = useToast()
 
 // ─── Success state ────────────────────────────────────────────────
 const showSuccess = ref(false)
@@ -386,7 +388,7 @@ async function handleSubmit() {
       // Non-critical; the success view is already shown.
     })
   } catch (err: any) {
-    errors.value.submit = err?.data?.statusMessage ?? 'Failed to schedule interview'
+    toast.error('Failed to schedule interview', { message: err?.data?.statusMessage, statusCode: err?.data?.statusCode })
   } finally {
     isSubmitting.value = false
   }
@@ -405,7 +407,7 @@ async function handleMoveToInterview() {
     refreshNuxtData('interviews').catch(() => {})
     emit('scheduled')
   } catch (err: any) {
-    errors.value.submit = err?.data?.statusMessage ?? 'Failed to move to interview stage'
+    toast.error('Failed to move to interview stage', { message: err?.data?.statusMessage, statusCode: err?.data?.statusCode })
   } finally {
     isMoving.value = false
   }
@@ -561,12 +563,6 @@ async function handleMoveToInterview() {
           <template v-else>
           <!-- Form content -->
           <div class="flex-1 overflow-y-auto px-6 py-5 space-y-5">
-            <!-- Error banner -->
-            <div v-if="errors.submit" class="flex items-start gap-2.5 rounded-xl border border-danger-200/60 bg-danger-50/80 p-3.5 text-sm text-danger-700 dark:border-danger-800/40 dark:bg-danger-950/30 dark:text-danger-300">
-              <AlertCircle class="size-4 shrink-0 mt-0.5" />
-              {{ errors.submit }}
-            </div>
-
             <!-- Candidate notification -->
             <div>
               <label class="block text-[13px] font-medium text-surface-700 dark:text-surface-300 mb-2.5">

--- a/app/components/JobQuestions.vue
+++ b/app/components/JobQuestions.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
 
 const { questions, status, addQuestion, updateQuestion, deleteQuestion, reorderQuestions } =
   useJobQuestions(props.jobId)
+const toast = useToast()
 
 // ─────────────────────────────────────────────
 // Add / Edit state
@@ -23,7 +24,6 @@ const editingQuestion = ref<{
 } | null>(null)
 
 const isSubmitting = ref(false)
-const actionError = ref<string | null>(null)
 
 async function handleAdd(data: {
   label: string
@@ -33,7 +33,6 @@ async function handleAdd(data: {
   options?: string[]
 }) {
   isSubmitting.value = true
-  actionError.value = null
   try {
     // Set displayOrder to the end of the list
     await addQuestion({
@@ -42,7 +41,7 @@ async function handleAdd(data: {
     })
     showAddForm.value = false
   } catch (err: any) {
-    actionError.value = err.data?.statusMessage ?? 'Failed to add question'
+    toast.error('Failed to add question', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
   } finally {
     isSubmitting.value = false
   }
@@ -57,12 +56,11 @@ async function handleUpdate(data: {
 }) {
   if (!editingQuestion.value) return
   isSubmitting.value = true
-  actionError.value = null
   try {
     await updateQuestion(editingQuestion.value.id, data)
     editingQuestion.value = null
   } catch (err: any) {
-    actionError.value = err.data?.statusMessage ?? 'Failed to update question'
+    toast.error('Failed to update question', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
   } finally {
     isSubmitting.value = false
   }
@@ -76,11 +74,10 @@ const deletingId = ref<string | null>(null)
 
 async function handleDelete(questionId: string) {
   deletingId.value = questionId
-  actionError.value = null
   try {
     await deleteQuestion(questionId)
   } catch (err: any) {
-    actionError.value = err.data?.statusMessage ?? 'Failed to delete question'
+    toast.error('Failed to delete question', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
   } finally {
     deletingId.value = null
   }
@@ -106,7 +103,7 @@ async function moveQuestion(index: number, direction: 'up' | 'down') {
   try {
     await reorderQuestions(order)
   } catch (err: any) {
-    actionError.value = err.data?.statusMessage ?? 'Failed to reorder questions'
+    toast.error('Failed to reorder questions', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
   }
 }
 
@@ -129,15 +126,6 @@ const typeLabels: Record<string, string> = {
 
 <template>
   <div>
-    <!-- Error banner -->
-    <div
-      v-if="actionError"
-      class="ui-alert ui-alert-danger mb-4"
-    >
-      {{ actionError }}
-      <button class="ml-2 underline" @click="actionError = null">Dismiss</button>
-    </div>
-
     <!-- Loading -->
     <div v-if="status === 'pending'" class="text-sm text-surface-400 py-4">
       Loading questions…

--- a/app/components/PropertySchemaEditor.vue
+++ b/app/components/PropertySchemaEditor.vue
@@ -147,7 +147,7 @@ async function submitForm() {
     const message = (err as { data?: { statusMessage?: string }; statusMessage?: string })?.data?.statusMessage
       ?? (err as { statusMessage?: string }).statusMessage
       ?? 'Failed to save property'
-    formError.value = message
+    toast.error('Failed to save property', { message })
   } finally {
     isSaving.value = false
   }

--- a/app/components/ScoreBreakdown.vue
+++ b/app/components/ScoreBreakdown.vue
@@ -20,6 +20,7 @@ const emit = defineEmits<{
 }>()
 
 const { track } = useTrack()
+const toast = useToast()
 const isAnalyzing = ref(false)
 const analyzeError = ref<string | null>(null)
 const parseFailedDocId = ref<string | null>(null)
@@ -106,8 +107,10 @@ async function runAnalysis() {
     const data = err?.data?.data
     if (data?.code === 'PARSE_FAILED' && data?.documentId) {
       parseFailedDocId.value = data.documentId
+      analyzeError.value = err?.data?.statusMessage ?? 'Analysis failed because the resume could not be parsed.'
+    } else {
+      toast.error('Analysis failed', { message: err?.data?.statusMessage ?? 'Make sure AI is configured in settings.', statusCode: err?.data?.statusCode })
     }
-    analyzeError.value = err?.data?.statusMessage ?? 'Analysis failed. Make sure AI is configured in settings.'
   } finally {
     isAnalyzing.value = false
   }
@@ -126,7 +129,7 @@ async function retryParse() {
     // Automatically re-run analysis after successful parse
     await runAnalysis()
   } catch (err: any) {
-    analyzeError.value = err?.data?.statusMessage ?? 'Failed to re-parse the resume. The file may be corrupted or image-based.'
+    toast.error('Failed to re-parse resume', { message: err?.data?.statusMessage ?? 'The file may be corrupted or image-based.', statusCode: err?.data?.statusCode })
     parseFailedDocId.value = null
   } finally {
     isRetryingParse.value = false

--- a/app/pages/dashboard/candidates/[id].vue
+++ b/app/pages/dashboard/candidates/[id].vue
@@ -158,7 +158,6 @@ const { uploadDocument, downloadDocument, getPreviewUrl, deleteDocument } = useD
 const fileInput = ref<HTMLInputElement | null>(null)
 const selectedDocType = ref<'resume' | 'cover_letter' | 'other'>('resume')
 const isUploading = ref(false)
-const uploadError = ref<string | null>(null)
 const showDocDeleteConfirm = ref<string | null>(null)
 const isDeletingDoc = ref(false)
 const documentPreview = useDocumentPreview({
@@ -185,14 +184,13 @@ async function handleFileSelected(event: Event) {
   const file = input.files?.[0]
   if (!file) return
 
-  uploadError.value = null
   isUploading.value = true
 
   try {
     await uploadDocument(candidateId, file, selectedDocType.value)
   } catch (err: any) {
     const msg = err.data?.statusMessage ?? err.statusMessage ?? 'Upload failed'
-    uploadError.value = msg
+    toast.error('Upload failed', { message: msg, statusCode: err.data?.statusCode ?? err.statusCode })
   } finally {
     isUploading.value = false
     // Reset input so the same file can be re-selected
@@ -364,15 +362,6 @@ async function handleDeleteDoc(docId: string) {
               </div>
             </template>
 
-            <template #error>
-              <div
-                v-if="uploadError"
-                class="mb-3 border border-danger-500/45 bg-danger-500/10 p-3 text-sm text-danger-100"
-              >
-                {{ uploadError }}
-                <button class="ml-1 cursor-pointer underline transition-colors hover:text-white" @click="uploadError = null">Dismiss</button>
-              </div>
-            </template>
           </CandidateDocumentsPanel>
 
           <!-- Document delete confirmation dialog -->

--- a/app/pages/dashboard/candidates/new.vue
+++ b/app/pages/dashboard/candidates/new.vue
@@ -17,6 +17,7 @@ useSeoMeta({
 const localePath = useLocalePath()
 const { createCandidate } = useCandidates()
 const { track } = useTrack()
+const toast = useToast()
 
 // Form state
 const form = ref({
@@ -31,7 +32,6 @@ const form = ref({
 
 const isSubmitting = ref(false)
 const errors = ref<Record<string, string>>({})
-const submitError = ref<string | null>(null)
 
 function validate(): boolean {
   const result = candidateFormSchema.safeParse(normalizeEmptyCandidateFormFields(form.value))
@@ -48,7 +48,6 @@ function validate(): boolean {
 }
 
 async function handleSubmit() {
-  submitError.value = null
   if (!validate()) return
 
   isSubmitting.value = true
@@ -70,7 +69,7 @@ async function handleSubmit() {
     if (err.statusCode === 409 || err.data?.statusCode === 409) {
       errors.value.email = message
     } else {
-      submitError.value = message
+      toast.error('Failed to add candidate', { message, statusCode: err.data?.statusCode ?? err.statusCode })
     }
   } finally {
     isSubmitting.value = false
@@ -89,14 +88,6 @@ async function handleSubmit() {
     </AppBackLink>
 
     <h1 class="text-2xl font-bold text-surface-900 dark:text-surface-100 mb-6">Add Candidate</h1>
-
-    <!-- Server error -->
-    <div
-      v-if="submitError"
-      class="rounded-lg border border-danger-200 dark:border-danger-800 bg-danger-50 dark:bg-danger-950 p-3 text-sm text-danger-700 dark:text-danger-400 mb-4"
-    >
-      {{ submitError }}
-    </div>
 
     <form class="space-y-5" @submit.prevent="handleSubmit">
       <!-- First Name -->

--- a/app/pages/dashboard/interviews/[id].vue
+++ b/app/pages/dashboard/interviews/[id].vue
@@ -4,7 +4,7 @@ import {
   FileText, UsersRound, CheckCircle2, XCircle, AlertTriangle,
   UserRound, Briefcase, Pencil, MapPin, Users, MessageSquare,
   Save, X, Mail, Send, CheckCheck, ChevronDown, ExternalLink,
-  Check, AlertCircle,
+  Check,
 } from 'lucide-vue-next'
 import {
   getInterviewStatusBadgeClass,
@@ -148,7 +148,6 @@ const rescheduleForm = reactive({
   duration: 60,
 })
 const isRescheduling = ref(false)
-const rescheduleError = ref('')
 
 function openReschedule() {
   if (!interview.value) return
@@ -156,14 +155,12 @@ function openReschedule() {
   rescheduleForm.date = d.toISOString().slice(0, 10)
   rescheduleForm.time = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
   rescheduleForm.duration = interview.value.duration
-  rescheduleError.value = ''
   showReschedule.value = true
 }
 
 async function handleReschedule() {
-  rescheduleError.value = ''
   if (!rescheduleForm.date || !rescheduleForm.time) {
-    rescheduleError.value = 'Date and time are required'
+    toast.error('Date and time required')
     return
   }
 
@@ -178,7 +175,7 @@ async function handleReschedule() {
     showReschedule.value = false
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
-    rescheduleError.value = err.data?.statusMessage ?? 'Failed to reschedule'
+    toast.error('Failed to reschedule', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
   } finally {
     isRescheduling.value = false
   }
@@ -224,7 +221,7 @@ async function handleSaveDetails() {
     showEditDetails.value = false
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
-    editErrors.value.submit = err.data?.statusMessage ?? 'Failed to update'
+    toast.error('Failed to update interview', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
   } finally {
     isSavingEdit.value = false
   }
@@ -252,7 +249,6 @@ async function handleDelete() {
 const showSendInvitation = ref(false)
 const selectedTemplateId = ref<string>('system-standard')
 const isSendingEmail = ref(false)
-const sendEmailError = ref('')
 const sendEmailSuccess = ref(false)
 const showEmailPreview = ref(false)
 
@@ -302,7 +298,6 @@ const emailPreviewBody = computed(() =>
 )
 
 async function handleSendInvitation() {
-  sendEmailError.value = ''
   isSendingEmail.value = true
   try {
     await sendInvitation(interviewId, { templateId: selectedTemplateId.value })
@@ -314,7 +309,7 @@ async function handleSendInvitation() {
     }, 2000)
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
-    sendEmailError.value = err?.data?.statusMessage ?? err?.message ?? 'Failed to send invitation'
+    toast.error('Failed to send invitation', { message: err?.data?.statusMessage ?? err?.message, statusCode: err?.data?.statusCode })
   } finally {
     isSendingEmail.value = false
   }
@@ -506,12 +501,6 @@ const localePath = useLocalePath()
                   <X class="size-4" />
                 </button>
               </div>
-            </div>
-
-            <!-- Error -->
-            <div v-if="sendEmailError" class="mx-5 mt-4 flex items-start gap-2.5 rounded-xl border border-danger-200/80 bg-danger-50 p-3.5 text-sm text-danger-700 dark:border-danger-800/60 dark:bg-danger-950/40 dark:text-danger-300">
-              <AlertCircle class="size-4 shrink-0 mt-0.5" />
-              {{ sendEmailError }}
             </div>
 
             <!-- Template selection -->
@@ -857,10 +846,6 @@ const localePath = useLocalePath()
         <div class="ui-modal-panel relative w-full max-w-md p-6">
           <h3 class="text-lg font-semibold text-surface-900 dark:text-surface-100 mb-4">Reschedule Interview</h3>
 
-          <div v-if="rescheduleError" class="mb-4 rounded-lg border border-danger-200 bg-danger-50 p-3 text-sm text-danger-700 dark:border-danger-800 dark:bg-danger-950/40 dark:text-danger-300">
-            {{ rescheduleError }}
-          </div>
-
           <form class="space-y-4" @submit.prevent="handleReschedule">
             <div>
               <label for="reschedule-date" class="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-1">
@@ -922,10 +907,6 @@ const localePath = useLocalePath()
       <div v-if="showEditDetails" class="factory-dashboard-portal ui-modal-backdrop fixed inset-0 z-50 flex items-center justify-center p-4" @click.self="showEditDetails = false">
         <div class="ui-modal-panel relative w-full max-w-lg max-h-[90vh] overflow-y-auto p-6">
           <h3 class="text-lg font-semibold text-surface-900 dark:text-surface-100 mb-5">Edit Interview Details</h3>
-
-          <div v-if="editErrors.submit" class="mb-4 rounded-lg border border-danger-200 bg-danger-50 p-3 text-sm text-danger-700 dark:border-danger-800 dark:bg-danger-950/40 dark:text-danger-300">
-            {{ editErrors.submit }}
-          </div>
 
           <form class="space-y-4" @submit.prevent="handleSaveDetails">
             <div>

--- a/app/pages/dashboard/interviews/index.vue
+++ b/app/pages/dashboard/interviews/index.vue
@@ -216,7 +216,7 @@ async function handleSaveEdit() {
     editingInterview.value = null
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
-    editErrors.value.submit = err?.data?.statusMessage ?? 'Failed to update interview'
+    toast.error('Failed to update interview', { message: err?.data?.statusMessage, statusCode: err?.data?.statusCode })
   } finally {
     isSaving.value = false
   }
@@ -685,10 +685,6 @@ const statusCounts = computed(() => {
         <div class="ui-modal-backdrop absolute inset-0" @click="cancelEdit" />
         <div class="ui-modal-panel relative p-6 max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto">
           <h3 class="text-lg font-semibold text-surface-900 dark:text-surface-100 mb-5">Edit Interview</h3>
-
-          <div v-if="editErrors.submit" class="ui-alert-danger mb-4 p-3 text-sm">
-            {{ editErrors.submit }}
-          </div>
 
           <form class="space-y-4" @submit.prevent="handleSaveEdit">
             <div>

--- a/app/pages/dashboard/interviews/templates/[id].vue
+++ b/app/pages/dashboard/interviews/templates/[id].vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import {
   Save, Eye, EyeOff, Copy, Trash2, Lock,
-  FileText, Mail, AlertCircle,
+  FileText, Mail,
 } from 'lucide-vue-next'
 
 definePageMeta({
@@ -13,6 +13,7 @@ const route = useRoute()
 const localePath = useLocalePath()
 const templateId = route.params.id as string
 const { handlePreviewReadOnlyError } = usePreviewReadOnly()
+const toast = useToast()
 
 const isSystemTemplate = computed(() => templateId.startsWith('system-'))
 
@@ -61,14 +62,12 @@ watchEffect(() => {
 
 // ─── Save ────────────────────────────────────────────────────────
 const isSaving = ref(false)
-const saveError = ref('')
 const saveSuccess = ref(false)
 
 async function handleSave() {
   if (isSystemTemplate.value) return
-  saveError.value = ''
   if (!form.name.trim() || !form.subject.trim() || !form.body.trim()) {
-    saveError.value = 'All fields are required'
+    toast.error('All fields are required')
     return
   }
 
@@ -84,7 +83,7 @@ async function handleSave() {
     setTimeout(() => { saveSuccess.value = false }, 2000)
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
-    saveError.value = err?.data?.statusMessage ?? 'Failed to save template'
+    toast.error('Failed to save template', { message: err?.data?.statusMessage, statusCode: err?.data?.statusCode })
   } finally {
     isSaving.value = false
   }
@@ -104,7 +103,7 @@ async function handleDuplicate() {
     await navigateTo(localePath(`/dashboard/interviews/templates/${(created as any).id}`))
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
-    saveError.value = err?.data?.statusMessage ?? 'Failed to duplicate template'
+    toast.error('Failed to duplicate template', { message: err?.data?.statusMessage, statusCode: err?.data?.statusCode })
   } finally {
     isDuplicating.value = false
   }
@@ -121,7 +120,7 @@ async function handleDelete() {
     await navigateTo(localePath('/dashboard/interviews/templates'))
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
-    saveError.value = err?.data?.statusMessage ?? 'Failed to delete template'
+    toast.error('Failed to delete template', { message: err?.data?.statusMessage, statusCode: err?.data?.statusCode })
   } finally {
     isDeleting.value = false
   }
@@ -238,12 +237,6 @@ useSeoMeta({
             </button>
           </template>
         </div>
-      </div>
-
-      <!-- Error -->
-      <div v-if="saveError" class="mb-6 flex items-start gap-2.5 rounded-xl border border-danger-200/80 bg-danger-50 p-4 text-sm text-danger-700 dark:border-danger-800/60 dark:bg-danger-950/40 dark:text-danger-300">
-        <AlertCircle class="size-4 shrink-0 mt-0.5" />
-        {{ saveError }}
       </div>
 
       <div class="grid gap-6" :class="showPreview ? 'lg:grid-cols-2' : 'lg:grid-cols-[1fr_320px]'">

--- a/app/pages/dashboard/interviews/templates/index.vue
+++ b/app/pages/dashboard/interviews/templates/index.vue
@@ -19,6 +19,7 @@ const localePath = useLocalePath()
 
 const { templates, status: fetchStatus, deleteTemplate } = useEmailTemplates()
 const { handlePreviewReadOnlyError } = usePreviewReadOnly()
+const toast = useToast()
 
 const deletingId = ref<string | null>(null)
 const showDeleteConfirm = ref(false)
@@ -35,7 +36,8 @@ async function handleDelete() {
   try {
     await deleteTemplate(templateToDelete.value.id)
   } catch (err: any) {
-    handlePreviewReadOnlyError(err)
+    if (handlePreviewReadOnlyError(err)) return
+    toast.error('Failed to delete template', { message: err?.data?.statusMessage, statusCode: err?.data?.statusCode })
   } finally {
     deletingId.value = null
     showDeleteConfirm.value = false

--- a/app/pages/dashboard/interviews/templates/new.vue
+++ b/app/pages/dashboard/interviews/templates/new.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {
-  Save, Eye, EyeOff, Mail, AlertCircle, FileText,
+  Save, Eye, EyeOff, Mail, FileText,
 } from 'lucide-vue-next'
 
 definePageMeta({
@@ -17,6 +17,7 @@ useSeoMeta({
 const localePath = useLocalePath()
 const { createTemplate } = useEmailTemplates()
 const { handlePreviewReadOnlyError } = usePreviewReadOnly()
+const toast = useToast()
 
 // ─── Form state ──────────────────────────────────────────────────
 const form = reactive({
@@ -27,7 +28,6 @@ const form = reactive({
 
 const showPreview = ref(false)
 const isSaving = ref(false)
-const saveError = ref('')
 
 const canSave = computed(() =>
   form.name.trim().length > 0
@@ -57,9 +57,8 @@ const previewBody = computed(() => renderTemplatePreview(form.body, sampleVariab
 
 // ─── Save ────────────────────────────────────────────────────────
 async function handleCreate() {
-  saveError.value = ''
   if (!canSave.value) {
-    saveError.value = 'All fields are required'
+    toast.error('All fields are required')
     return
   }
 
@@ -73,7 +72,7 @@ async function handleCreate() {
     await navigateTo(localePath(`/dashboard/interviews/templates/${(created as any).id}`))
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
-    saveError.value = err?.data?.statusMessage ?? 'Failed to create template'
+    toast.error('Failed to create template', { message: err?.data?.statusMessage, statusCode: err?.data?.statusCode })
   } finally {
     isSaving.value = false
   }
@@ -122,12 +121,6 @@ async function handleCreate() {
           {{ isSaving ? 'Creating…' : 'Create Template' }}
         </button>
       </div>
-    </div>
-
-    <!-- Error -->
-    <div v-if="saveError" class="ui-alert-danger mb-6 flex items-start gap-2.5 rounded-xl p-4 text-sm">
-      <AlertCircle class="size-4 shrink-0 mt-0.5" />
-      {{ saveError }}
     </div>
 
     <div class="grid gap-6" :class="showPreview ? 'lg:grid-cols-2' : 'lg:grid-cols-[1fr_320px]'">

--- a/app/pages/dashboard/interviews/templates/new.vue
+++ b/app/pages/dashboard/interviews/templates/new.vue
@@ -28,6 +28,7 @@ const form = reactive({
 
 const showPreview = ref(false)
 const isSaving = ref(false)
+const validationError = ref('')
 
 const canSave = computed(() =>
   form.name.trim().length > 0
@@ -57,8 +58,10 @@ const previewBody = computed(() => renderTemplatePreview(form.body, sampleVariab
 
 // ─── Save ────────────────────────────────────────────────────────
 async function handleCreate() {
+  validationError.value = ''
+
   if (!canSave.value) {
-    toast.error('All fields are required')
+    validationError.value = 'All fields are required.'
     return
   }
 
@@ -122,6 +125,10 @@ async function handleCreate() {
         </button>
       </div>
     </div>
+
+    <p v-if="validationError" class="ui-alert ui-alert-danger mb-5 text-sm">
+      {{ validationError }}
+    </p>
 
     <div class="grid gap-6" :class="showPreview ? 'lg:grid-cols-2' : 'lg:grid-cols-[1fr_320px]'">
       <!-- Editor panel -->

--- a/app/pages/dashboard/jobs/[id]/application-form.vue
+++ b/app/pages/dashboard/jobs/[id]/application-form.vue
@@ -206,14 +206,12 @@ const requireResume = ref(false)
 const requireCoverLetter = ref(false)
 const isSavingRequirements = ref(false)
 const requirementsSaved = ref(false)
-const requirementsError = ref<string | null>(null)
 const applicationComplianceEnabled = ref(true)
 const includeEeo = ref(true)
 const includeVeteran = ref(true)
 const includeDisability = ref(true)
 const isSavingCompliance = ref(false)
 const complianceSaved = ref(false)
-const complianceError = ref<string | null>(null)
 const previewComplianceEnabled = computed(() =>
   applicationComplianceEnabled.value && (includeEeo.value || includeVeteran.value || includeDisability.value),
 )
@@ -232,13 +230,12 @@ watch(job, (j) => {
 
 async function saveRequirements() {
   isSavingRequirements.value = true
-  requirementsError.value = null
   try {
     await updateJob({ requireResume: requireResume.value, requireCoverLetter: requireCoverLetter.value })
     requirementsSaved.value = true
     setTimeout(() => { requirementsSaved.value = false }, 2000)
   } catch (err: any) {
-    requirementsError.value = err?.data?.statusMessage ?? 'Failed to save requirements.'
+    toast.error('Failed to save requirements', { message: err?.data?.statusMessage, statusCode: err?.data?.statusCode })
   } finally {
     isSavingRequirements.value = false
   }
@@ -246,7 +243,6 @@ async function saveRequirements() {
 
 async function saveComplianceQuestions() {
   isSavingCompliance.value = true
-  complianceError.value = null
   try {
     await updateJob({
       applicationComplianceEnabled: applicationComplianceEnabled.value,
@@ -257,7 +253,7 @@ async function saveComplianceQuestions() {
     complianceSaved.value = true
     setTimeout(() => { complianceSaved.value = false }, 2000)
   } catch (err: any) {
-    complianceError.value = err?.data?.statusMessage ?? 'Failed to save compliance questions.'
+    toast.error('Failed to save compliance questions', { message: err?.data?.statusMessage, statusCode: err?.data?.statusCode })
   } finally {
     isSavingCompliance.value = false
   }
@@ -682,9 +678,6 @@ async function copyTrackingUrl(code: string) {
         >
           {{ requirementsSaved ? 'Saved!' : isSavingRequirements ? 'Saving…' : 'Save requirements' }}
         </button>
-        <p v-if="requirementsError" class="mt-2 text-xs text-danger-600 dark:text-danger-400">
-          {{ requirementsError }}
-        </p>
       </div>
 
       <!-- Compliance Questions -->
@@ -766,9 +759,6 @@ async function copyTrackingUrl(code: string) {
         >
           {{ complianceSaved ? 'Saved!' : isSavingCompliance ? 'Saving...' : 'Save compliance questions' }}
         </button>
-        <p v-if="complianceError" class="mt-2 text-xs text-danger-600 dark:text-danger-400">
-          {{ complianceError }}
-        </p>
       </div>
 
       <!-- Application Form Questions -->

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -713,7 +713,6 @@ const rescheduleForm = reactive({
   duration: 60,
 })
 const isRescheduling = ref(false)
-const rescheduleError = ref('')
 
 function toggleInterviewExpand(id: string) {
   if (expandedInterviewId.value === id) {
@@ -774,7 +773,7 @@ async function saveInterviewEdit() {
     await refreshJobInterviews()
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
-    interviewEditErrors.value.submit = err?.data?.statusMessage ?? 'Failed to save changes'
+    toast.error('Failed to save changes', { message: err?.data?.statusMessage, statusCode: err?.data?.statusCode })
   } finally {
     isInterviewSaving.value = false
   }
@@ -802,18 +801,15 @@ function openReschedule(iv: Interview) {
   rescheduleForm.date = d.toISOString().slice(0, 10)
   rescheduleForm.time = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
   rescheduleForm.duration = iv.duration
-  rescheduleError.value = ''
 }
 
 function cancelReschedule() {
   rescheduleInterviewId.value = null
-  rescheduleError.value = ''
 }
 
 async function handleReschedule() {
-  rescheduleError.value = ''
   if (!rescheduleForm.date || !rescheduleForm.time) {
-    rescheduleError.value = 'Date and time are required'
+    toast.error('Date and time required')
     return
   }
 
@@ -832,7 +828,7 @@ async function handleReschedule() {
     await refreshJobInterviews()
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
-    rescheduleError.value = err?.data?.statusMessage ?? 'Failed to reschedule'
+    toast.error('Failed to reschedule', { message: err?.data?.statusMessage, statusCode: err?.data?.statusCode })
   } finally {
     isRescheduling.value = false
   }
@@ -1738,7 +1734,6 @@ function closeDocPreview() {
                             />
                           </div>
                         </div>
-                        <p v-if="rescheduleError" class="mt-2 text-xs text-danger-600 dark:text-danger-400">{{ rescheduleError }}</p>
                         <div class="flex items-center justify-end gap-2 mt-3">
                           <button
                             class="cursor-pointer rounded-lg border border-surface-300 dark:border-surface-700 px-3 py-1.5 text-xs font-medium text-surface-700 dark:text-surface-300 hover:bg-surface-50 dark:hover:bg-surface-800 transition-colors"
@@ -1921,8 +1916,6 @@ function closeDocPreview() {
                                 Add interviewer
                               </button>
                             </div>
-
-                            <p v-if="interviewEditErrors.submit" class="text-xs text-danger-600 dark:text-danger-400">{{ interviewEditErrors.submit }}</p>
 
                             <div class="flex items-center justify-end gap-2 pt-2">
                               <button

--- a/app/pages/dashboard/jobs/new.vue
+++ b/app/pages/dashboard/jobs/new.vue
@@ -263,7 +263,6 @@ const isSubmitting = ref(false)
 const errors = ref<Record<string, string>>({})
 const showAddForm = ref(false)
 const editingQuestion = ref<DraftQuestion | null>(null)
-const questionActionError = ref<string | null>(null)
 const nextQuestionId = ref(1)
 
 // Check if at least one AI provider is configured with a valid API key.
@@ -562,7 +561,6 @@ function handleAddQuestion(data: {
     options: data.options ?? null,
   })
   showAddForm.value = false
-  questionActionError.value = null
 }
 
 function handleUpdateQuestion(data: {
@@ -589,7 +587,6 @@ function handleUpdateQuestion(data: {
     options: data.options ?? null,
   }
   editingQuestion.value = null
-  questionActionError.value = null
 }
 
 function handleDeleteQuestion(questionId: string) {
@@ -599,7 +596,6 @@ function handleDeleteQuestion(questionId: string) {
   if (editingQuestion.value?.id === questionId) {
     editingQuestion.value = null
   }
-  questionActionError.value = null
 }
 
 function moveQuestion(index: number, direction: 'up' | 'down') {
@@ -1049,14 +1045,6 @@ const questionTypeLabels: Record<QuestionType, string> = {
                   <span v-if="applicationForm.questions.length > 0" class="text-xs font-medium text-surface-400 dark:text-surface-500 tabular-nums">
                     {{ applicationForm.questions.length }} {{ applicationForm.questions.length === 1 ? 'question' : 'questions' }} added
                   </span>
-                </div>
-
-                <div
-                  v-if="questionActionError"
-                  class="rounded-lg border border-danger-200 dark:border-danger-800 bg-danger-50 dark:bg-danger-950 p-3 text-sm text-danger-700 dark:text-danger-400 mt-4"
-                >
-                  {{ questionActionError }}
-                  <button class="ml-2 underline" @click="questionActionError = null">Dismiss</button>
                 </div>
 
                 <div v-if="applicationForm.questions.length > 0" class="divide-y divide-surface-100 dark:divide-surface-800">

--- a/app/pages/dashboard/settings/account.vue
+++ b/app/pages/dashboard/settings/account.vue
@@ -11,6 +11,7 @@ useSeoMeta({
 })
 
 const { data: session } = await authClient.useSession(useFetch)
+const toast = useToast()
 
 // ─────────────────────────────────────────────
 // Profile editing
@@ -18,7 +19,6 @@ const { data: session } = await authClient.useSession(useFetch)
 const profileName = ref('')
 const isSavingProfile = ref(false)
 const profileSuccess = ref(false)
-const profileError = ref('')
 
 watch(() => session.value?.user, (user) => {
   if (user) {
@@ -28,7 +28,6 @@ watch(() => session.value?.user, (user) => {
 
 async function handleSaveProfile() {
   isSavingProfile.value = true
-  profileError.value = ''
   profileSuccess.value = false
 
   try {
@@ -40,7 +39,7 @@ async function handleSaveProfile() {
     setTimeout(() => { profileSuccess.value = false }, 3000)
   }
   catch (err: unknown) {
-    profileError.value = err instanceof Error ? err.message : 'Failed to update profile'
+    toast.error('Failed to update profile', { message: err instanceof Error ? err.message : undefined })
   }
   finally {
     isSavingProfile.value = false
@@ -149,9 +148,6 @@ function getInitials(name: string | undefined): string {
           </Transition>
         </div>
 
-        <div v-if="profileError" class="ui-alert ui-alert-danger">
-          {{ profileError }}
-        </div>
       </div>
     </section>
 

--- a/app/pages/dashboard/settings/index.vue
+++ b/app/pages/dashboard/settings/index.vue
@@ -14,6 +14,7 @@ const { allowed: canUpdateOrg, isLoading: isUpdateOrgPermissionLoading } = usePe
 const { allowed: canDeleteOrg } = usePermission({ organization: ['delete'] })
 const { defaultSalaryUnit, updateSettings } = useOrgSettings()
 const { track } = useTrack()
+const toast = useToast()
 const config = useRuntimeConfig()
 const factoryOrgName = computed(() => String(config.public.factoryOrgName || 'Factory').trim())
 const factoryOrgSlug = computed(() => String(config.public.factoryOrgSlug || 'factory').trim().toLowerCase())
@@ -38,7 +39,6 @@ const orgSlug = ref(factoryOrgSlug.value)
 const localDefaultSalaryUnit = ref<'YEAR' | 'MONTH' | 'HOUR'>('YEAR')
 const isSaving = ref(false)
 const saveSuccess = ref(false)
-const saveError = ref('')
 
 /** Slug must be lowercase alphanumeric + hyphens, 2-48 chars, no leading/trailing hyphen */
 const slugPattern = /^[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?$/
@@ -70,15 +70,14 @@ async function handleSaveOrg() {
 
   // Prevent saving empty or invalid values
   if (!trimmedName) {
-    saveError.value = 'Organization name cannot be empty.'
+    toast.error('Organization name required', { message: 'Organization name cannot be empty.' })
     return
   }
   if (!trimmedSlug || slugError.value) {
-    saveError.value = slugError.value || 'Organization slug cannot be empty.'
+    toast.error('Invalid organization slug', { message: slugError.value || 'Organization slug cannot be empty.' })
     return
   }
   isSaving.value = true
-  saveError.value = ''
   saveSuccess.value = false
 
   try {
@@ -96,7 +95,7 @@ async function handleSaveOrg() {
     setTimeout(() => { saveSuccess.value = false }, 3000)
   }
   catch (err: unknown) {
-    saveError.value = err instanceof Error ? err.message : 'Failed to update organization'
+    toast.error('Failed to update organization', { message: err instanceof Error ? err.message : undefined })
   }
   finally {
     isSaving.value = false
@@ -109,7 +108,6 @@ async function handleSaveOrg() {
 const showDeleteConfirm = ref(false)
 const deleteConfirmText = ref('')
 const isDeleting = ref(false)
-const deleteError = ref('')
 
 const canConfirmDelete = computed(() => {
   const name = activeOrg.value?.name
@@ -119,7 +117,6 @@ const canConfirmDelete = computed(() => {
 async function handleDeleteOrg() {
   if (!canDeleteOrg.value || !canConfirmDelete.value) return
   isDeleting.value = true
-  deleteError.value = ''
 
   try {
     track('org_deleted')
@@ -132,7 +129,7 @@ async function handleDeleteOrg() {
     await navigateTo(localePath('/onboarding/create-org'), { external: true })
   }
   catch (err: unknown) {
-    deleteError.value = err instanceof Error ? err.message : 'Failed to delete organization'
+    toast.error('Failed to delete organization', { message: err instanceof Error ? err.message : undefined })
   }
   finally {
     isDeleting.value = false
@@ -256,9 +253,6 @@ async function handleDeleteOrg() {
           </Transition>
         </div>
 
-        <div v-if="saveError" class="ui-alert ui-alert-danger">
-          {{ saveError }}
-        </div>
       </div>
     </section>
 
@@ -324,9 +318,6 @@ async function handleDeleteOrg() {
               >
                 Cancel
               </button>
-            </div>
-            <div v-if="deleteError" class="ui-alert ui-alert-danger">
-              {{ deleteError }}
             </div>
           </div>
         </Transition>

--- a/app/pages/dashboard/settings/integrations.vue
+++ b/app/pages/dashboard/settings/integrations.vue
@@ -13,6 +13,7 @@ useSeoMeta({
 
 const route = useRoute()
 const { calendarStatus, isConnected, isAvailable, connect, disconnect, refresh, status } = useCalendarIntegration()
+const toast = useToast()
 
 const isDisconnecting = ref(false)
 const showDisconnectConfirm = ref(false)
@@ -32,7 +33,6 @@ const destinationTypeLabel = (type: string) => type === 'shared_mailbox' ? 'Shar
 
 // Handle OAuth callback query params
 const successMessage = ref('')
-const errorMessage = ref('')
 
 onMounted(() => {
   const success = route.query.success as string | undefined
@@ -43,13 +43,13 @@ onMounted(() => {
     refresh()
   }
   else if (error === 'consent_denied') {
-    errorMessage.value = 'Calendar connection was cancelled. You can try again anytime.'
+    toast.error('Calendar connection cancelled', { message: 'You can try again anytime.' })
   }
   else if (error === 'oauth_failed') {
-    errorMessage.value = `Failed to connect ${calendarProviderName.value}. Please try again.`
+    toast.error(`Failed to connect ${calendarProviderName.value}`, { message: 'Please try again.' })
   }
   else if (error === 'account_mismatch' || error === 'calendar_not_accessible') {
-    errorMessage.value = `Could not access ${sharedCalendarEmail.value}. Sign in with a Factory Microsoft account that can access that mailbox.`
+    toast.error(`Could not access ${sharedCalendarEmail.value}`, { message: 'Sign in with a Factory Microsoft account that can access that mailbox.' })
   }
 
   // Clear query params after reading
@@ -70,7 +70,7 @@ async function handleDisconnect() {
     successMessage.value = `${calendarProviderName.value} disconnected.`
   }
   catch {
-    errorMessage.value = 'Failed to disconnect. Please try again.'
+    toast.error('Failed to disconnect', { message: 'Please try again.' })
   }
   finally {
     isDisconnecting.value = false
@@ -88,7 +88,7 @@ async function updateSyncInterviewers(enabled: boolean) {
       ? 'Interviewer calendar sync enabled.'
       : 'Interviewer calendar sync disabled.'
   } catch {
-    errorMessage.value = 'Failed to update setting.'
+    toast.error('Failed to update setting')
   }
 }
 </script>
@@ -117,24 +117,6 @@ async function updateSyncInterviewers(enabled: boolean) {
         <button
           class="ui-button ui-button-ghost p-1"
           @click="successMessage = ''"
-        >
-          <X class="size-4" />
-        </button>
-      </div>
-    </Transition>
-
-    <Transition name="fade">
-      <div
-        v-if="errorMessage"
-        class="ui-alert ui-alert-danger mb-4 flex items-center gap-3"
-      >
-        <AlertTriangle class="size-4 shrink-0" />
-        <p class="flex-1">
-          {{ errorMessage }}
-        </p>
-        <button
-          class="ui-button ui-button-ghost p-1"
-          @click="errorMessage = ''"
         >
           <X class="size-4" />
         </button>

--- a/app/pages/dashboard/settings/localization.vue
+++ b/app/pages/dashboard/settings/localization.vue
@@ -11,6 +11,7 @@ useSeoMeta({
 const { allowed: canUpdateOrg } = usePermission({ organization: ['update'] })
 const { nameDisplayFormat, dateFormat, updateSettings } = useOrgSettings()
 const { track } = useTrack()
+const toast = useToast()
 
 const localNameFormat = ref<'first_last' | 'last_first'>('first_last')
 const localDateFormat = ref<'mdy' | 'dmy' | 'ymd'>('mdy')
@@ -42,12 +43,10 @@ watch([nameDisplayFormat, dateFormat], ([nf, df]) => {
 
 const isSaving = ref(false)
 const saveSuccess = ref(false)
-const saveError = ref('')
 
 async function handleSave() {
   if (!canUpdateOrg.value) return
   isSaving.value = true
-  saveError.value = ''
   saveSuccess.value = false
 
   try {
@@ -60,7 +59,7 @@ async function handleSave() {
     setTimeout(() => { saveSuccess.value = false }, 3000)
   }
   catch (err: unknown) {
-    saveError.value = err instanceof Error ? err.message : 'Failed to save settings'
+    toast.error('Failed to save settings', { message: err instanceof Error ? err.message : undefined })
   }
   finally {
     isSaving.value = false
@@ -161,14 +160,6 @@ const previewDateFormatted = computed(() => {
               <span class="font-medium text-surface-900 dark:text-surface-100">{{ previewDateFormatted }}</span>
             </div>
           </div>
-        </div>
-
-        <!-- Error -->
-        <div
-          v-if="saveError"
-          class="ui-alert ui-alert-danger"
-        >
-          {{ saveError }}
         </div>
 
         <!-- Save button -->

--- a/app/pages/dashboard/settings/members.vue
+++ b/app/pages/dashboard/settings/members.vue
@@ -16,6 +16,7 @@ useSeoMeta({
 
 const { activeOrg } = useCurrentOrg()
 const { data: session } = await authClient.useSession(useFetch)
+const toast = useToast()
 const { allowed: canManageMembers, isLoading: isManageMembersPermissionLoading } = usePermission({ member: ['create'] })
 const { allowed: canInvite } = usePermission({ invitation: ['create'] })
 const { track } = useTrack()
@@ -94,19 +95,16 @@ const inviteEmail = ref('')
 const inviteRole = ref<'admin' | 'member'>('member')
 const isInviting = ref(false)
 const inviteSuccess = ref('')
-const inviteError = ref('')
 
 function resetInviteForm() {
   inviteEmail.value = ''
   inviteRole.value = 'member'
-  inviteError.value = ''
   inviteSuccess.value = ''
 }
 
 async function handleInvite() {
   if (!canInvite.value || !inviteEmail.value.trim()) return
   isInviting.value = true
-  inviteError.value = ''
   inviteSuccess.value = ''
 
   try {
@@ -123,7 +121,7 @@ async function handleInvite() {
     await fetchInvitations()
   }
   catch (err: unknown) {
-    inviteError.value = err instanceof Error ? err.message : 'Failed to send invitation'
+    toast.error('Failed to send invitation', { message: err instanceof Error ? err.message : undefined })
   }
   finally {
     isInviting.value = false
@@ -171,7 +169,6 @@ onMounted(fetchInvitations)
 async function handleResendInvitation(invitation: { id: string; email: string; role: string }) {
   resendingInvitation.value = invitation.id
   resendSuccess.value = ''
-  inviteError.value = ''
 
   try {
     const result = await authClient.organization.inviteMember({
@@ -185,7 +182,7 @@ async function handleResendInvitation(invitation: { id: string; email: string; r
     await fetchInvitations()
   }
   catch (err: unknown) {
-    inviteError.value = err instanceof Error ? err.message : 'Failed to resend invitation'
+    toast.error('Failed to resend invitation', { message: err instanceof Error ? err.message : undefined })
   }
   finally {
     resendingInvitation.value = null
@@ -203,7 +200,7 @@ async function handleCancelInvitation(invitationId: string) {
     await fetchInvitations()
   }
   catch (err: unknown) {
-    invitationsError.value = err instanceof Error ? err.message : 'Failed to cancel invitation'
+    toast.error('Failed to cancel invitation', { message: err instanceof Error ? err.message : undefined })
   }
   finally {
     cancellingInvitation.value = null
@@ -292,7 +289,7 @@ async function handleCreateLink() {
     await fetchInviteLinks()
   }
   catch (err: any) {
-    createLinkError.value = err?.data?.statusMessage || 'Failed to create invite link'
+    toast.error('Failed to create invite link', { message: err?.data?.statusMessage })
   }
   finally {
     isCreatingLink.value = false
@@ -330,7 +327,7 @@ async function handleRevokeLink(linkId: string) {
     await fetchInviteLinks()
   }
   catch (err: any) {
-    linksError.value = err?.data?.statusMessage || 'Failed to revoke invite link'
+    toast.error('Failed to revoke invite link', { message: err?.data?.statusMessage })
   }
   finally {
     revokingLinkId.value = null
@@ -369,7 +366,6 @@ const isLoadingJoinRequests = ref(true)
 const joinRequestsError = ref('')
 const approvingRequestId = ref<string | null>(null)
 const rejectingRequestId = ref<string | null>(null)
-const joinRequestActionError = ref('')
 
 async function fetchJoinRequests() {
   isLoadingJoinRequests.value = true
@@ -390,14 +386,13 @@ onMounted(fetchJoinRequests)
 
 async function handleApproveRequest(requestId: string) {
   approvingRequestId.value = requestId
-  joinRequestActionError.value = ''
 
   try {
     await $fetch(`/api/join-requests/${requestId}/approve`, { method: 'POST' })
     await Promise.all([fetchJoinRequests(), fetchMembers()])
   }
   catch (err: any) {
-    joinRequestActionError.value = err?.data?.statusMessage || 'Failed to approve request'
+    toast.error('Failed to approve request', { message: err?.data?.statusMessage })
   }
   finally {
     approvingRequestId.value = null
@@ -406,14 +401,13 @@ async function handleApproveRequest(requestId: string) {
 
 async function handleRejectRequest(requestId: string) {
   rejectingRequestId.value = requestId
-  joinRequestActionError.value = ''
 
   try {
     await $fetch(`/api/join-requests/${requestId}/reject`, { method: 'POST' })
     await fetchJoinRequests()
   }
   catch (err: any) {
-    joinRequestActionError.value = err?.data?.statusMessage || 'Failed to reject request'
+    toast.error('Failed to reject request', { message: err?.data?.statusMessage })
   }
   finally {
     rejectingRequestId.value = null
@@ -425,7 +419,6 @@ async function handleRejectRequest(requestId: string) {
 // ─────────────────────────────────────────────
 const activeDropdown = ref<string | null>(null)
 const isUpdatingRole = ref<string | null>(null)
-const roleUpdateError = ref('')
 
 function toggleDropdown(memberId: string) {
   activeDropdown.value = activeDropdown.value === memberId ? null : memberId
@@ -437,7 +430,6 @@ function closeDropdown() {
 
 async function handleUpdateRole(memberId: string, newRole: 'admin' | 'member') {
   isUpdatingRole.value = memberId
-  roleUpdateError.value = ''
 
   try {
     const result = await authClient.organization.updateMemberRole({
@@ -448,7 +440,7 @@ async function handleUpdateRole(memberId: string, newRole: 'admin' | 'member') {
     await fetchMembers()
   }
   catch (err: unknown) {
-    roleUpdateError.value = err instanceof Error ? err.message : 'Failed to update role'
+    toast.error('Failed to update role', { message: err instanceof Error ? err.message : undefined })
   }
   finally {
     isUpdatingRole.value = null
@@ -461,7 +453,6 @@ async function handleUpdateRole(memberId: string, newRole: 'admin' | 'member') {
 // ─────────────────────────────────────────────
 const memberToRemove = ref<{ id: string; name: string } | null>(null)
 const isRemoving = ref(false)
-const removeError = ref('')
 
 async function handleRemoveMember() {
   if (!memberToRemove.value) return
@@ -470,12 +461,11 @@ async function handleRemoveMember() {
   const currentUserId = session.value?.user?.id
   const targetMember = members.value.find(m => m.id === memberToRemove.value?.id)
   if (targetMember && currentUserId && targetMember.userId === currentUserId) {
-    removeError.value = 'You cannot remove yourself from the organization.'
+    toast.error('Cannot remove yourself', { message: 'You cannot remove yourself from the organization.' })
     return
   }
 
   isRemoving.value = true
-  removeError.value = ''
 
   try {
     const result = await authClient.organization.removeMember({
@@ -486,7 +476,7 @@ async function handleRemoveMember() {
     await fetchMembers()
   }
   catch (err: unknown) {
-    removeError.value = err instanceof Error ? err.message : 'Failed to remove member'
+    toast.error('Failed to remove member', { message: err instanceof Error ? err.message : undefined })
   }
   finally {
     isRemoving.value = false
@@ -625,20 +615,9 @@ onUnmounted(() => {
             </div>
           </Transition>
 
-          <div v-if="inviteError" class="ui-alert ui-alert-danger mt-3 px-3 py-2">
-            {{ inviteError }}
-          </div>
         </div>
       </Transition>
     </section>
-
-    <!-- Role update error banner -->
-    <div v-if="roleUpdateError" class="ui-alert ui-alert-danger mb-4 flex items-center justify-between">
-      <span>{{ roleUpdateError }}</span>
-      <button class="ui-button ui-button-ghost p-1" @click="roleUpdateError = ''">
-        <X class="size-4" />
-      </button>
-    </div>
 
     <!-- Resend success banner -->
     <Transition
@@ -954,14 +933,6 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <!-- Join request action error -->
-      <div v-if="joinRequestActionError" class="ui-alert ui-alert-danger rounded-none border-x-0 border-t-0 px-4 sm:px-6 py-2 flex items-center justify-between">
-        <span>{{ joinRequestActionError }}</span>
-        <button class="ui-button ui-button-ghost p-1" @click="joinRequestActionError = ''">
-          <X class="size-4" />
-        </button>
-      </div>
-
       <!-- Loading state -->
       <div v-if="isLoadingJoinRequests" class="ui-empty-state px-4 sm:px-6 py-6 text-sm">
         <Loader2 class="size-4 animate-spin mx-auto mb-1.5" />
@@ -1239,14 +1210,10 @@ onUnmounted(() => {
                 They will lose access to all organization data immediately.
               </p>
 
-              <div v-if="removeError" class="ui-alert ui-alert-danger mb-4 px-3 py-2">
-                {{ removeError }}
-              </div>
-
               <div class="flex items-center gap-3 justify-end">
                 <button
                   class="ui-button ui-button-secondary"
-                  @click="memberToRemove = null; removeError = ''"
+                  @click="memberToRemove = null"
                 >
                   Cancel
                 </button>

--- a/app/pages/dashboard/settings/sso.vue
+++ b/app/pages/dashboard/settings/sso.vue
@@ -18,6 +18,7 @@ useSeoMeta({
 const { allowed: canManageSso, role: currentOrgRole } = usePermission({ organization: ['update'] })
 const { track } = useTrack()
 const { signupAllowedDomains, updateSettings } = useOrgSettings()
+const toast = useToast()
 const canManageSignupDomains = computed(() => currentOrgRole.value === 'owner')
 const config = useRuntimeConfig()
 const requestUrl = useRequestURL()
@@ -46,7 +47,6 @@ const hasProvider = computed(() => (providers.value?.length ?? 0) > 0)
 // ─────────────────────────────────────────────
 const showForm = ref(false)
 const isRegistering = ref(false)
-const formError = ref('')
 const formSuccess = ref('')
 
 const form = reactive({
@@ -64,7 +64,6 @@ const localSignupAllowedDomains = ref<string[]>([])
 const newSignupDomain = ref('')
 const isSavingDomains = ref(false)
 const domainSaveSuccess = ref(false)
-const domainSaveError = ref('')
 const signupDomainPolicyTooltip = 'Domains must match a configured SSO provider or an organization-level calendar integration. Only owners can save changes.'
 
 watch(signupAllowedDomains, (domains) => {
@@ -101,7 +100,6 @@ const canAddSignupDomain = computed(() =>
 )
 
 function handleAddSignupDomain() {
-  domainSaveError.value = ''
   domainSaveSuccess.value = false
 
   if (!canAddSignupDomain.value || !normalizedNewSignupDomain.value) return
@@ -111,7 +109,6 @@ function handleAddSignupDomain() {
 }
 
 function handleRemoveSignupDomain(domain: string) {
-  domainSaveError.value = ''
   domainSaveSuccess.value = false
   localSignupAllowedDomains.value = parsedSignupAllowedDomains.value.filter(item => item !== domain)
 }
@@ -119,16 +116,15 @@ function handleRemoveSignupDomain(domain: string) {
 async function handleSaveSignupDomains() {
   if (!canManageSignupDomains.value) return
 
-  domainSaveError.value = ''
   domainSaveSuccess.value = false
 
   if (invalidSignupDomains.value.length > 0) {
-    domainSaveError.value = `Invalid domain: ${invalidSignupDomains.value[0]}`
+    toast.error('Invalid domain', { message: invalidSignupDomains.value[0] })
     return
   }
 
   if (hasTooManySignupDomains.value) {
-    domainSaveError.value = `Add ${SIGNUP_ALLOWED_DOMAINS_MAX} or fewer domains.`
+    toast.error('Too many domains', { message: `Add ${SIGNUP_ALLOWED_DOMAINS_MAX} or fewer domains.` })
     return
   }
 
@@ -144,7 +140,7 @@ async function handleSaveSignupDomains() {
   }
   catch (err: unknown) {
     const fetchErr = err as { data?: { statusMessage?: string }; message?: string }
-    domainSaveError.value = fetchErr.data?.statusMessage ?? fetchErr.message ?? 'Failed to save signup domain allowlist'
+    toast.error('Failed to save signup domain allowlist', { message: fetchErr.data?.statusMessage ?? fetchErr.message })
   }
   finally {
     isSavingDomains.value = false
@@ -172,7 +168,6 @@ function resetForm() {
   form.domain = ''
   form.clientId = ''
   form.clientSecret = ''
-  formError.value = ''
 }
 
 /**
@@ -189,7 +184,6 @@ watch(() => form.domain, (domain) => {
 async function handleRegister() {
   if (!canManageSso.value) return
 
-  formError.value = ''
   formSuccess.value = ''
   isRegistering.value = true
 
@@ -212,7 +206,7 @@ async function handleRegister() {
     await refreshProviders()
   } catch (err: unknown) {
     const fetchErr = err as { data?: { statusMessage?: string }; message?: string }
-    formError.value = fetchErr.data?.statusMessage ?? fetchErr.message ?? 'Failed to register SSO provider'
+    toast.error('Failed to register SSO provider', { message: fetchErr.data?.statusMessage ?? fetchErr.message })
   } finally {
     isRegistering.value = false
   }
@@ -236,7 +230,7 @@ async function handleDelete(id: string) {
     await refreshProviders()
   } catch (err: unknown) {
     const fetchErr = err as { data?: { statusMessage?: string }; message?: string }
-    formError.value = fetchErr.data?.statusMessage ?? fetchErr.message ?? 'Failed to remove SSO provider'
+    toast.error('Failed to remove SSO provider', { message: fetchErr.data?.statusMessage ?? fetchErr.message })
   } finally {
     deletingId.value = null
   }
@@ -284,21 +278,6 @@ async function copyCallbackUrl(providerId: string) {
           {{ formSuccess }}
         </p>
         <button class="text-emerald-400 hover:text-emerald-600 dark:hover:text-emerald-200" @click="formSuccess = ''">
-          <X class="size-4" />
-        </button>
-      </div>
-    </Transition>
-
-    <Transition name="fade">
-      <div
-        v-if="formError"
-        class="ui-alert ui-alert-danger mb-4 flex items-center gap-3"
-      >
-        <AlertTriangle class="size-4 shrink-0" />
-        <p class="flex-1">
-          {{ formError }}
-        </p>
-        <button class="text-danger-400 hover:text-danger-600 dark:hover:text-danger-200" @click="formError = ''">
           <X class="size-4" />
         </button>
       </div>
@@ -419,9 +398,6 @@ async function copyCallbackUrl(providerId: string) {
                 Domains saved
               </span>
             </Transition>
-          </div>
-          <div v-if="domainSaveError" class="ui-alert ui-alert-danger">
-            {{ domainSaveError }}
           </div>
           <div v-if="!canManageSignupDomains" class="ui-alert ui-alert-info">
             Only organization owners can manage signup domain allowlists.

--- a/app/pages/onboarding/create-org.vue
+++ b/app/pages/onboarding/create-org.vue
@@ -17,13 +17,13 @@ const { acceptInviteLink } = useInviteLinks()
 const localePath = useLocalePath()
 const config = useRuntimeConfig()
 const { track } = useTrack()
+const toast = useToast()
 
 onMounted(() => track('onboarding_viewed', { mode: viewMode.value }))
 
 const orgName = ref('')
 const slug = ref('')
 const slugEdited = ref(false)
-const error = ref('')
 const isLoading = ref(false)
 const showCreateForm = ref(false)
 const publicOrgCreationEnabled = computed(
@@ -90,25 +90,23 @@ function onSlugInput() {
 }
 
 async function handleCreateOrg() {
-  error.value = ''
-
   if (!publicOrgCreationEnabled.value) {
-    error.value = 'Factory Careers uses a single Factory organization. Ask an administrator for an invitation.'
+    toast.error('Organization creation disabled', { message: 'Factory Careers uses a single Factory organization. Ask an administrator for an invitation.' })
     return
   }
 
   if (!orgName.value.trim()) {
-    error.value = 'Organization name is required.'
+    toast.error('Organization name required')
     return
   }
 
   if (!slug.value.trim()) {
-    error.value = 'Slug is required.'
+    toast.error('Slug required')
     return
   }
 
   if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(slug.value)) {
-    error.value = 'Slug must be lowercase alphanumeric with hyphens, and cannot start or end with a hyphen.'
+    toast.error('Invalid slug', { message: 'Slug must be lowercase alphanumeric with hyphens, and cannot start or end with a hyphen.' })
     return
   }
 
@@ -121,7 +119,7 @@ async function handleCreateOrg() {
     await createOrg({ name: orgName.value.trim(), slug: slug.value.trim() })
   }
   catch (err: any) {
-    error.value = err?.message ?? 'Failed to create organization. The slug may already be taken.'
+    toast.error('Failed to create organization', { message: err?.message ?? 'The slug may already be taken.' })
     isLoading.value = false
   }
 }
@@ -130,7 +128,6 @@ async function handleCreateOrg() {
 // Join existing org — invite code
 // ─────────────────────────────────────────────
 const inviteCode = ref('')
-const inviteCodeError = ref('')
 const isAcceptingCode = ref(false)
 const inviteCodeSuccess = ref(false)
 
@@ -155,11 +152,10 @@ function extractToken(input: string): string {
 }
 
 async function handleAcceptInviteCode() {
-  inviteCodeError.value = ''
   const token = extractToken(inviteCode.value)
 
   if (!token) {
-    inviteCodeError.value = 'Please enter an invite link or code.'
+    toast.error('Invite code required', { message: 'Please enter an invite link or code.' })
     return
   }
 
@@ -182,7 +178,7 @@ async function handleAcceptInviteCode() {
     }, 1500)
   }
   catch (err: any) {
-    inviteCodeError.value = err?.data?.statusMessage || 'Invalid, expired, or already used invite link.'
+    toast.error('Could not join organization', { message: err?.data?.statusMessage || 'Invalid, expired, or already used invite link.' })
   }
   finally {
     isAcceptingCode.value = false
@@ -195,11 +191,9 @@ async function handleAcceptInviteCode() {
 const orgSearch = ref('')
 const orgSearchResults = ref<Array<{ id: string; name: string; slug: string }>>([])
 const isSearching = ref(false)
-const searchError = ref('')
 const joinRequestMessage = ref('')
 const isSubmittingRequest = ref(false)
 const requestSuccess = ref('')
-const requestError = ref('')
 const selectedOrg = ref<{ id: string; name: string; slug: string } | null>(null)
 
 let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined
@@ -218,7 +212,6 @@ async function handleOrgSearch() {
   if (q.length < 2) return
 
   isSearching.value = true
-  searchError.value = ''
 
   try {
     const data = await $fetch('/api/org-search', {
@@ -227,7 +220,7 @@ async function handleOrgSearch() {
     orgSearchResults.value = data as typeof orgSearchResults.value
   }
   catch (err: any) {
-    searchError.value = err?.data?.statusMessage || 'Search failed'
+    toast.error('Search failed', { message: err?.data?.statusMessage })
   }
   finally {
     isSearching.value = false
@@ -238,7 +231,6 @@ async function handleSubmitJoinRequest() {
   if (!selectedOrg.value) return
 
   isSubmittingRequest.value = true
-  requestError.value = ''
   requestSuccess.value = ''
 
   try {
@@ -255,7 +247,7 @@ async function handleSubmitJoinRequest() {
     joinRequestMessage.value = ''
   }
   catch (err: any) {
-    requestError.value = err?.data?.statusMessage || 'Failed to send join request'
+    toast.error('Failed to send join request', { message: err?.data?.statusMessage })
   }
   finally {
     isSubmittingRequest.value = false
@@ -350,7 +342,6 @@ async function handleSubmitJoinRequest() {
           Join
         </button>
       </div>
-      <div v-if="inviteCodeError" class="mt-2 text-xs text-danger-600 dark:text-danger-400">{{ inviteCodeError }}</div>
     </div>
 
     <!-- Divider -->
@@ -382,8 +373,6 @@ async function handleSubmitJoinRequest() {
           <Loader2 v-if="isSearching" class="size-4 animate-spin text-surface-400" />
         </template>
       </GooeySearchInput>
-
-      <div v-if="searchError" class="mt-2 text-xs text-danger-600 dark:text-danger-400">{{ searchError }}</div>
 
       <!-- Search results -->
       <div v-if="orgSearchResults.length > 0 && !selectedOrg" class="mt-2 border border-surface-200 dark:border-surface-700 rounded-md overflow-hidden">
@@ -442,8 +431,6 @@ async function handleSubmitJoinRequest() {
         </button>
       </div>
 
-      <div v-if="requestError" class="mt-2 text-xs text-danger-600 dark:text-danger-400">{{ requestError }}</div>
-
       <!-- Request success -->
       <div v-if="requestSuccess" class="ui-alert ui-alert-success mt-2 flex items-center gap-2 text-xs">
         <Check class="size-4 flex-shrink-0" />
@@ -468,8 +455,6 @@ async function handleSubmitJoinRequest() {
     <p class="text-sm text-surface-500 dark:text-surface-400 text-center mb-2">
       Set up your workspace to start managing candidates and jobs.
     </p>
-
-    <div v-if="error" class="ui-alert ui-alert-danger">{{ error }}</div>
 
     <label class="flex flex-col gap-1 text-sm font-medium text-surface-700 dark:text-surface-300">
       <span>Organization name</span>

--- a/app/pages/onboarding/create-org.vue
+++ b/app/pages/onboarding/create-org.vue
@@ -25,6 +25,7 @@ const orgName = ref('')
 const slug = ref('')
 const slugEdited = ref(false)
 const isLoading = ref(false)
+const createOrgValidationError = ref('')
 const showCreateForm = ref(false)
 const publicOrgCreationEnabled = computed(
   () => config.public.factoryPublicOrgCreationEnabled === true,
@@ -90,23 +91,25 @@ function onSlugInput() {
 }
 
 async function handleCreateOrg() {
+  createOrgValidationError.value = ''
+
   if (!publicOrgCreationEnabled.value) {
     toast.error('Organization creation disabled', { message: 'Factory Careers uses a single Factory organization. Ask an administrator for an invitation.' })
     return
   }
 
   if (!orgName.value.trim()) {
-    toast.error('Organization name required')
+    createOrgValidationError.value = 'Organization name is required.'
     return
   }
 
   if (!slug.value.trim()) {
-    toast.error('Slug required')
+    createOrgValidationError.value = 'Slug is required.'
     return
   }
 
   if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(slug.value)) {
-    toast.error('Invalid slug', { message: 'Slug must be lowercase alphanumeric with hyphens, and cannot start or end with a hyphen.' })
+    createOrgValidationError.value = 'Slug must be lowercase alphanumeric with hyphens, and cannot start or end with a hyphen.'
     return
   }
 
@@ -479,6 +482,10 @@ async function handleSubmitJoinRequest() {
       />
       <span class="text-xs font-normal text-surface-400">Used in URLs. Lowercase letters, numbers, and hyphens only.</span>
     </label>
+
+    <p v-if="createOrgValidationError" class="ui-alert ui-alert-danger text-sm">
+      {{ createOrgValidationError }}
+    </p>
 
     <button
       type="submit"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "vitest run",
     "test:unit": "vitest run",
     "preflight:pr": "node scripts/run-pr-validation-preflight.mjs",
+    "preflight:cli-parity": "node scripts/run-pr-validation-preflight.mjs --step cli-parity",
     "typecheck": "nuxi typecheck",
     "test:e2e": "npx playwright test",
     "cli:pack": "npm pack --workspace @thefactory/careers-cli --dry-run",

--- a/scripts/run-pr-validation-preflight.mjs
+++ b/scripts/run-pr-validation-preflight.mjs
@@ -147,6 +147,12 @@ function getStepSlug(name) {
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   const stepArgIndex = argv.indexOf('--step')
   const requestedStep = stepArgIndex >= 0 ? argv[stepArgIndex + 1] : ''
+
+  if (stepArgIndex >= 0 && (!requestedStep || requestedStep.startsWith('-'))) {
+    console.error('Missing value for --step. Pass a PR preflight step name or alias.')
+    exit(1)
+  }
+
   const steps = requestedStep
     ? getPrPreflightSteps().filter((step) => {
         return getStepSlug(step.name) === requestedStep || step.aliases?.includes(requestedStep)

--- a/scripts/run-pr-validation-preflight.mjs
+++ b/scripts/run-pr-validation-preflight.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { exit } from 'node:process'
+import { argv, exit } from 'node:process'
 import { fileURLToPath } from 'node:url'
 
 const productionEnv = {
@@ -44,7 +44,6 @@ export function getFetchArgsForBaseRef(baseRef, fallbackRemote = 'origin') {
 
     return [
       '--no-tags',
-      '--depth=1',
       remote,
       `+refs/heads/${branch}:refs/remotes/${remote}/${branch}`,
     ]
@@ -55,13 +54,12 @@ export function getFetchArgsForBaseRef(baseRef, fallbackRemote = 'origin') {
 
     return [
       '--no-tags',
-      '--depth=1',
       fallbackRemote,
       `+refs/heads/${branch}:refs/remotes/${fallbackRemote}/${branch}`,
     ]
   }
 
-  return ['--no-tags', '--depth=1', fallbackRemote, baseRef]
+  return ['--no-tags', fallbackRemote, baseRef]
 }
 
 function getChangedFiles() {
@@ -129,7 +127,7 @@ function runCliSmokeTests() {
 
 export function getPrPreflightSteps() {
   return [
-    { name: 'CLI parity evidence', run: runCliParityEvidence },
+    { name: 'CLI parity evidence', aliases: ['cli-parity'], run: runCliParityEvidence },
     { name: 'Unit tests', run: () => run('npm', ['run', 'test:unit']) },
     { name: 'Lint', run: runOptionalLint },
     { name: 'Typecheck', run: () => run('npm', ['run', 'typecheck']) },
@@ -142,8 +140,25 @@ export function getPrPreflightSteps() {
   ]
 }
 
+function getStepSlug(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+}
+
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  for (const step of getPrPreflightSteps()) {
+  const stepArgIndex = argv.indexOf('--step')
+  const requestedStep = stepArgIndex >= 0 ? argv[stepArgIndex + 1] : ''
+  const steps = requestedStep
+    ? getPrPreflightSteps().filter((step) => {
+        return getStepSlug(step.name) === requestedStep || step.aliases?.includes(requestedStep)
+      })
+    : getPrPreflightSteps()
+
+  if (requestedStep && steps.length === 0) {
+    console.error(`Unknown PR preflight step: ${requestedStep}`)
+    exit(1)
+  }
+
+  for (const step of steps) {
     console.log(`\n==> ${step.name}`)
 
     let status = 1

--- a/tests/unit/action-error-toasts.test.ts
+++ b/tests/unit/action-error-toasts.test.ts
@@ -176,4 +176,19 @@ describe('action error toast handling', () => {
       }
     }
   })
+
+  it('keeps client-side form validation anchored in the form', () => {
+    const onboardingSource = readProjectFile('app/pages/onboarding/create-org.vue')
+    const newTemplateSource = readProjectFile('app/pages/dashboard/interviews/templates/new.vue')
+
+    expect(onboardingSource).toContain('createOrgValidationError')
+    expect(onboardingSource).toContain('v-if="createOrgValidationError"')
+    expect(onboardingSource).not.toContain("toast.error('Organization name required')")
+    expect(onboardingSource).not.toContain("toast.error('Slug required')")
+    expect(onboardingSource).not.toContain("toast.error('Invalid slug'")
+
+    expect(newTemplateSource).toContain('validationError')
+    expect(newTemplateSource).toContain('v-if="validationError"')
+    expect(newTemplateSource).not.toContain("toast.error('All fields are required')")
+  })
 })

--- a/tests/unit/action-error-toasts.test.ts
+++ b/tests/unit/action-error-toasts.test.ts
@@ -1,0 +1,179 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+const toastTargets = [
+  'app/pages/onboarding/create-org.vue',
+  'app/pages/dashboard/settings/members.vue',
+  'app/pages/dashboard/settings/sso.vue',
+  'app/pages/dashboard/settings/index.vue',
+  'app/pages/dashboard/settings/account.vue',
+  'app/pages/dashboard/settings/localization.vue',
+  'app/pages/dashboard/settings/integrations.vue',
+  'app/pages/dashboard/interviews/[id].vue',
+  'app/components/InterviewEmailModal.vue',
+  'app/pages/dashboard/interviews/templates/[id].vue',
+  'app/pages/dashboard/interviews/templates/new.vue',
+  'app/pages/dashboard/interviews/templates/index.vue',
+  'app/pages/dashboard/interviews/index.vue',
+  'app/components/InterviewScheduleSidebar.vue',
+  'app/pages/dashboard/jobs/[id]/application-form.vue',
+  'app/pages/dashboard/jobs/[id]/index.vue',
+  'app/components/JobQuestions.vue',
+  'app/pages/dashboard/candidates/new.vue',
+  'app/pages/dashboard/candidates/[id].vue',
+  'app/components/CandidateDetailSidebar.vue',
+  'app/components/ApplyCandidateModal.vue',
+  'app/components/ApplyToJobModal.vue',
+  'app/components/FeedbackModal.vue',
+  'app/components/PropertySchemaEditor.vue',
+  'app/pages/dashboard/jobs/new.vue',
+]
+
+const disallowedInlineActionErrors: Record<string, string[]> = {
+  'app/pages/onboarding/create-org.vue': [
+    'error.value = err?.message',
+    'inviteCodeError.value = err?.data?.statusMessage',
+    'searchError.value = err?.data?.statusMessage',
+    'requestError.value = err?.data?.statusMessage',
+    'v-if="inviteCodeError"',
+    'v-if="searchError"',
+    'v-if="requestError"',
+  ],
+  'app/pages/dashboard/settings/members.vue': [
+    'inviteError.value = err instanceof Error',
+    'invitationsError.value = err instanceof Error ? err.message : \'Failed to cancel invitation\'',
+    'createLinkError.value = err?.data?.statusMessage',
+    'linksError.value = err?.data?.statusMessage',
+    'joinRequestActionError.value = err?.data?.statusMessage',
+    'roleUpdateError.value = err instanceof Error',
+    'removeError.value = err instanceof Error',
+    'v-if="inviteError"',
+    'v-if="roleUpdateError"',
+    'v-if="joinRequestActionError"',
+    'v-if="removeError"',
+  ],
+  'app/pages/dashboard/settings/sso.vue': [
+    'domainSaveError.value = fetchErr.data?.statusMessage',
+    'formError.value = fetchErr.data?.statusMessage',
+    'v-if="formError"',
+    'v-if="domainSaveError"',
+  ],
+  'app/pages/dashboard/settings/index.vue': [
+    'saveError.value = err instanceof Error',
+    'deleteError.value = err instanceof Error',
+    'v-if="saveError"',
+    'v-if="deleteError"',
+  ],
+  'app/pages/dashboard/settings/account.vue': [
+    'profileError.value = err instanceof Error',
+    'v-if="profileError"',
+  ],
+  'app/pages/dashboard/settings/localization.vue': [
+    'saveError.value = err instanceof Error',
+    'v-if="saveError"',
+  ],
+  'app/pages/dashboard/settings/integrations.vue': [
+    'const errorMessage = ref',
+    'errorMessage.value = `Failed to connect',
+    'errorMessage.value = `Could not access',
+    'errorMessage.value = \'Failed to disconnect',
+    'errorMessage.value = \'Failed to update setting',
+    'v-if="errorMessage"',
+  ],
+  'app/pages/dashboard/interviews/[id].vue': [
+    'rescheduleError.value = err.data?.statusMessage',
+    'editErrors.value.submit = err.data?.statusMessage',
+    'sendEmailError.value = err?.data?.statusMessage',
+    'v-if="sendEmailError"',
+    'v-if="rescheduleError"',
+    'v-if="editErrors.submit"',
+  ],
+  'app/components/InterviewEmailModal.vue': [
+    'sendError.value = err?.data?.statusMessage',
+    'templateSaveError.value = err?.data?.statusMessage',
+    'v-if="sendError"',
+    'v-if="templateSaveError"',
+  ],
+  'app/pages/dashboard/interviews/templates/[id].vue': [
+    'saveError.value = err?.data?.statusMessage',
+    'v-if="saveError"',
+  ],
+  'app/pages/dashboard/interviews/templates/new.vue': [
+    'saveError.value = err?.data?.statusMessage',
+    'v-if="saveError"',
+  ],
+  'app/pages/dashboard/interviews/templates/index.vue': [
+    'handlePreviewReadOnlyError(err)\n  } finally',
+  ],
+  'app/pages/dashboard/interviews/index.vue': [
+    'editErrors.value.submit = err?.data?.statusMessage',
+    'v-if="editErrors.submit"',
+  ],
+  'app/components/InterviewScheduleSidebar.vue': [
+    'errors.value.submit = err?.data?.statusMessage',
+    'v-if="errors.submit"',
+  ],
+  'app/pages/dashboard/jobs/[id]/application-form.vue': [
+    'requirementsError.value = err?.data?.statusMessage',
+    'complianceError.value = err?.data?.statusMessage',
+    'v-if="requirementsError"',
+    'v-if="complianceError"',
+  ],
+  'app/pages/dashboard/jobs/[id]/index.vue': [
+    'interviewEditErrors.value.submit = err?.data?.statusMessage',
+    'rescheduleError.value = err?.data?.statusMessage',
+    'v-if="rescheduleError"',
+  ],
+  'app/components/JobQuestions.vue': [
+    'actionError.value = err.data?.statusMessage',
+    'v-if="actionError"',
+  ],
+  'app/pages/dashboard/candidates/new.vue': [
+    'submitError.value = message',
+    'v-if="submitError"',
+  ],
+  'app/pages/dashboard/candidates/[id].vue': [
+    'uploadError.value = msg',
+    'v-if="uploadError"',
+  ],
+  'app/components/CandidateDetailSidebar.vue': [
+    'uploadError.value = err.data?.statusMessage',
+    'v-if="uploadError"',
+  ],
+  'app/components/ApplyCandidateModal.vue': [
+    'applyError.value = err.data?.statusMessage',
+    'v-if="applyError"',
+  ],
+  'app/components/ApplyToJobModal.vue': [
+    'applyError.value = err.data?.statusMessage',
+    'v-if="applyError"',
+  ],
+  'app/components/FeedbackModal.vue': [
+    'submitError.value = err.data?.statusMessage',
+  ],
+  'app/components/PropertySchemaEditor.vue': [
+    'formError.value = message',
+  ],
+  'app/pages/dashboard/jobs/new.vue': [
+    'questionActionError',
+  ],
+}
+
+describe('action error toast handling', () => {
+  it('routes targeted action and mutation failures through the toast system', () => {
+    for (const path of toastTargets) {
+      const source = readProjectFile(path)
+
+      expect(source, `${path} should initialize toast handling`).toContain('useToast()')
+      expect(source, `${path} should surface at least one action error toast`).toContain('toast.error(')
+
+      for (const pattern of disallowedInlineActionErrors[path] ?? []) {
+        expect(source, `${path} should not keep inline action error pattern: ${pattern}`).not.toContain(pattern)
+      }
+    }
+  })
+})

--- a/tests/unit/cli-ci-coverage.test.ts
+++ b/tests/unit/cli-ci-coverage.test.ts
@@ -16,7 +16,7 @@ describe('CLI CI coverage', () => {
     expect(workflow).toContain('npm run typecheck')
     expect(workflow).toContain('npm run build')
     expect(workflow).toContain('Check CLI parity evidence')
-    expect(workflow).toContain('scripts/cli-parity-check.ts --stdin')
+    expect(workflow).toContain('npm run preflight:cli-parity')
     expect(workflow).toContain('Run CLI smoke tests')
     expect(workflow).toContain('./packages/careers-cli/bin/factory-careers.mjs --help')
     expect(workflow).toContain('./packages/careers-cli/bin/factory-careers.mjs auth status --json')

--- a/tests/unit/git-hooks-preflight.test.ts
+++ b/tests/unit/git-hooks-preflight.test.ts
@@ -43,13 +43,11 @@ describe('git hook preflight checks', () => {
   it('fetches the configured base ref instead of hard-coding main', () => {
     expect(getFetchArgsForBaseRef('origin/release/1.4')).toEqual([
       '--no-tags',
-      '--depth=1',
       'origin',
       '+refs/heads/release/1.4:refs/remotes/origin/release/1.4',
     ])
     expect(getFetchArgsForBaseRef('upstream/main')).toEqual([
       '--no-tags',
-      '--depth=1',
       'upstream',
       '+refs/heads/main:refs/remotes/upstream/main',
     ])

--- a/tests/unit/git-hooks-preflight.test.ts
+++ b/tests/unit/git-hooks-preflight.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 import { getFetchArgsForBaseRef, getPrPreflightSteps } from '../../scripts/run-pr-validation-preflight.mjs'
 import { validateConventionalTitle } from '../../scripts/validate-conventional-title.mjs'
@@ -51,5 +52,15 @@ describe('git hook preflight checks', () => {
       'upstream',
       '+refs/heads/main:refs/remotes/upstream/main',
     ])
+  })
+
+  it('fails clearly when the preflight step flag is missing a value', () => {
+    const result = spawnSync('node', ['scripts/run-pr-validation-preflight.mjs', '--step'], {
+      encoding: 'utf8',
+      timeout: 2_000,
+    })
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('Missing value for --step')
   })
 })

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -290,7 +290,6 @@ describe('brand-neutral theme variables', () => {
         recipes: [
           'ui-modal-panel',
           'ui-panel-muted',
-          'ui-alert-danger',
           'ui-field',
           'ui-button-primary',
           'ui-button-secondary',
@@ -314,7 +313,6 @@ describe('brand-neutral theme variables', () => {
       {
         path: 'app/pages/onboarding/create-org.vue',
         recipes: [
-          'ui-alert-danger',
           'ui-alert-success',
           'ui-button-primary',
           'ui-empty-state',
@@ -584,19 +582,19 @@ describe('brand-neutral theme variables', () => {
       },
       {
         path: 'app/pages/dashboard/settings/account.vue',
-        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-field', 'ui-alert-danger', 'ui-button-primary'],
+        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-field', 'ui-button-primary'],
       },
       {
         path: 'app/pages/dashboard/settings/localization.vue',
-        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-panel-muted', 'ui-alert-danger', 'ui-button-primary'],
+        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-panel-muted', 'ui-button-primary'],
       },
       {
         path: 'app/pages/dashboard/settings/integrations.vue',
-        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-panel-muted', 'ui-alert-danger', 'ui-alert-success', 'ui-button-primary', 'ui-button-danger', 'ui-button-secondary'],
+        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-panel-muted', 'ui-alert-success', 'ui-button-primary', 'ui-button-danger', 'ui-button-secondary'],
       },
       {
         path: 'app/pages/dashboard/settings/sso.vue',
-        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-panel-muted', 'ui-empty-panel', 'ui-field', 'ui-alert-danger', 'ui-alert-success', 'ui-button-primary', 'ui-button-secondary', 'ui-button-danger-outline'],
+        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-panel-muted', 'ui-empty-panel', 'ui-field', 'ui-alert-success', 'ui-button-primary', 'ui-button-secondary', 'ui-button-danger-outline'],
       },
     ]
 
@@ -620,7 +618,6 @@ describe('brand-neutral theme variables', () => {
       'ui-settings-panel-body',
       'ui-list-row',
       'ui-field',
-      'ui-alert-danger',
       'ui-alert-success',
       'ui-button-primary',
       'ui-button-secondary',
@@ -762,7 +759,6 @@ describe('brand-neutral theme variables', () => {
       {
         path: 'app/pages/dashboard/interviews/templates/new.vue',
         recipes: [
-          'ui-alert-danger',
           'ui-button-ghost',
           'ui-button-primary',
           'ui-button-secondary',
@@ -780,7 +776,6 @@ describe('brand-neutral theme variables', () => {
       {
         path: 'app/pages/dashboard/interviews/templates/[id].vue',
         recipes: [
-          'ui-alert-danger',
           'ui-button-danger',
           'ui-button-ghost',
           'ui-button-primary',
@@ -856,7 +851,6 @@ describe('brand-neutral theme variables', () => {
           /flex size-11 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-brand-500/,
           /cursor-pointer inline-flex items-center gap-1\.5 rounded-xl border border-surface-200/,
           /cursor-pointer inline-flex items-center gap-1\.5 rounded-xl bg-brand-600/,
-          /rounded-xl border border-danger-200\/80 bg-danger-50/,
           /rounded-xl border border-surface-200 dark:border-surface-800 bg-white dark:bg-surface-900/,
           /w-full rounded-lg border border-surface-200 dark:border-surface-700/,
           /rounded-xl border border-brand-200 dark:border-brand-800\/60 bg-white/,
@@ -868,7 +862,6 @@ describe('brand-neutral theme variables', () => {
         path: 'app/pages/dashboard/interviews/templates/[id].vue',
         patterns: [
           /inline-flex items-center gap-1 rounded-full border border-surface-200/,
-          /rounded-xl border border-danger-200 bg-danger-50/,
           /inline-flex items-center gap-1\.5 rounded-lg bg-brand-600/,
           /cursor-pointer inline-flex items-center gap-1\.5 rounded-xl border border-surface-200/,
           /cursor-pointer inline-flex items-center gap-1\.5 rounded-xl bg-brand-600/,


### PR DESCRIPTION
## Summary
- Route audited action/mutation failures through global toast errors across onboarding, settings, interviews, jobs, candidates, documents, feedback, property editing, and AI scoring.
- Remove now-unused inline action-error banners while leaving field validation, page-load errors, and retry-required parse errors anchored in the UI.
- Add a static regression test for toast-based action error handling and update theme recipe assertions for surfaces that no longer render inline danger alerts.

## Validation
- `npm run test:unit -- tests/unit/action-error-toasts.test.ts`
- `npm run test:unit -- tests/unit/theme-neutrality.test.ts tests/unit/action-error-toasts.test.ts`
- `npm run test:unit`
- `npm run typecheck` (passes with existing Nuxt/Vue warnings about missing i18n config and vue-router/volar export)
- `git diff --check`
- `git push -u origin codex/toast-error-handling-audit` (pre-push ran unit tests, typecheck, CLI smoke tests, production env contract, and full Nuxt build)
