### PR TITLE
fix: surface success feedback as toasts

### DIFF
--- a/app/pages/dashboard/interviews/templates/[id].vue
+++ b/app/pages/dashboard/interviews/templates/[id].vue
@@ -12,6 +12,7 @@ definePageMeta({
 const route = useRoute()
 const localePath = useLocalePath()
 const templateId = route.params.id as string
+const toast = useToast()
 const { handlePreviewReadOnlyError } = usePreviewReadOnly()
 
 const isSystemTemplate = computed(() => templateId.startsWith('system-'))
@@ -62,7 +63,6 @@ watchEffect(() => {
 // ─── Save ────────────────────────────────────────────────────────
 const isSaving = ref(false)
 const saveError = ref('')
-const saveSuccess = ref(false)
 
 async function handleSave() {
   if (isSystemTemplate.value) return
@@ -79,9 +79,8 @@ async function handleSave() {
       subject: form.subject.trim(),
       body: form.body.trim(),
     })
-    saveSuccess.value = true
+    toast.success('Template saved')
     hasLoaded.value = false // Re-sync
-    setTimeout(() => { saveSuccess.value = false }, 2000)
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
     saveError.value = err?.data?.statusMessage ?? 'Failed to save template'
@@ -234,7 +233,7 @@ useSeoMeta({
               @click="handleSave"
             >
               <Save class="size-4" />
-              {{ isSaving ? 'Saving…' : saveSuccess ? 'Saved!' : 'Save Changes' }}
+              {{ isSaving ? 'Saving…' : 'Save Changes' }}
             </button>
           </template>
         </div>

--- a/app/pages/dashboard/jobs/[id]/application-form.vue
+++ b/app/pages/dashboard/jobs/[id]/application-form.vue
@@ -124,7 +124,6 @@ const postingSchema = z.object({
 
 const postingErrors = ref<Record<string, string>>({})
 const isSavingPosting = ref(false)
-const postingSaved = ref(false)
 
 async function savePostingDetails() {
   const result = postingSchema.safeParse(form.value)
@@ -156,8 +155,7 @@ async function savePostingDetails() {
       activeFrom: form.value.activeFrom ? new Date(form.value.activeFrom) : new Date(todayDateInputValue()),
       validThrough: form.value.validThrough ? new Date(form.value.validThrough) : null,
     } as any)
-    postingSaved.value = true
-    setTimeout(() => { postingSaved.value = false }, 2000)
+    toast.success('Application details saved')
   } catch (err: any) {
     if (handlePreviewReadOnlyError(err)) return
     toast.error('Failed to save application details', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
@@ -205,14 +203,12 @@ function onSalaryMaxChange(e: Event) {
 const requireResume = ref(false)
 const requireCoverLetter = ref(false)
 const isSavingRequirements = ref(false)
-const requirementsSaved = ref(false)
 const requirementsError = ref<string | null>(null)
 const applicationComplianceEnabled = ref(true)
 const includeEeo = ref(true)
 const includeVeteran = ref(true)
 const includeDisability = ref(true)
 const isSavingCompliance = ref(false)
-const complianceSaved = ref(false)
 const complianceError = ref<string | null>(null)
 const previewComplianceEnabled = computed(() =>
   applicationComplianceEnabled.value && (includeEeo.value || includeVeteran.value || includeDisability.value),
@@ -235,8 +231,7 @@ async function saveRequirements() {
   requirementsError.value = null
   try {
     await updateJob({ requireResume: requireResume.value, requireCoverLetter: requireCoverLetter.value })
-    requirementsSaved.value = true
-    setTimeout(() => { requirementsSaved.value = false }, 2000)
+    toast.success('Application requirements saved')
   } catch (err: any) {
     requirementsError.value = err?.data?.statusMessage ?? 'Failed to save requirements.'
   } finally {
@@ -254,8 +249,7 @@ async function saveComplianceQuestions() {
       includeVeteran: includeVeteran.value,
       includeDisability: includeDisability.value,
     })
-    complianceSaved.value = true
-    setTimeout(() => { complianceSaved.value = false }, 2000)
+    toast.success('Compliance questions saved')
   } catch (err: any) {
     complianceError.value = err?.data?.statusMessage ?? 'Failed to save compliance questions.'
   } finally {
@@ -619,7 +613,7 @@ async function copyTrackingUrl(code: string) {
             class="ui-button ui-button-primary h-10 px-5 text-sm"
           >
             <Save class="size-4" />
-            {{ postingSaved ? 'Saved!' : isSavingPosting ? 'Saving...' : 'Save application details' }}
+            {{ isSavingPosting ? 'Saving...' : 'Save application details' }}
           </button>
         </div>
       </form>
@@ -680,7 +674,7 @@ async function copyTrackingUrl(code: string) {
           class="ui-button ui-button-primary px-4 py-2 text-sm"
           @click="saveRequirements"
         >
-          {{ requirementsSaved ? 'Saved!' : isSavingRequirements ? 'Saving…' : 'Save requirements' }}
+          {{ isSavingRequirements ? 'Saving…' : 'Save requirements' }}
         </button>
         <p v-if="requirementsError" class="mt-2 text-xs text-danger-600 dark:text-danger-400">
           {{ requirementsError }}
@@ -764,7 +758,7 @@ async function copyTrackingUrl(code: string) {
           class="ui-button ui-button-primary px-4 py-2 text-sm"
           @click="saveComplianceQuestions"
         >
-          {{ complianceSaved ? 'Saved!' : isSavingCompliance ? 'Saving...' : 'Save compliance questions' }}
+          {{ isSavingCompliance ? 'Saving...' : 'Save compliance questions' }}
         </button>
         <p v-if="complianceError" class="mt-2 text-xs text-danger-600 dark:text-danger-400">
           {{ complianceError }}

--- a/app/pages/dashboard/settings/account.vue
+++ b/app/pages/dashboard/settings/account.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {
-  User, Save, Loader2, Check, Mail,
+  User, Save, Loader2, Mail,
 } from 'lucide-vue-next'
 
 definePageMeta({})
@@ -11,13 +11,13 @@ useSeoMeta({
 })
 
 const { data: session } = await authClient.useSession(useFetch)
+const toast = useToast()
 
 // ─────────────────────────────────────────────
 // Profile editing
 // ─────────────────────────────────────────────
 const profileName = ref('')
 const isSavingProfile = ref(false)
-const profileSuccess = ref(false)
 const profileError = ref('')
 
 watch(() => session.value?.user, (user) => {
@@ -29,15 +29,13 @@ watch(() => session.value?.user, (user) => {
 async function handleSaveProfile() {
   isSavingProfile.value = true
   profileError.value = ''
-  profileSuccess.value = false
 
   try {
     const result = await authClient.updateUser({
       name: profileName.value.trim(),
     })
     if (result.error) throw new Error(String(result.error.message ?? 'Failed to update profile'))
-    profileSuccess.value = true
-    setTimeout(() => { profileSuccess.value = false }, 3000)
+    toast.success('Profile updated')
   }
   catch (err: unknown) {
     profileError.value = err instanceof Error ? err.message : 'Failed to update profile'
@@ -136,17 +134,6 @@ function getInitials(name: string | undefined): string {
             {{ isSavingProfile ? 'Saving…' : 'Save profile' }}
           </button>
 
-          <Transition
-            enter-active-class="transition-opacity duration-300"
-            leave-active-class="transition-opacity duration-300"
-            enter-from-class="opacity-0"
-            leave-to-class="opacity-0"
-          >
-            <span v-if="profileSuccess" class="text-sm text-success-600 dark:text-success-400 font-medium flex items-center gap-1.5">
-              <Check class="size-4" />
-              Profile updated
-            </span>
-          </Transition>
         </div>
 
         <div v-if="profileError" class="ui-alert ui-alert-danger">

--- a/app/pages/dashboard/settings/index.vue
+++ b/app/pages/dashboard/settings/index.vue
@@ -14,6 +14,7 @@ const { allowed: canUpdateOrg, isLoading: isUpdateOrgPermissionLoading } = usePe
 const { allowed: canDeleteOrg } = usePermission({ organization: ['delete'] })
 const { defaultSalaryUnit, updateSettings } = useOrgSettings()
 const { track } = useTrack()
+const toast = useToast()
 const config = useRuntimeConfig()
 const factoryOrgName = computed(() => String(config.public.factoryOrgName || 'Factory').trim())
 const factoryOrgSlug = computed(() => String(config.public.factoryOrgSlug || 'factory').trim().toLowerCase())
@@ -37,7 +38,6 @@ const orgName = ref(factoryOrgName.value)
 const orgSlug = ref(factoryOrgSlug.value)
 const localDefaultSalaryUnit = ref<'YEAR' | 'MONTH' | 'HOUR'>('YEAR')
 const isSaving = ref(false)
-const saveSuccess = ref(false)
 const saveError = ref('')
 
 /** Slug must be lowercase alphanumeric + hyphens, 2-48 chars, no leading/trailing hyphen */
@@ -79,7 +79,6 @@ async function handleSaveOrg() {
   }
   isSaving.value = true
   saveError.value = ''
-  saveSuccess.value = false
 
   try {
     await authClient.organization.update({
@@ -92,8 +91,7 @@ async function handleSaveOrg() {
       defaultSalaryUnit: localDefaultSalaryUnit.value,
     })
     track('org_settings_saved')
-    saveSuccess.value = true
-    setTimeout(() => { saveSuccess.value = false }, 3000)
+    toast.success('Organization settings saved')
   }
   catch (err: unknown) {
     saveError.value = err instanceof Error ? err.message : 'Failed to update organization'
@@ -244,16 +242,6 @@ async function handleDeleteOrg() {
             {{ isSaving ? 'Saving…' : 'Save changes' }}
           </button>
 
-          <Transition
-            enter-active-class="transition-opacity duration-300"
-            leave-active-class="transition-opacity duration-300"
-            enter-from-class="opacity-0"
-            leave-to-class="opacity-0"
-          >
-            <span v-if="saveSuccess" class="text-sm text-success-600 dark:text-success-400 font-medium">
-              Changes saved
-            </span>
-          </Transition>
         </div>
 
         <div v-if="saveError" class="ui-alert ui-alert-danger">

--- a/app/pages/dashboard/settings/integrations.vue
+++ b/app/pages/dashboard/settings/integrations.vue
@@ -13,6 +13,7 @@ useSeoMeta({
 
 const route = useRoute()
 const { calendarStatus, isConnected, isAvailable, connect, disconnect, refresh, status } = useCalendarIntegration()
+const toast = useToast()
 
 const isDisconnecting = ref(false)
 const showDisconnectConfirm = ref(false)
@@ -31,7 +32,6 @@ const calendarDestinations = computed(() => calendarStatus.value.destinations ??
 const destinationTypeLabel = (type: string) => type === 'shared_mailbox' ? 'Shared mailbox' : 'User mailbox'
 
 // Handle OAuth callback query params
-const successMessage = ref('')
 const errorMessage = ref('')
 
 onMounted(() => {
@@ -39,7 +39,7 @@ onMounted(() => {
   const error = route.query.error as string | undefined
 
   if (success === 'connected') {
-    successMessage.value = `${calendarProviderLabel.value} connected successfully! Your interviews will now sync automatically.`
+    toast.success(`${calendarProviderLabel.value} connected`, 'Your interviews will now sync automatically.')
     refresh()
   }
   else if (error === 'consent_denied') {
@@ -67,7 +67,7 @@ async function handleDisconnect() {
   try {
     await disconnect()
     showDisconnectConfirm.value = false
-    successMessage.value = `${calendarProviderName.value} disconnected.`
+    toast.success(`${calendarProviderName.value} disconnected`)
   }
   catch {
     errorMessage.value = 'Failed to disconnect. Please try again.'
@@ -84,9 +84,7 @@ async function updateSyncInterviewers(enabled: boolean) {
       body: { calendarSyncInterviewers: enabled },
     })
     await refresh()
-    successMessage.value = enabled
-      ? 'Interviewer calendar sync enabled.'
-      : 'Interviewer calendar sync disabled.'
+    toast.success(enabled ? 'Interviewer calendar sync enabled' : 'Interviewer calendar sync disabled')
   } catch {
     errorMessage.value = 'Failed to update setting.'
   }
@@ -104,25 +102,7 @@ async function updateSyncInterviewers(enabled: boolean) {
       </p>
     </div>
 
-    <!-- Success/Error Messages -->
-    <Transition name="fade">
-      <div
-        v-if="successMessage"
-        class="ui-alert ui-alert-success mb-4 flex items-center gap-3"
-      >
-        <Check class="size-4 shrink-0" />
-        <p class="flex-1">
-          {{ successMessage }}
-        </p>
-        <button
-          class="ui-button ui-button-ghost p-1"
-          @click="successMessage = ''"
-        >
-          <X class="size-4" />
-        </button>
-      </div>
-    </Transition>
-
+    <!-- Error Messages -->
     <Transition name="fade">
       <div
         v-if="errorMessage"

--- a/app/pages/dashboard/settings/localization.vue
+++ b/app/pages/dashboard/settings/localization.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Globe, Save, Check, Loader2, ChevronDown } from 'lucide-vue-next'
+import { Globe, Save, Loader2, ChevronDown } from 'lucide-vue-next'
 
 definePageMeta({})
 
@@ -11,6 +11,7 @@ useSeoMeta({
 const { allowed: canUpdateOrg } = usePermission({ organization: ['update'] })
 const { nameDisplayFormat, dateFormat, updateSettings } = useOrgSettings()
 const { track } = useTrack()
+const toast = useToast()
 
 const localNameFormat = ref<'first_last' | 'last_first'>('first_last')
 const localDateFormat = ref<'mdy' | 'dmy' | 'ymd'>('mdy')
@@ -41,14 +42,12 @@ watch([nameDisplayFormat, dateFormat], ([nf, df]) => {
 }, { immediate: true })
 
 const isSaving = ref(false)
-const saveSuccess = ref(false)
 const saveError = ref('')
 
 async function handleSave() {
   if (!canUpdateOrg.value) return
   isSaving.value = true
   saveError.value = ''
-  saveSuccess.value = false
 
   try {
     await updateSettings({
@@ -56,8 +55,7 @@ async function handleSave() {
       dateFormat: localDateFormat.value,
     })
     track('localization_settings_saved')
-    saveSuccess.value = true
-    setTimeout(() => { saveSuccess.value = false }, 3000)
+    toast.success('Localization settings saved')
   }
   catch (err: unknown) {
     saveError.value = err instanceof Error ? err.message : 'Failed to save settings'
@@ -178,10 +176,9 @@ const previewDateFormatted = computed(() => {
             class="ui-button ui-button-primary disabled:opacity-50 disabled:cursor-not-allowed"
             @click="handleSave"
           >
-            <Check v-if="saveSuccess" class="size-4" />
-            <Loader2 v-else-if="isSaving" class="size-4 animate-spin" />
+            <Loader2 v-if="isSaving" class="size-4 animate-spin" />
             <Save v-else class="size-4" />
-            {{ saveSuccess ? 'Saved!' : isSaving ? 'Saving…' : 'Save changes' }}
+            {{ isSaving ? 'Saving…' : 'Save changes' }}
           </button>
           <p v-if="!canUpdateOrg" class="text-xs text-surface-400">Only admins and owners can change organization settings.</p>
         </div>

--- a/app/pages/dashboard/settings/members.vue
+++ b/app/pages/dashboard/settings/members.vue
@@ -19,6 +19,7 @@ const { data: session } = await authClient.useSession(useFetch)
 const { allowed: canManageMembers, isLoading: isManageMembersPermissionLoading } = usePermission({ member: ['create'] })
 const { allowed: canInvite } = usePermission({ invitation: ['create'] })
 const { track } = useTrack()
+const toast = useToast()
 const { allowed: canCancelInvite } = usePermission({ invitation: ['cancel'] })
 const {
   listInviteLinks: fetchInviteLinksApi,
@@ -93,33 +94,30 @@ const showInviteForm = ref(false)
 const inviteEmail = ref('')
 const inviteRole = ref<'admin' | 'member'>('member')
 const isInviting = ref(false)
-const inviteSuccess = ref('')
 const inviteError = ref('')
 
 function resetInviteForm() {
   inviteEmail.value = ''
   inviteRole.value = 'member'
   inviteError.value = ''
-  inviteSuccess.value = ''
 }
 
 async function handleInvite() {
   if (!canInvite.value || !inviteEmail.value.trim()) return
   isInviting.value = true
   inviteError.value = ''
-  inviteSuccess.value = ''
 
   try {
+    const email = inviteEmail.value.trim()
     const result = await authClient.organization.inviteMember({
-      email: inviteEmail.value.trim().toLowerCase(),
+      email: email.toLowerCase(),
       role: inviteRole.value,
     })
     if (result.error) throw new Error(String(result.error.message ?? 'Failed to send invitation'))
-    inviteSuccess.value = `Invitation sent to ${inviteEmail.value.trim()}`
+    toast.success('Invitation sent', email)
     track('member_invited')
     inviteEmail.value = ''
     inviteRole.value = 'member'
-    setTimeout(() => { inviteSuccess.value = '' }, 5000)
     await fetchInvitations()
   }
   catch (err: unknown) {
@@ -145,7 +143,6 @@ const isLoadingInvitations = ref(true)
 const invitationsError = ref('')
 const resendingInvitation = ref<string | null>(null)
 const cancellingInvitation = ref<string | null>(null)
-const resendSuccess = ref('')
 
 async function fetchInvitations() {
   isLoadingInvitations.value = true
@@ -170,7 +167,6 @@ onMounted(fetchInvitations)
 
 async function handleResendInvitation(invitation: { id: string; email: string; role: string }) {
   resendingInvitation.value = invitation.id
-  resendSuccess.value = ''
   inviteError.value = ''
 
   try {
@@ -180,8 +176,7 @@ async function handleResendInvitation(invitation: { id: string; email: string; r
       resend: true,
     })
     if (result.error) throw new Error(String(result.error.message ?? 'Failed to resend invitation'))
-    resendSuccess.value = `Invitation resent to ${invitation.email}`
-    setTimeout(() => { resendSuccess.value = '' }, 5000)
+    toast.success('Invitation resent', invitation.email)
     await fetchInvitations()
   }
   catch (err: unknown) {
@@ -240,7 +235,6 @@ const newLinkMaxUses = ref<string | number>('')
 const newLinkExpiresInHours = ref(168) // 7 days default
 const isCreatingLink = ref(false)
 const createLinkError = ref('')
-const createLinkSuccess = ref('')
 const copiedLinkId = ref<string | null>(null)
 const revokingLinkId = ref<string | null>(null)
 
@@ -263,7 +257,6 @@ onMounted(fetchInviteLinks)
 async function handleCreateLink() {
   isCreatingLink.value = true
   createLinkError.value = ''
-  createLinkSuccess.value = ''
 
   try {
     // Vue 3 auto-coerces type="number" input values to numbers (even without .number
@@ -283,12 +276,11 @@ async function handleCreateLink() {
       expiresInHours: newLinkExpiresInHours.value,
     })
 
-    createLinkSuccess.value = 'Invite link created!'
+    toast.success('Invite link created')
     showCreateLinkForm.value = false
     newLinkRole.value = 'member'
     newLinkMaxUses.value = ''
     newLinkExpiresInHours.value = 168
-    setTimeout(() => { createLinkSuccess.value = '' }, 5000)
     await fetchInviteLinks()
   }
   catch (err: any) {
@@ -613,18 +605,6 @@ onUnmounted(() => {
             </button>
           </div>
 
-          <Transition
-            enter-active-class="transition-opacity duration-300"
-            leave-active-class="transition-opacity duration-300"
-            enter-from-class="opacity-0"
-            leave-to-class="opacity-0"
-          >
-            <div v-if="inviteSuccess" class="ui-feedback-success mt-3 text-sm">
-              <Check class="size-4" />
-              {{ inviteSuccess }}
-            </div>
-          </Transition>
-
           <div v-if="inviteError" class="ui-alert ui-alert-danger mt-3 px-3 py-2">
             {{ inviteError }}
           </div>
@@ -639,19 +619,6 @@ onUnmounted(() => {
         <X class="size-4" />
       </button>
     </div>
-
-    <!-- Resend success banner -->
-    <Transition
-      enter-active-class="transition-opacity duration-300"
-      leave-active-class="transition-opacity duration-300"
-      enter-from-class="opacity-0"
-      leave-to-class="opacity-0"
-    >
-      <div v-if="resendSuccess" class="ui-alert ui-alert-success mb-4 flex items-center gap-2">
-        <Check class="size-4" />
-        {{ resendSuccess }}
-      </div>
-    </Transition>
 
     <!-- Pending invitations -->
     <section v-if="canInvite && (isLoadingInvitations || pendingInvitations.length > 0)" class="ui-panel ui-settings-panel mb-6">
@@ -838,19 +805,6 @@ onUnmounted(() => {
           <div v-if="createLinkError" class="ui-feedback-danger mt-2 text-xs">
             {{ createLinkError }}
           </div>
-        </div>
-      </Transition>
-
-      <!-- Success banner -->
-      <Transition
-        enter-active-class="transition-opacity duration-300"
-        leave-active-class="transition-opacity duration-300"
-        enter-from-class="opacity-0"
-        leave-to-class="opacity-0"
-      >
-        <div v-if="createLinkSuccess" class="ui-alert ui-alert-success rounded-none border-x-0 border-t-0 px-4 sm:px-6 py-2 flex items-center gap-2">
-          <Check class="size-4" />
-          {{ createLinkSuccess }}
         </div>
       </Transition>
 

--- a/app/pages/dashboard/settings/sso.vue
+++ b/app/pages/dashboard/settings/sso.vue
@@ -18,6 +18,7 @@ useSeoMeta({
 const { allowed: canManageSso, role: currentOrgRole } = usePermission({ organization: ['update'] })
 const { track } = useTrack()
 const { signupAllowedDomains, updateSettings } = useOrgSettings()
+const toast = useToast()
 const canManageSignupDomains = computed(() => currentOrgRole.value === 'owner')
 const config = useRuntimeConfig()
 const requestUrl = useRequestURL()
@@ -47,7 +48,6 @@ const hasProvider = computed(() => (providers.value?.length ?? 0) > 0)
 const showForm = ref(false)
 const isRegistering = ref(false)
 const formError = ref('')
-const formSuccess = ref('')
 
 const form = reactive({
   providerId: '',
@@ -63,7 +63,6 @@ const form = reactive({
 const localSignupAllowedDomains = ref<string[]>([])
 const newSignupDomain = ref('')
 const isSavingDomains = ref(false)
-const domainSaveSuccess = ref(false)
 const domainSaveError = ref('')
 const signupDomainPolicyTooltip = 'Domains must match a configured SSO provider or an organization-level calendar integration. Only owners can save changes.'
 
@@ -102,7 +101,6 @@ const canAddSignupDomain = computed(() =>
 
 function handleAddSignupDomain() {
   domainSaveError.value = ''
-  domainSaveSuccess.value = false
 
   if (!canAddSignupDomain.value || !normalizedNewSignupDomain.value) return
 
@@ -112,7 +110,6 @@ function handleAddSignupDomain() {
 
 function handleRemoveSignupDomain(domain: string) {
   domainSaveError.value = ''
-  domainSaveSuccess.value = false
   localSignupAllowedDomains.value = parsedSignupAllowedDomains.value.filter(item => item !== domain)
 }
 
@@ -120,7 +117,6 @@ async function handleSaveSignupDomains() {
   if (!canManageSignupDomains.value) return
 
   domainSaveError.value = ''
-  domainSaveSuccess.value = false
 
   if (invalidSignupDomains.value.length > 0) {
     domainSaveError.value = `Invalid domain: ${invalidSignupDomains.value[0]}`
@@ -139,8 +135,7 @@ async function handleSaveSignupDomains() {
       signupAllowedDomains: parsedSignupAllowedDomains.value,
     })
     track('signup_domain_allowlist_saved', { domain_count: parsedSignupAllowedDomains.value.length })
-    domainSaveSuccess.value = true
-    setTimeout(() => { domainSaveSuccess.value = false }, 3000)
+    toast.success('Signup domain allowlist saved')
   }
   catch (err: unknown) {
     const fetchErr = err as { data?: { statusMessage?: string }; message?: string }
@@ -190,7 +185,6 @@ async function handleRegister() {
   if (!canManageSso.value) return
 
   formError.value = ''
-  formSuccess.value = ''
   isRegistering.value = true
 
   try {
@@ -206,7 +200,7 @@ async function handleRegister() {
     })
 
     track('sso_provider_registered')
-    formSuccess.value = 'SSO provider registered successfully. Your team can now sign in with their corporate credentials.'
+    toast.success('SSO provider registered', 'Your team can now sign in with their corporate credentials.')
     resetForm()
     showForm.value = false
     await refreshProviders()
@@ -231,7 +225,7 @@ async function handleDelete(id: string) {
   try {
     await $fetch(`/api/sso/providers/${id}`, { method: 'DELETE' })
     track('sso_provider_deleted')
-    formSuccess.value = 'SSO provider removed.'
+    toast.success('SSO provider removed')
     confirmDeleteId.value = null
     await refreshProviders()
   } catch (err: unknown) {
@@ -272,22 +266,6 @@ async function copyCallbackUrl(providerId: string) {
         Manage trusted identity domains, SSO providers, and work-account access.
       </p>
     </div>
-
-    <!-- Success/Error Messages -->
-    <Transition name="fade">
-      <div
-        v-if="formSuccess"
-        class="ui-alert ui-alert-success mb-4 flex items-center gap-3"
-      >
-        <Check class="size-4 shrink-0" />
-        <p class="flex-1">
-          {{ formSuccess }}
-        </p>
-        <button class="text-emerald-400 hover:text-emerald-600 dark:hover:text-emerald-200" @click="formSuccess = ''">
-          <X class="size-4" />
-        </button>
-      </div>
-    </Transition>
 
     <Transition name="fade">
       <div
@@ -409,16 +387,6 @@ async function copyCallbackUrl(providerId: string) {
               <Check v-else class="size-4" />
               {{ isSavingDomains ? 'Saving…' : 'Save domains' }}
             </button>
-            <Transition
-              enter-active-class="transition-opacity duration-300"
-              leave-active-class="transition-opacity duration-300"
-              enter-from-class="opacity-0"
-              leave-to-class="opacity-0"
-            >
-              <span v-if="domainSaveSuccess" class="text-sm text-success-600 dark:text-success-400 font-medium">
-                Domains saved
-              </span>
-            </Transition>
           </div>
           <div v-if="domainSaveError" class="ui-alert ui-alert-danger">
             {{ domainSaveError }}

--- a/app/pages/onboarding/create-org.vue
+++ b/app/pages/onboarding/create-org.vue
@@ -17,6 +17,7 @@ const { acceptInviteLink } = useInviteLinks()
 const localePath = useLocalePath()
 const config = useRuntimeConfig()
 const { track } = useTrack()
+const toast = useToast()
 
 onMounted(() => track('onboarding_viewed', { mode: viewMode.value }))
 
@@ -198,7 +199,6 @@ const isSearching = ref(false)
 const searchError = ref('')
 const joinRequestMessage = ref('')
 const isSubmittingRequest = ref(false)
-const requestSuccess = ref('')
 const requestError = ref('')
 const selectedOrg = ref<{ id: string; name: string; slug: string } | null>(null)
 
@@ -239,7 +239,6 @@ async function handleSubmitJoinRequest() {
 
   isSubmittingRequest.value = true
   requestError.value = ''
-  requestSuccess.value = ''
 
   try {
     await $fetch('/api/join-requests', {
@@ -249,7 +248,7 @@ async function handleSubmitJoinRequest() {
         message: joinRequestMessage.value.trim() || undefined,
       },
     })
-    requestSuccess.value = `Join request sent to ${selectedOrg.value.name}! An admin will review it.`
+    toast.success(`Join request sent to ${selectedOrg.value.name}`, 'An admin will review it.')
     track('org_joined', { method: 'search_request' })
     selectedOrg.value = null
     joinRequestMessage.value = ''
@@ -444,11 +443,6 @@ async function handleSubmitJoinRequest() {
 
       <div v-if="requestError" class="mt-2 text-xs text-danger-600 dark:text-danger-400">{{ requestError }}</div>
 
-      <!-- Request success -->
-      <div v-if="requestSuccess" class="ui-alert ui-alert-success mt-2 flex items-center gap-2 text-xs">
-        <Check class="size-4 flex-shrink-0" />
-        {{ requestSuccess }}
-      </div>
     </div>
 
     <!-- Back links -->

--- a/tests/unit/success-feedback-toasts.test.ts
+++ b/tests/unit/success-feedback-toasts.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('success feedback toasts', () => {
+  it('uses toasts for transient action success messages instead of inline success banners', () => {
+    const expectations = [
+      {
+        path: 'app/pages/dashboard/settings/account.vue',
+        disallowed: ['profileSuccess'],
+      },
+      {
+        path: 'app/pages/dashboard/settings/index.vue',
+        disallowed: ['saveSuccess'],
+      },
+      {
+        path: 'app/pages/dashboard/settings/localization.vue',
+        disallowed: ['saveSuccess'],
+      },
+      {
+        path: 'app/pages/dashboard/settings/sso.vue',
+        disallowed: ['formSuccess', 'domainSaveSuccess'],
+      },
+      {
+        path: 'app/pages/dashboard/settings/integrations.vue',
+        disallowed: ['successMessage'],
+      },
+      {
+        path: 'app/pages/dashboard/settings/members.vue',
+        disallowed: ['inviteSuccess', 'resendSuccess', 'createLinkSuccess'],
+      },
+      {
+        path: 'app/pages/dashboard/jobs/[id]/application-form.vue',
+        disallowed: ['postingSaved', 'requirementsSaved', 'complianceSaved'],
+      },
+      {
+        path: 'app/pages/dashboard/interviews/templates/[id].vue',
+        disallowed: ['saveSuccess'],
+      },
+      {
+        path: 'app/pages/onboarding/create-org.vue',
+        disallowed: ['requestSuccess'],
+      },
+    ]
+
+    for (const { path, disallowed } of expectations) {
+      const source = readProjectFile(path)
+
+      expect(source, `${path} should use the toast composable`).toContain('useToast()')
+      expect(source, `${path} should emit success toasts`).toContain('toast.success(')
+
+      for (const token of disallowed) {
+        expect(source, `${path} should not keep transient inline success state ${token}`).not.toContain(token)
+      }
+    }
+  })
+})

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -315,7 +315,6 @@ describe('brand-neutral theme variables', () => {
         path: 'app/pages/onboarding/create-org.vue',
         recipes: [
           'ui-alert-danger',
-          'ui-alert-success',
           'ui-button-primary',
           'ui-empty-state',
           'ui-field',
@@ -592,11 +591,11 @@ describe('brand-neutral theme variables', () => {
       },
       {
         path: 'app/pages/dashboard/settings/integrations.vue',
-        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-panel-muted', 'ui-alert-danger', 'ui-alert-success', 'ui-button-primary', 'ui-button-danger', 'ui-button-secondary'],
+        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-panel-muted', 'ui-alert-danger', 'ui-button-primary', 'ui-button-danger', 'ui-button-secondary'],
       },
       {
         path: 'app/pages/dashboard/settings/sso.vue',
-        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-panel-muted', 'ui-empty-panel', 'ui-field', 'ui-alert-danger', 'ui-alert-success', 'ui-button-primary', 'ui-button-secondary', 'ui-button-danger-outline'],
+        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-panel-muted', 'ui-empty-panel', 'ui-field', 'ui-alert-danger', 'ui-button-primary', 'ui-button-secondary', 'ui-button-danger-outline'],
       },
     ]
 
@@ -621,7 +620,6 @@ describe('brand-neutral theme variables', () => {
       'ui-list-row',
       'ui-field',
       'ui-alert-danger',
-      'ui-alert-success',
       'ui-button-primary',
       'ui-button-secondary',
       'ui-button-danger',


### PR DESCRIPTION
## Summary

- Converts high-confidence transient success states to `toast.success` across onboarding, settings, members, SSO/integrations, job application form, and interview templates.
- Leaves stateful success flows untouched: auth/join success pages, interview scheduling success view, job publish success page, feedback success state, and copy button affordances.
- Adds a static guard for these high-confidence success-toast paths and updates theme-neutrality expectations where inline success alerts were removed.

## Validation

- `npm run test:unit -- tests/unit/success-feedback-toasts.test.ts` (red first, then green)
- `npm run test:unit -- tests/unit/success-feedback-toasts.test.ts tests/unit/theme-neutrality.test.ts`
- `npm run test:unit`
- `npm run typecheck` (passes with existing Nuxt i18n / Vue Volar warnings)
- `git diff --check`
- Push preflight: lint, typecheck, tests, and build
