### PR TITLE
feat: add shared popover primitives

### DIFF
--- a/app/components/AppTopBar.vue
+++ b/app/components/AppTopBar.vue
@@ -17,11 +17,8 @@ const { data: session } = await authClient.useSession(useFetch)
 const isSigningOut = ref(false)
 
 const showFeedbackModal = ref(false)
-const showUserMenu = ref(false)
 const showMobileMenu = ref(false)
-const showGetStartedMenu = ref(false)
 const showMoreNav = ref(false)
-const showMoreActions = ref(false)
 
 const config = useRuntimeConfig()
 const { activeOrg } = useCurrentOrg()
@@ -34,12 +31,14 @@ const isDemo = computed(() => {
   return slug && activeOrg.value?.slug === slug
 })
 
-const getStartedMenuRef = useTemplateRef<HTMLElement>('getStartedMenuRoot')
-function onClickOutsideGetStarted(e: MouseEvent) {
-  if (getStartedMenuRef.value && !getStartedMenuRef.value.contains(e.target as Node)) {
-    showGetStartedMenu.value = false
-  }
-}
+const getStartedTriggerRef = ref<HTMLElement | null>(null)
+const getStartedPanelRef = ref<HTMLElement | null>(null)
+const getStartedMenu = useMenuButton({
+  id: 'topbar-get-started-menu',
+  triggerRef: getStartedTriggerRef,
+  menuRef: getStartedPanelRef,
+})
+const showGetStartedMenu = getStartedMenu.isOpen
 
 const userName = computed(() => session.value?.user?.name ?? 'User')
 const userEmail = computed(() => session.value?.user?.email ?? '')
@@ -104,7 +103,25 @@ const { data: feedbackConfig } = useFetch('/api/feedback/config', {
 const isFeedbackEnabled = computed(() => feedbackConfig.value?.enabled === true)
 
 const showChatbot = useFeatureFlagEnabled('chatbot-experience')
-const showFactoryMoreActions = false
+
+const moreActionsTriggerRef = ref<HTMLElement | null>(null)
+const moreActionsPanelRef = ref<HTMLElement | null>(null)
+const moreActionsMenu = useMenuButton({
+  id: 'topbar-more-actions-menu',
+  triggerRef: moreActionsTriggerRef,
+  menuRef: moreActionsPanelRef,
+})
+const showMoreActions = moreActionsMenu.isOpen
+
+const userTriggerRef = ref<HTMLElement | null>(null)
+const userPanelRef = ref<HTMLElement | null>(null)
+const userMenu = useMenuButton({
+  id: 'topbar-user-menu',
+  triggerRef: userTriggerRef,
+  menuRef: userPanelRef,
+  focusOnOpen: false,
+})
+const showUserMenu = userMenu.isOpen
 
 const jobTabs = computed(() => {
   if (!activeJobId.value) return []
@@ -191,29 +208,6 @@ function handleNewJobClick() {
   }
 }
 
-// Close user menu on outside click
-const userMenuRef = useTemplateRef<HTMLElement>('userMenuRoot')
-const moreActionsMenuRef = useTemplateRef<HTMLElement>('moreActionsMenuRoot')
-function onClickOutsideUser(e: MouseEvent) {
-  if (userMenuRef.value && !userMenuRef.value.contains(e.target as Node)) {
-    showUserMenu.value = false
-  }
-}
-function onClickOutsideMoreActions(e: MouseEvent) {
-  if (moreActionsMenuRef.value && !moreActionsMenuRef.value.contains(e.target as Node)) {
-    showMoreActions.value = false
-  }
-}
-onMounted(() => {
-  document.addEventListener('click', onClickOutsideUser)
-  document.addEventListener('click', onClickOutsideMoreActions)
-  document.addEventListener('click', onClickOutsideGetStarted)
-})
-onUnmounted(() => {
-  document.removeEventListener('click', onClickOutsideUser)
-  document.removeEventListener('click', onClickOutsideMoreActions)
-  document.removeEventListener('click', onClickOutsideGetStarted)
-})
 </script>
 
 <template>
@@ -323,10 +317,15 @@ onUnmounted(() => {
         <!-- Right: Actions -->
         <div class="flex shrink-0 items-center gap-1 pl-2 lg:gap-1.5 lg:pl-3 xl:pl-4">
           <!-- Get Started CTA (demo mode only) -->
-          <div v-if="isDemo" ref="getStartedMenuRoot" class="relative hidden sm:block">
+          <div v-if="isDemo" class="relative hidden sm:block">
             <button
+              ref="getStartedTriggerRef"
               class="factory-button-cta factory-button-premium group inline-flex h-9 items-center gap-2 px-4 text-[13px] transition-all duration-200 cursor-pointer"
-              @click="showGetStartedMenu = !showGetStartedMenu"
+              aria-haspopup="menu"
+              :aria-expanded="showGetStartedMenu"
+              aria-controls="topbar-get-started-menu"
+              @click="getStartedMenu.toggleMenu"
+              @keydown="getStartedMenu.onTriggerKeydown"
             >
               <Sparkles class="size-3.5 transition-transform duration-300 group-hover:rotate-12" />
               Get Started
@@ -345,8 +344,12 @@ onUnmounted(() => {
               leave-to-class="opacity-0 scale-95 -translate-y-1"
             >
               <div
+                id="topbar-get-started-menu"
+                ref="getStartedPanelRef"
                 v-if="showGetStartedMenu"
                 class="absolute right-0 top-[calc(100%+6px)] w-72 border border-white/12 bg-black shadow-2xl shadow-black/50 overflow-hidden"
+                role="menu"
+                @keydown="getStartedMenu.onMenuKeydown"
               >
                 <div class="px-4 py-3 border-b border-white/10">
                   <p class="text-xs font-medium text-white/45 uppercase tracking-normal">Choose your setup</p>
@@ -355,6 +358,8 @@ onUnmounted(() => {
                   <NuxtLink
                     :to="$localePath('/auth/fresh-signup')"
                     class="flex items-start gap-3 px-3 py-2.5 transition-colors hover:bg-brand-500/12 no-underline group/item"
+                    role="menuitem"
+                    @click="getStartedMenu.closeMenu()"
                   >
                     <div class="flex items-center justify-center size-8 bg-brand-500/15 text-brand-400 shrink-0 mt-0.5">
                       <Cloud class="size-4" />
@@ -369,6 +374,8 @@ onUnmounted(() => {
                     target="_blank"
                     rel="noopener noreferrer"
                     class="flex items-start gap-3 px-3 py-2.5 transition-colors hover:bg-white/[0.05] no-underline group/item"
+                    role="menuitem"
+                    @click="getStartedMenu.closeMenu()"
                   >
                     <div class="flex items-center justify-center size-8 bg-white/[0.06] text-white/58 shrink-0 mt-0.5">
                       <Server class="size-4" />
@@ -394,18 +401,17 @@ onUnmounted(() => {
 
           <!-- More actions dropdown -->
           <div
-            v-if="showFactoryMoreActions"
-            ref="moreActionsMenuRoot"
             class="relative hidden sm:block"
-            @mouseenter="showMoreActions = true"
-            @mouseleave="showMoreActions = false"
           >
             <button
+              ref="moreActionsTriggerRef"
               class="inline-flex items-center justify-center size-8 bg-transparent text-white/55 transition-all duration-200 cursor-pointer hover:bg-white/[0.04] hover:text-white"
               title="More options"
               aria-haspopup="menu"
               :aria-expanded="showMoreActions"
-              @click.stop="showMoreActions = true"
+              aria-controls="topbar-more-actions-menu"
+              @click.stop="moreActionsMenu.toggleMenu"
+              @keydown="moreActionsMenu.onTriggerKeydown"
             >
               <MoreHorizontal class="size-4" />
             </button>
@@ -421,14 +427,22 @@ onUnmounted(() => {
                 v-if="showMoreActions"
                 class="absolute right-0 top-full z-50 pt-1.5"
               >
-                <div class="w-64 border border-white/12 bg-black shadow-2xl shadow-black/50 overflow-visible py-1">
+                <div
+                  id="topbar-more-actions-menu"
+                  ref="moreActionsPanelRef"
+                  class="w-64 border border-white/12 bg-black shadow-2xl shadow-black/50 overflow-visible py-1"
+                  role="menu"
+                  @keydown="moreActionsMenu.onMenuKeydown"
+                >
                   <div class="py-1">
                     <NuxtLink
                       :to="$localePath('/dashboard/updates')"
                       class="flex items-center gap-2.5 px-3 py-2 text-[13px] font-medium transition-colors no-underline"
+                      role="menuitem"
                       :class="isActiveRoute('/dashboard/updates', false)
                         ? 'bg-brand-500/12 text-white'
                         : 'text-white/62 hover:text-white'"
+                      @click="moreActionsMenu.closeMenu()"
                     >
                       <ArrowUpCircle class="size-4" />
                       Updates & changelog
@@ -436,7 +450,8 @@ onUnmounted(() => {
                     <button
                       v-if="isFeedbackEnabled"
                       class="flex items-center gap-2.5 w-full px-3 py-2 text-[13px] font-medium text-white/62 hover:text-white transition-colors cursor-pointer border-0 bg-transparent text-left"
-                      @click="showFeedbackModal = true; showMoreActions = false"
+                      role="menuitem"
+                      @click="showFeedbackModal = true; moreActionsMenu.closeMenu()"
                     >
                       <MessageSquarePlus class="size-4" />
                       Report issue
@@ -451,10 +466,15 @@ onUnmounted(() => {
           <div class="hidden sm:block w-px h-6 bg-white/10 mx-0.5" />
 
           <!-- User menu -->
-          <div ref="userMenuRoot" class="relative">
+          <div class="relative">
             <button
+              ref="userTriggerRef"
               class="flex h-9 items-center gap-1.5 border-0 bg-transparent px-0 transition-colors duration-200 cursor-pointer hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-500/60"
-              @click="showUserMenu = !showUserMenu"
+              aria-haspopup="menu"
+              :aria-expanded="showUserMenu"
+              aria-controls="topbar-user-menu"
+              @click="userMenu.toggleMenu"
+              @keydown="userMenu.onTriggerKeydown"
             >
               <img
                 v-if="userImage"
@@ -481,8 +501,12 @@ onUnmounted(() => {
               leave-to-class="opacity-0 scale-95 -translate-y-1"
             >
               <div
+                id="topbar-user-menu"
+                ref="userPanelRef"
                 v-if="showUserMenu"
                 class="absolute right-0 top-[calc(100%+6px)] w-64 border border-white/12 bg-black shadow-2xl shadow-black/50 overflow-hidden"
+                role="menu"
+                @keydown="userMenu.onMenuKeydown"
               >
                 <!-- User info header -->
                 <div class="px-4 py-3 border-b border-white/10">
@@ -507,6 +531,7 @@ onUnmounted(() => {
                   <button
                     class="flex items-center gap-2.5 w-full px-4 py-2 text-sm text-white/62 hover:bg-white/[0.05] hover:text-white transition-colors cursor-pointer border-0 bg-transparent text-left"
                     :disabled="isSigningOut"
+                    role="menuitem"
                     @click="handleSignOut"
                   >
                     <LogOut class="size-4" />

--- a/app/components/FactorySelect.vue
+++ b/app/components/FactorySelect.vue
@@ -20,12 +20,17 @@ const emit = defineEmits<{
 
 const open = ref(false)
 const menuRef = ref<HTMLElement | null>(null)
+const triggerRef = ref<HTMLElement | null>(null)
 
 const selectedLabel = computed(() => {
   const opts = props.options ?? []
   const found = opts.find(o => o.value === props.modelValue)
   return found ? found.label : (props.placeholder || 'Select...')
 })
+
+const generatedSelectId = useId()
+const selectId = computed(() => props.id ?? generatedSelectId)
+const selectedIndex = computed(() => (props.options ?? []).findIndex(o => o.value === props.modelValue))
 
 function toggle() {
   if (props.disabled) return
@@ -37,39 +42,52 @@ function select(value: any) {
   open.value = false
 }
 
-function handleClickOutside(e: MouseEvent) {
-  if (typeof document === 'undefined') return
-  if (menuRef.value && !menuRef.value.contains(e.target as Node)) {
-    open.value = false
-  }
+function selectByIndex(index: number) {
+  const option = (props.options ?? [])[index]
+  if (option) select(option.value)
 }
 
-watch(open, (val) => {
-  if (typeof document === 'undefined') return
-  if (val) {
-    document.addEventListener('click', handleClickOutside, true)
-  } else {
-    document.removeEventListener('click', handleClickOutside, true)
-  }
+const listboxNavigation = useListboxNavigation({
+  idBase: selectId,
+  open,
+  optionCount: computed(() => props.options?.length ?? 0),
+  selectedIndex,
+  openListbox: () => {
+    if (!props.disabled) open.value = true
+  },
+  closeListbox: () => {
+    open.value = false
+    triggerRef.value?.focus()
+  },
+  selectIndex: selectByIndex,
 })
+const activeDescendantId = listboxNavigation.activeDescendantId
+const activeOptionIndex = listboxNavigation.activeIndex
 
-onUnmounted(() => {
-  if (typeof document !== 'undefined') {
-    document.removeEventListener('click', handleClickOutside, true)
-  }
+useOutsidePointer({
+  root: menuRef,
+  active: open,
+  eventName: 'click',
+  onOutside: () => {
+    open.value = false
+  },
 })
 </script>
 
 <template>
   <div ref="menuRef" class="factory-filter-dropdown relative" :class="class">
     <button
-      :id="id"
+      ref="triggerRef"
+      :id="selectId"
       type="button"
       class="factory-filter-select factory-filter-dropdown-trigger flex w-full items-center justify-between gap-2 border px-3 py-2 text-sm text-left focus:outline-none transition-colors"
       :disabled="disabled"
       :aria-expanded="open"
+      :aria-controls="`${selectId}-listbox`"
+      :aria-activedescendant="activeDescendantId"
       aria-haspopup="listbox"
       @click="toggle"
+      @keydown="listboxNavigation.onKeydown"
     >
       <span class="truncate">{{ selectedLabel }}</span>
       <ChevronDown
@@ -80,17 +98,21 @@ onUnmounted(() => {
 
     <div
       v-if="open"
+      :id="`${selectId}-listbox`"
       class="factory-filter-dropdown-menu absolute left-0 right-0 top-full z-[70] mt-1 border py-1"
       role="listbox"
+      @keydown="listboxNavigation.onKeydown"
     >
       <button
-        v-for="opt in (options ?? [])"
+        v-for="(opt, idx) in (options ?? [])"
         :key="String(opt.value)"
+        :id="listboxNavigation.optionId(idx)"
         type="button"
         class="factory-filter-dropdown-option flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors"
-        :class="{ 'is-active': modelValue === opt.value }"
+        :class="{ 'is-active': modelValue === opt.value || activeOptionIndex === idx }"
         role="option"
         :aria-selected="modelValue === opt.value"
+        @mouseenter="listboxNavigation.activate(idx)"
         @click="select(opt.value)"
       >
         <Check class="size-3.5 shrink-0" :class="modelValue === opt.value ? '' : 'opacity-0'" />

--- a/app/components/FilterDrawer.vue
+++ b/app/components/FilterDrawer.vue
@@ -25,6 +25,7 @@ function close() {
 const showSaveForm = ref(false)
 const newName = ref('')
 const nameInput = ref<HTMLInputElement | null>(null)
+const drawerRef = ref<HTMLElement | null>(null)
 
 async function openSaveForm() {
   showSaveForm.value = true
@@ -56,13 +57,13 @@ watch(() => props.modelValue, (open) => {
   document.body.style.overflow = open ? 'hidden' : ''
 })
 
-// Close on Escape
-function onKeydown(e: KeyboardEvent) {
-  if (e.key === 'Escape' && props.modelValue) close()
-}
-onMounted(() => document.addEventListener('keydown', onKeydown))
+useFocusTrap({
+  root: drawerRef,
+  active: computed(() => props.modelValue),
+  onEscape: close,
+})
+
 onUnmounted(() => {
-  document.removeEventListener('keydown', onKeydown)
   if (typeof document !== 'undefined') document.body.style.overflow = ''
 })
 </script>
@@ -89,6 +90,7 @@ onUnmounted(() => {
       leave-to-class="translate-x-full"
     >
       <aside
+        ref="drawerRef"
         v-if="modelValue"
         class="factory-dashboard-portal ui-drawer-panel ui-filter-drawer fixed inset-y-0 right-0 z-[60] w-full max-w-md flex flex-col"
         role="dialog"

--- a/app/composables/useFocusTrap.ts
+++ b/app/composables/useFocusTrap.ts
@@ -1,0 +1,105 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { nextTick, onBeforeUnmount, toValue, watch } from 'vue'
+
+type FocusTrapOptions = {
+  root: MaybeRefOrGetter<HTMLElement | null | undefined>
+  active: MaybeRefOrGetter<boolean>
+  onEscape?: () => void
+  focusFirst?: boolean
+  restoreFocus?: boolean
+}
+
+const focusableSelector = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+function getFocusable(root: HTMLElement) {
+  return Array.from(root.querySelectorAll<HTMLElement>(focusableSelector))
+    .filter(el => !el.hasAttribute('disabled') && el.getAttribute('aria-hidden') !== 'true')
+}
+
+export function useFocusTrap(options: FocusTrapOptions) {
+  let previousFocus: HTMLElement | null = null
+  const shouldFocusFirst = options.focusFirst ?? true
+  const shouldRestoreFocus = options.restoreFocus ?? true
+
+  function focusFirst() {
+    const root = toValue(options.root)
+    if (!root) return
+    const first = getFocusable(root)[0] ?? root
+    first.focus()
+  }
+
+  function restoreFocus() {
+    if (!shouldRestoreFocus) return
+    previousFocus?.focus()
+    previousFocus = null
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    if (!toValue(options.active)) return
+
+    if (event.key === 'Escape') {
+      options.onEscape?.()
+      return
+    }
+
+    if (event.key !== 'Tab') return
+
+    const root = toValue(options.root)
+    if (!root) return
+    const focusable = getFocusable(root)
+    if (focusable.length === 0) {
+      event.preventDefault()
+      root.focus()
+      return
+    }
+
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    const current = document.activeElement
+
+    if (event.shiftKey && current === first) {
+      event.preventDefault()
+      last?.focus()
+    } else if (!event.shiftKey && current === last) {
+      event.preventDefault()
+      first?.focus()
+    }
+  }
+
+  watch(
+    () => toValue(options.active),
+    async (active) => {
+      if (typeof document === 'undefined') return
+      if (active) {
+        previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null
+        document.addEventListener('keydown', onKeydown)
+        if (shouldFocusFirst) {
+          await nextTick()
+          focusFirst()
+        }
+      } else {
+        document.removeEventListener('keydown', onKeydown)
+        restoreFocus()
+      }
+    },
+    { immediate: true },
+  )
+
+  onBeforeUnmount(() => {
+    if (typeof document !== 'undefined') document.removeEventListener('keydown', onKeydown)
+    restoreFocus()
+  })
+
+  return {
+    focusFirst,
+    restoreFocus,
+    onKeydown,
+  }
+}

--- a/app/composables/useListboxNavigation.ts
+++ b/app/composables/useListboxNavigation.ts
@@ -1,0 +1,95 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { computed, ref, toValue, watch } from 'vue'
+
+type UseListboxNavigationOptions = {
+  idBase: MaybeRefOrGetter<string>
+  open: MaybeRefOrGetter<boolean>
+  optionCount: MaybeRefOrGetter<number>
+  selectedIndex?: MaybeRefOrGetter<number>
+  openListbox?: () => void
+  closeListbox?: () => void
+  selectIndex: (index: number) => void
+}
+
+export function useListboxNavigation(options: UseListboxNavigationOptions) {
+  const activeIndex = ref(-1)
+
+  const activeDescendantId = computed(() =>
+    activeIndex.value >= 0 ? optionId(activeIndex.value) : undefined
+  )
+
+  function optionId(index: number) {
+    return `${toValue(options.idBase)}-option-${index}`
+  }
+
+  function clamp(index: number) {
+    const count = toValue(options.optionCount)
+    if (count <= 0) return -1
+    if (index < 0) return count - 1
+    if (index >= count) return 0
+    return index
+  }
+
+  function currentSelectedIndex() {
+    const selected = options.selectedIndex == null ? 0 : toValue(options.selectedIndex)
+    return selected >= 0 ? selected : 0
+  }
+
+  function activate(index: number) {
+    activeIndex.value = clamp(index)
+  }
+
+  function selectActive() {
+    if (activeIndex.value < 0) return
+    options.selectIndex(activeIndex.value)
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    const open = toValue(options.open)
+    if (!open && ['ArrowDown', 'ArrowUp', 'Enter', ' '].includes(event.key)) {
+      event.preventDefault()
+      options.openListbox?.()
+      activate(currentSelectedIndex())
+      return
+    }
+
+    if (!open) return
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      activate(activeIndex.value + 1)
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      activate(activeIndex.value - 1)
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      activate(0)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      activate(toValue(options.optionCount) - 1)
+    } else if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      selectActive()
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      options.closeListbox?.()
+    }
+  }
+
+  watch(
+    () => toValue(options.open),
+    (open) => {
+      if (open) activate(currentSelectedIndex())
+      else activeIndex.value = -1
+    },
+  )
+
+  return {
+    activeIndex,
+    activeDescendantId,
+    optionId,
+    activate,
+    selectActive,
+    onKeydown,
+  }
+}

--- a/app/composables/useMenuButton.ts
+++ b/app/composables/useMenuButton.ts
@@ -1,0 +1,89 @@
+import type { Ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
+
+type UseMenuButtonOptions = {
+  id: string
+  triggerRef?: Ref<HTMLElement | null>
+  menuRef?: Ref<HTMLElement | null>
+  closeOnOutside?: boolean
+  focusOnOpen?: boolean
+}
+
+export function useMenuButton(options: UseMenuButtonOptions) {
+  const isOpen = ref(false)
+  const triggerRef = options.triggerRef ?? ref<HTMLElement | null>(null)
+  const menuRef = options.menuRef ?? ref<HTMLElement | null>(null)
+  const focusOnOpen = options.focusOnOpen ?? true
+
+  function focusTrigger() {
+    triggerRef.value?.focus()
+  }
+
+  function focusFirstMenuItem() {
+    const first = menuRef.value?.querySelector<HTMLElement>('[role="menuitem"], a[href], button:not([disabled])')
+    first?.focus()
+  }
+
+  async function openMenu() {
+    isOpen.value = true
+    if (focusOnOpen) {
+      await nextTick()
+      focusFirstMenuItem()
+    }
+  }
+
+  function closeMenu(options: { restoreFocus?: boolean } = {}) {
+    if (!isOpen.value) return
+    isOpen.value = false
+    if (options.restoreFocus) focusTrigger()
+  }
+
+  function toggleMenu() {
+    if (isOpen.value) closeMenu()
+    else openMenu()
+  }
+
+  function onTriggerKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' || event.key === ' ' || event.key === 'ArrowDown') {
+      event.preventDefault()
+      openMenu()
+    } else if (event.key === 'Escape') {
+      closeMenu({ restoreFocus: true })
+    }
+  }
+
+  function onMenuKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      closeMenu({ restoreFocus: true })
+    }
+  }
+
+  if (options.closeOnOutside ?? true) {
+    useOutsidePointer({
+      root: [triggerRef, menuRef],
+      active: isOpen,
+      onOutside: () => closeMenu(),
+    })
+  }
+
+  const triggerAttrs = computed(() => ({
+    'aria-haspopup': 'menu',
+    'aria-expanded': isOpen.value,
+    'aria-controls': options.id,
+  }))
+
+  return {
+    isOpen,
+    triggerRef,
+    menuRef,
+    triggerAttrs,
+    openMenu,
+    closeMenu,
+    toggleMenu,
+    focusTrigger,
+    focusFirstMenuItem,
+    onTriggerKeydown,
+    onMenuKeydown,
+  }
+}

--- a/app/composables/useOutsidePointer.ts
+++ b/app/composables/useOutsidePointer.ts
@@ -1,0 +1,60 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { onBeforeUnmount, toValue, watch } from 'vue'
+
+type MaybeElement = HTMLElement | null | undefined
+
+type UseOutsidePointerOptions = {
+  root: MaybeRefOrGetter<MaybeElement> | Array<MaybeRefOrGetter<MaybeElement>>
+  active?: MaybeRefOrGetter<boolean>
+  eventName?: 'click' | 'mousedown' | 'pointerdown'
+  capture?: boolean
+  onOutside: (event: MouseEvent | PointerEvent) => void
+}
+
+export function useOutsidePointer(options: UseOutsidePointerOptions) {
+  const eventName = options.eventName ?? 'pointerdown'
+  const capture = options.capture ?? true
+  const roots = Array.isArray(options.root) ? options.root : [options.root]
+
+  function isActive() {
+    return options.active == null ? true : toValue(options.active)
+  }
+
+  function containsTarget(target: EventTarget | null) {
+    if (!(target instanceof Node)) return false
+    return roots.some((root) => {
+      const el = toValue(root)
+      return el ? el.contains(target) : false
+    })
+  }
+
+  function onDocumentPointer(event: MouseEvent | PointerEvent) {
+    if (!isActive() || containsTarget(event.target)) return
+    options.onOutside(event)
+  }
+
+  function addListener() {
+    if (typeof document === 'undefined') return
+    document.addEventListener(eventName, onDocumentPointer as EventListener, capture)
+  }
+
+  function removeListener() {
+    if (typeof document === 'undefined') return
+    document.removeEventListener(eventName, onDocumentPointer as EventListener, capture)
+  }
+
+  watch(
+    () => isActive(),
+    (active) => {
+      removeListener()
+      if (active) addListener()
+    },
+    { immediate: true },
+  )
+
+  onBeforeUnmount(removeListener)
+
+  return {
+    onDocumentPointer,
+  }
+}

--- a/tests/unit/shared-popover-primitives.test.ts
+++ b/tests/unit/shared-popover-primitives.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+function readProjectFile(path: string) {
+  return readFileSync(join(process.cwd(), path), 'utf8')
+}
+
+function expectFile(path: string) {
+  expect(existsSync(join(process.cwd(), path)), `${path} should exist`).toBe(true)
+  return readProjectFile(path)
+}
+
+describe('shared keyboard and popover primitives', () => {
+  it('provides reusable focus, outside-click, menu, and listbox helpers', () => {
+    const outsidePointer = expectFile('app/composables/useOutsidePointer.ts')
+    const focusTrap = expectFile('app/composables/useFocusTrap.ts')
+    const menuButton = expectFile('app/composables/useMenuButton.ts')
+    const listboxNavigation = expectFile('app/composables/useListboxNavigation.ts')
+
+    expect(outsidePointer).toContain('useOutsidePointer')
+    expect(focusTrap).toContain('useFocusTrap')
+    expect(focusTrap).toContain('restoreFocus')
+    expect(focusTrap).toContain('focusFirst')
+    expect(menuButton).toContain('useMenuButton')
+    expect(menuButton).toContain('aria-expanded')
+    expect(menuButton).toContain('focusTrigger')
+    expect(listboxNavigation).toContain('useListboxNavigation')
+    expect(listboxNavigation).toContain('activeDescendantId')
+    expect(listboxNavigation).toContain('selectActive')
+  })
+
+  it('uses the shared primitives in representative dashboard controls', () => {
+    const filterDrawer = readProjectFile('app/components/FilterDrawer.vue')
+    const factorySelect = readProjectFile('app/components/FactorySelect.vue')
+    const topbar = readProjectFile('app/components/AppTopBar.vue')
+
+    expect(filterDrawer).toContain('useFocusTrap')
+    expect(filterDrawer).not.toContain("document.addEventListener('keydown', onKeydown)")
+
+    expect(factorySelect).toContain('useOutsidePointer')
+    expect(factorySelect).toContain('useListboxNavigation')
+    expect(factorySelect).toContain('aria-activedescendant')
+    expect(factorySelect).not.toContain('document.addEventListener(\'click\', handleClickOutside')
+
+    expect(topbar).toContain('useMenuButton')
+    expect(topbar).toContain('moreActionsMenu')
+    expect(topbar).not.toContain('const showFactoryMoreActions = false')
+    expect(topbar).not.toMatch(/v-if="showFactoryMoreActions"[\s\S]*title="More options"/)
+  })
+})

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -948,7 +948,8 @@ describe('brand-neutral theme variables', () => {
     const source = readProjectFile('app/components/FactorySelect.vue')
 
     expect(source).toMatch(/defineOptions\(\{\s*inheritAttrs:\s*false,\s*\}\)/)
-    expect(source).toMatch(/<button[\s\S]*:id="id"/)
+    expect(source).toContain('const selectId = computed(() => props.id ?? generatedSelectId)')
+    expect(source).toMatch(/<button[\s\S]*:id="selectId"/)
   })
 
   it('keeps remaining dashboard display helpers centralized', () => {

--- a/tests/unit/topbar-responsive.test.ts
+++ b/tests/unit/topbar-responsive.test.ts
@@ -18,9 +18,12 @@ describe('dashboard top bar responsiveness', () => {
     expect(source).toContain('factory-button-cta factory-button-premium mx-1 hidden h-9')
   })
 
-  it('temporarily hides the desktop more actions menu pending a Factory refactor', () => {
-    expect(source).toContain('const showFactoryMoreActions = false')
-    expect(source).toMatch(/v-if="showFactoryMoreActions"[\s\S]*title="More options"/)
+  it('shows the desktop more actions menu as a keyboard-operable Factory menu', () => {
+    expect(source).not.toContain('const showFactoryMoreActions = false')
+    expect(source).toContain('title="More options"')
+    expect(source).toContain('aria-controls="topbar-more-actions-menu"')
+    expect(source).toContain('role="menu"')
+    expect(source).toContain('useMenuButton')
   })
 
   it('uses bordered Factory controls for job context sub-navigation tabs', () => {


### PR DESCRIPTION
## Summary
- add shared focus trap, outside pointer, menu button, and listbox navigation composables
- wire the primitives into FilterDrawer, FactorySelect, and AppTopBar menus
- re-enable the desktop topbar more-actions menu with keyboard/menu semantics

## Verification
- npm run preflight:pr
- pre-push hook reran npm run preflight:pr
- Playwright browser pass against local dashboard: more-actions menu opens by click and Enter, focuses the Updates menuitem, closes with Escape, and sits clear of the user menu

Closes #48
Closes #37