### PR TITLE
ci: skip heavyweight CI for draft PRs

### DIFF
--- a/.github/workflows/backup-restore-rehearsal.yml
+++ b/.github/workflows/backup-restore-rehearsal.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   rehearsal:
     name: Backup and restore rehearsal
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze JavaScript/TypeScript
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/docker-readme-validation.yml
+++ b/.github/workflows/docker-readme-validation.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   integration:
     name: Simulate new-user setup (setup.sh → docker compose up)
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   smoke:
     name: Playwright smoke
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -85,6 +86,7 @@ jobs:
 
   security-core:
     name: Playwright security core
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -178,7 +180,7 @@ jobs:
     name: Playwright E2E
     runs-on: ubuntu-latest
     needs: [smoke, security-core]
-    if: ${{ always() }}
+    if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
         shell: bash

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   validate:
     name: Build, typecheck, and test
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   gitleaks:
     name: Gitleaks
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
## Summary
- add draft-PR guards to heavyweight workflow jobs
- keep CI active for ready PRs, later synchronizes, workflow dispatch, pushes, and scheduled scans

## Validation
- Ruby Psych parsed the touched workflow YAML files
- Guard-count script confirmed every job in the six touched workflows has the draft guard
- Pre-push validation passed: CLI parity check, unit tests, typecheck, CLI smoke tests, production env contract, and build