### PR TITLE
fix: set default font to inter

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "@fontsource-variable/inter";
 @plugin "@tailwindcss/typography";
 @source "../../../shared/properties.ts";
 
@@ -14,6 +15,7 @@
 
 /* ── Theme tokens ───────────────────────────────────────── */
 @theme {
+  --font-sans: "Inter Variable", "Inter", ui-sans-serif, system-ui, sans-serif;
 
   /* ── Brand / Primary ──────────────────────────────────
      Factory orange — used for primary actions, active nav,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@aws-sdk/client-s3": "^3.1053.0",
         "@better-auth/sso": "^1.6.11",
         "@caffeinebounce/email": "^0.6.125",
+        "@fontsource-variable/inter": "^5.2.8",
         "@nuxtjs/i18n": "^10.4.0",
         "@nuxtjs/mdc": "^0.22.0",
         "@opentelemetry/api-logs": "^0.218.0",
@@ -1969,6 +1970,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@hapi/address": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@aws-sdk/client-s3": "^3.1053.0",
     "@better-auth/sso": "^1.6.11",
     "@caffeinebounce/email": "^0.6.125",
+    "@fontsource-variable/inter": "^5.2.8",
     "@nuxtjs/i18n": "^10.4.0",
     "@nuxtjs/mdc": "^0.22.0",
     "@opentelemetry/api-logs": "^0.218.0",

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
@@ -16,6 +16,17 @@ function sliceBetween(source: string, startMarker: string, endMarker: string) {
 }
 
 describe('brand-neutral theme variables', () => {
+  it('uses self-hosted Inter as the global sans font', () => {
+    const css = readProjectFile('app/assets/css/main.css')
+    const packageJson = JSON.parse(readProjectFile('package.json'))
+
+    expect(packageJson.dependencies).toHaveProperty('@fontsource-variable/inter')
+    expect(css).toContain('@import "@fontsource-variable/inter";')
+    expect(existsSync(join(process.cwd(), 'node_modules/@fontsource-variable/inter/index.css'))).toBe(true)
+    expect(css).toMatch(/--font-sans:\s*"Inter Variable",\s*"Inter",\s*ui-sans-serif,/)
+    expect(css).toMatch(/body\s*\{[\s\S]*font-family:\s*var\(--font-sans\);/)
+  })
+
   it('keeps Factory dark pages on a true black document background', () => {
     const css = readProjectFile('app/assets/css/main.css')
     const baseLayer = css.match(/@layer base \{[\s\S]*?\n\}/)?.[0] ?? ''


### PR DESCRIPTION
## Summary
- self-host Inter Variable via Fontsource and set it as the Tailwind/global sans default
- add a theme regression test that guards the package import, font token, and body font-family

## Verification
- npm run test:unit -- tests/unit/theme-neutrality.test.ts
- npm run typecheck
- npm run build
- local Playwright check on http://127.0.0.1:3017/jobs confirmed body font-family resolves to Inter Variable
- pre-push hook ran npm run preflight:pr: CLI parity, full unit suite (124 files / 780 tests), typecheck, CLI smoke, production env validation, build