### PR TITLE
ci: validate PR title before push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 set -eu
 
+node scripts/validate-current-pr-title.mjs
 npm run preflight:pr

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "vitest run",
     "test:unit": "vitest run",
     "test:smoke:ai-candidate-review": "vitest run --config vitest.smoke.config.ts tests/smoke/ai-candidate-review-context-smoke.smoke.ts",
+    "preflight:pr-title": "node scripts/validate-current-pr-title.mjs",
     "preflight:pr": "node scripts/run-pr-validation-preflight.mjs",
     "preflight:cli-parity": "node scripts/run-pr-validation-preflight.mjs --step cli-parity",
     "typecheck": "nuxi typecheck",

--- a/scripts/validate-current-pr-title.mjs
+++ b/scripts/validate-current-pr-title.mjs
@@ -3,9 +3,17 @@ import { exit } from 'node:process'
 import { fileURLToPath } from 'node:url'
 import { validateConventionalTitle } from './validate-conventional-title.mjs'
 
-export function getPrTitleValidationStatus(title, errorOutput = '') {
+export function getPrTitleValidationStatus(title, errorOutput = '', commandError = null) {
   const normalizedTitle = String(title ?? '').trim()
   const normalizedError = String(errorOutput ?? '').toLowerCase()
+
+  if (!normalizedTitle && commandError?.code === 'ENOENT') {
+    return {
+      ok: true,
+      skipped: true,
+      message: 'GitHub CLI not found; skipping PR title validation.',
+    }
+  }
 
   if (!normalizedTitle && /no pull requests? found|failed to find pull request/.test(normalizedError)) {
     return {
@@ -48,13 +56,7 @@ function readCurrentPrTitle() {
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   const prTitle = readCurrentPrTitle()
-
-  if (prTitle.error) {
-    console.error(`Unable to run gh for PR title validation: ${prTitle.error.message}`)
-    exit(1)
-  }
-
-  const status = getPrTitleValidationStatus(prTitle.stdout, prTitle.stderr)
+  const status = getPrTitleValidationStatus(prTitle.stdout, prTitle.stderr, prTitle.error)
 
   if (status.skipped) {
     console.log(status.message)

--- a/scripts/validate-current-pr-title.mjs
+++ b/scripts/validate-current-pr-title.mjs
@@ -1,0 +1,70 @@
+import { spawnSync } from 'node:child_process'
+import { exit } from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { validateConventionalTitle } from './validate-conventional-title.mjs'
+
+export function getPrTitleValidationStatus(title, errorOutput = '') {
+  const normalizedTitle = String(title ?? '').trim()
+  const normalizedError = String(errorOutput ?? '').toLowerCase()
+
+  if (!normalizedTitle && /no pull requests? found|failed to find pull request/.test(normalizedError)) {
+    return {
+      ok: true,
+      skipped: true,
+      message: 'No open pull request found for the current branch; skipping PR title validation.',
+    }
+  }
+
+  if (!normalizedTitle) {
+    return {
+      ok: false,
+      skipped: false,
+      message: 'Unable to read the current pull request title.',
+    }
+  }
+
+  const result = validateConventionalTitle(normalizedTitle)
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      skipped: false,
+      message: `Current PR title failed title lint: ${result.message}`,
+    }
+  }
+
+  return {
+    ok: true,
+    skipped: false,
+    message: 'Current PR title matches Conventional Commit format.',
+  }
+}
+
+function readCurrentPrTitle() {
+  return spawnSync('gh', ['pr', 'view', '--json', 'title', '--jq', '.title'], {
+    encoding: 'utf8',
+  })
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const prTitle = readCurrentPrTitle()
+
+  if (prTitle.error) {
+    console.error(`Unable to run gh for PR title validation: ${prTitle.error.message}`)
+    exit(1)
+  }
+
+  const status = getPrTitleValidationStatus(prTitle.stdout, prTitle.stderr)
+
+  if (status.skipped) {
+    console.log(status.message)
+    exit(0)
+  }
+
+  if (!status.ok) {
+    console.error(status.message)
+    exit(prTitle.status || 1)
+  }
+
+  console.log(status.message)
+}

--- a/tests/unit/git-hooks-preflight.test.ts
+++ b/tests/unit/git-hooks-preflight.test.ts
@@ -50,6 +50,13 @@ describe('git hook preflight checks', () => {
     })
   })
 
+  it('skips local PR title validation when gh is not installed', () => {
+    expect(getPrTitleValidationStatus('', '', { code: 'ENOENT', message: 'spawnSync gh ENOENT' })).toMatchObject({
+      ok: true,
+      skipped: true,
+    })
+  })
+
   it('rejects the current PR title when it would fail the PR title workflow', () => {
     expect(getPrTitleValidationStatus('[codex] skip heavyweight CI for draft PRs', '')).toMatchObject({
       ok: false,

--- a/tests/unit/git-hooks-preflight.test.ts
+++ b/tests/unit/git-hooks-preflight.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 import { getFetchArgsForBaseRef, getPrPreflightSteps } from '../../scripts/run-pr-validation-preflight.mjs'
 import { validateConventionalTitle } from '../../scripts/validate-conventional-title.mjs'
+import { getPrTitleValidationStatus } from '../../scripts/validate-current-pr-title.mjs'
 
 describe('git hook preflight checks', () => {
   it('accepts PR-title-compatible conventional commit subjects', () => {
@@ -38,7 +39,22 @@ describe('git hook preflight checks', () => {
 
     expect(packageJson.scripts.prepare).toBe('node scripts/install-git-hooks.mjs')
     expect(readFileSync('.githooks/commit-msg', 'utf8')).toContain('validate-conventional-title.mjs')
+    expect(readFileSync('.githooks/pre-push', 'utf8')).toContain('validate-current-pr-title.mjs')
     expect(readFileSync('.githooks/pre-push', 'utf8')).toContain('preflight:pr')
+  })
+
+  it('skips local PR title validation before a branch has an open PR', () => {
+    expect(getPrTitleValidationStatus('', 'failed to find pull request')).toMatchObject({
+      ok: true,
+      skipped: true,
+    })
+  })
+
+  it('rejects the current PR title when it would fail the PR title workflow', () => {
+    expect(getPrTitleValidationStatus('[codex] skip heavyweight CI for draft PRs', '')).toMatchObject({
+      ok: false,
+      skipped: false,
+    })
   })
 
   it('fetches the configured base ref instead of hard-coding main', () => {


### PR DESCRIPTION
## Summary
- add a local PR-title preflight script that validates the current branch PR title with the same Conventional Commit helper used by commit-msg hooks
- run the guard first in `.githooks/pre-push`, while skipping cleanly before a branch has an open PR
- add unit coverage for the hook wiring, no-PR skip path, and invalid `[codex] ...` title case

## Validation
- npm run test:unit -- tests/unit/git-hooks-preflight.test.ts
- npm run preflight:pr-title
- git push pre-push suite passed: PR title guard, CLI parity, unit tests, typecheck, CLI smoke tests, production env contract, and build