### PR TITLE
docs: add agent guidance conventions

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! cmp -s AGENTS.md CLAUDE.md; then
+  cat >&2 <<'EOF'
+AGENTS.md and CLAUDE.md must stay in sync.
+
+Update both files with identical content before committing.
+EOF
+  exit 1
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,176 @@
+# Agent Context
+
+## What This Repo Is
+
+`factory-careers` is Factory's hiring and applicant-tracking system for
+`careers.thefactoryhq.com`.
+
+- Public job board and application flows live under `app/pages` and supporting `app/components`.
+- Authenticated dashboard surfaces live under `app/pages/dashboard`.
+- Nitro API routes, server utilities, database schema, migrations, and scripts live under `server`.
+- Shared cross-boundary helpers live under `shared`.
+- The authenticated CLI lives under `packages/careers-cli`.
+- Unit tests live under `tests/unit`; browser tests live under `e2e`.
+
+## Stack
+
+- Nuxt 4 and Vue 3
+- TypeScript
+- Nitro server routes
+- PostgreSQL with Drizzle ORM
+- Better Auth
+- Tailwind CSS v4
+- Vitest and Playwright
+- MinIO/S3-compatible private document storage
+- Microsoft and Google calendar integration paths
+- Shared `@caffeinebounce/email` package for transactional email rendering
+
+## Product Boundaries
+
+Factory Careers began as an AGPL-compatible Reqcore fork, but it is now its own
+Factory operational product. Preserve useful upstream patterns where they fit,
+but evaluate product, security, access, deployment, and automation decisions
+against Factory's current workflow.
+
+This app owns Factory Careers-specific ATS behavior: jobs, candidates,
+applications, source tracking, interviews, organization controls, AI-assisted
+recruiting workflows, public job applications, and authenticated CLI automation.
+
+Reusable package behavior belongs in the appropriate shared package. Do not copy
+shared-package source into this repo for local tweaks.
+
+## Local Setup
+
+Use the README for full setup details. The short version:
+
+```bash
+export NODE_AUTH_TOKEN=ghp_your_github_packages_read_token
+npm ci
+./setup.sh
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+In Codex worktrees, the sibling checkout at
+`/Users/douglasebanks/code/repos/factory-careers` is the usual source of truth
+for `.env` and `.env.local`.
+
+## Authenticated CLI
+
+The CLI is the preferred automation surface for agents and operator scripts.
+
+```bash
+./packages/careers-cli/bin/factory-careers.mjs --help
+./packages/careers-cli/bin/factory-careers.mjs auth status --json
+```
+
+Keep CLI behavior deterministic and agent-friendly:
+
+- Support `--json`, `--stdin`, `--yes`, and `--no-input` on automation paths.
+- Return structured status, code, and message fields in JSON mode.
+- Add CLI parity evidence when API, shared contract, or route behavior changes.
+- Keep `docs/CLI.md` aligned with route coverage and intentional exclusions.
+
+## Organization And AI Context
+
+Organization-level defaults belong in organization settings, not hardcoded
+server prompts or shared logic. In particular, keep business framing such as
+`analysisContext` editable through the organization settings flow and available
+to the CLI.
+
+Do not hardcode org-specific business context into shared scoring, parsing, or
+chatbot logic when a settings/config/content surface is the correct owner.
+
+## Verification
+
+Run the narrowest useful proof set for the change, then broaden when touching
+API contracts, auth, tenant isolation, database schema, CLI coverage, public
+applications, or dashboard workflows.
+
+Common checks:
+
+```bash
+npm run test:unit
+npm run typecheck
+npm run build
+```
+
+Useful focused checks:
+
+```bash
+npm run check:conventions
+npm run preflight:cli-parity
+./packages/careers-cli/bin/factory-careers.mjs --help
+./packages/careers-cli/bin/factory-careers.mjs auth status --json
+npm run test:e2e:smoke
+```
+
+Run `npm run preflight:pr` before pushing broad changes. It mirrors the required
+PR validation path: CLI parity evidence, unit tests, optional lint, typecheck,
+CLI smoke tests, production env contract validation, and build.
+
+Browser QA matters for public job flows, application forms, dashboard controls,
+settings pages, custom listboxes/menus, responsive layout, and visual polish.
+Green unit tests are not enough for visible UX changes.
+
+## Convention Checks
+
+Use `npm run check:conventions` when changing agent instructions, contributor
+docs, repo conventions, CLI docs, theme rules, API/shared contracts, or
+workflow-sensitive files. This fast check verifies AGENTS/CLAUDE sync, CLI
+parity guard wiring, merge-conflict hygiene, theme rules, and agent-facing docs.
+
+This is a focused rules bundle, not a replacement for typecheck, build, e2e, or
+runtime browser checks when behavior changes.
+
+## DRY And Reuse
+
+Search for an existing component, composable, helper, or server utility before creating a new one.
+Start with `rg` across `app/components`, `app/composables`, `server/utils`, `server/api`, `shared`, and `packages/careers-cli` so new work fits the repo instead of adding a parallel pattern.
+
+Prefer extending or extracting existing pieces over creating one-off variants.
+If similar UI, validation, API plumbing, CLI formatting, auth checks, or data
+normalization already exists, reuse it directly or create a shared abstraction
+near the current owner. Keep abstractions small and grounded in real repeated
+behavior.
+
+Treat structural duplication as implementation work. When a DRY pass surfaces
+repeated components, copy-pasted request handlers, duplicated form logic, or
+parallel state helpers, fix the shared shape or split the cleanup into scoped
+follow-up issues rather than leaving only a note.
+
+## Working Rules
+
+- Keep changes scoped to the task. This repo often has active adjacent PRs.
+- Check `git status --short` before editing, before staging, and before final handoff.
+- Pin GitHub CLI commands with `gh --repo theFactoryHQ/factory-careers ...`.
+- Use Nuxt 4 `app/` plus root `server/` structure.
+- Use `env` from `server/utils/env.ts` in server code instead of direct `process.env` access.
+- For domain data, always scope server queries by `organizationId` from session.
+- Preserve tenant isolation and role checks when touching dashboard or API code.
+- Prefer typed schemas and structured parsers over ad hoc string manipulation.
+- Keep expected negative paths quiet and explicit; validation failures should return useful status codes without noisy production logs.
+- Follow [docs/reference/THEME.md](docs/reference/THEME.md) for visual work.
+- For UI work, preserve visible focus, Escape behavior, focus return, and keyboard support for custom listbox, menu, combobox, modal, and drawer patterns.
+- Do not edit unrelated OpenClaw, agent, machine-level config, or private personality files from this repo.
+
+## Important Areas
+
+- Public jobs and applications: `app/pages/jobs`, `app/pages/apply`, public API routes, upload handling, and application compliance tests.
+- Dashboard: `app/pages/dashboard`, `app/components`, `app/composables`, and dashboard-focused unit/e2e coverage.
+- Auth and access: Better Auth config, SSO providers, invitation links, join requests, signup domain allowlists, and RBAC helpers.
+- AI workflows: `server/utils/ai`, AI config routes, scoring tests, org `analysisContext`, and provider/model catalog behavior.
+- CLI: `packages/careers-cli`, `docs/CLI.md`, route coverage manifests, and CLI parity tests.
+- Database: `server/database`, Drizzle migrations, and `server/database/migrations/meta/_journal.json`.
+- Operations: `render.yaml`, Docker files, production env validation, backup rehearsals, and docs under `docs/operations`.
+
+## Pull Request Hygiene
+
+- Start from a clean branch or worktree when possible.
+- Use focused commits with prefixes such as `feat:`, `fix:`, `refactor:`, or `docs:`.
+- Agent-generated commits should use `git commit --no-verify`; then run the relevant checks manually.
+- Keep DCO requirements in mind for human-authored commits.
+- If API/shared contract files change, run `npm run preflight:cli-parity` and include CLI docs or tests as evidence when needed.
+- When concurrent schema work exists, check migration numbering and `_journal.json` early to avoid collision churn.
+- Before calling a PR ready, verify both code health and visible UX when the change is user-facing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,176 @@
+# Agent Context
+
+## What This Repo Is
+
+`factory-careers` is Factory's hiring and applicant-tracking system for
+`careers.thefactoryhq.com`.
+
+- Public job board and application flows live under `app/pages` and supporting `app/components`.
+- Authenticated dashboard surfaces live under `app/pages/dashboard`.
+- Nitro API routes, server utilities, database schema, migrations, and scripts live under `server`.
+- Shared cross-boundary helpers live under `shared`.
+- The authenticated CLI lives under `packages/careers-cli`.
+- Unit tests live under `tests/unit`; browser tests live under `e2e`.
+
+## Stack
+
+- Nuxt 4 and Vue 3
+- TypeScript
+- Nitro server routes
+- PostgreSQL with Drizzle ORM
+- Better Auth
+- Tailwind CSS v4
+- Vitest and Playwright
+- MinIO/S3-compatible private document storage
+- Microsoft and Google calendar integration paths
+- Shared `@caffeinebounce/email` package for transactional email rendering
+
+## Product Boundaries
+
+Factory Careers began as an AGPL-compatible Reqcore fork, but it is now its own
+Factory operational product. Preserve useful upstream patterns where they fit,
+but evaluate product, security, access, deployment, and automation decisions
+against Factory's current workflow.
+
+This app owns Factory Careers-specific ATS behavior: jobs, candidates,
+applications, source tracking, interviews, organization controls, AI-assisted
+recruiting workflows, public job applications, and authenticated CLI automation.
+
+Reusable package behavior belongs in the appropriate shared package. Do not copy
+shared-package source into this repo for local tweaks.
+
+## Local Setup
+
+Use the README for full setup details. The short version:
+
+```bash
+export NODE_AUTH_TOKEN=ghp_your_github_packages_read_token
+npm ci
+./setup.sh
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+In Codex worktrees, the sibling checkout at
+`/Users/douglasebanks/code/repos/factory-careers` is the usual source of truth
+for `.env` and `.env.local`.
+
+## Authenticated CLI
+
+The CLI is the preferred automation surface for agents and operator scripts.
+
+```bash
+./packages/careers-cli/bin/factory-careers.mjs --help
+./packages/careers-cli/bin/factory-careers.mjs auth status --json
+```
+
+Keep CLI behavior deterministic and agent-friendly:
+
+- Support `--json`, `--stdin`, `--yes`, and `--no-input` on automation paths.
+- Return structured status, code, and message fields in JSON mode.
+- Add CLI parity evidence when API, shared contract, or route behavior changes.
+- Keep `docs/CLI.md` aligned with route coverage and intentional exclusions.
+
+## Organization And AI Context
+
+Organization-level defaults belong in organization settings, not hardcoded
+server prompts or shared logic. In particular, keep business framing such as
+`analysisContext` editable through the organization settings flow and available
+to the CLI.
+
+Do not hardcode org-specific business context into shared scoring, parsing, or
+chatbot logic when a settings/config/content surface is the correct owner.
+
+## Verification
+
+Run the narrowest useful proof set for the change, then broaden when touching
+API contracts, auth, tenant isolation, database schema, CLI coverage, public
+applications, or dashboard workflows.
+
+Common checks:
+
+```bash
+npm run test:unit
+npm run typecheck
+npm run build
+```
+
+Useful focused checks:
+
+```bash
+npm run check:conventions
+npm run preflight:cli-parity
+./packages/careers-cli/bin/factory-careers.mjs --help
+./packages/careers-cli/bin/factory-careers.mjs auth status --json
+npm run test:e2e:smoke
+```
+
+Run `npm run preflight:pr` before pushing broad changes. It mirrors the required
+PR validation path: CLI parity evidence, unit tests, optional lint, typecheck,
+CLI smoke tests, production env contract validation, and build.
+
+Browser QA matters for public job flows, application forms, dashboard controls,
+settings pages, custom listboxes/menus, responsive layout, and visual polish.
+Green unit tests are not enough for visible UX changes.
+
+## Convention Checks
+
+Use `npm run check:conventions` when changing agent instructions, contributor
+docs, repo conventions, CLI docs, theme rules, API/shared contracts, or
+workflow-sensitive files. This fast check verifies AGENTS/CLAUDE sync, CLI
+parity guard wiring, merge-conflict hygiene, theme rules, and agent-facing docs.
+
+This is a focused rules bundle, not a replacement for typecheck, build, e2e, or
+runtime browser checks when behavior changes.
+
+## DRY And Reuse
+
+Search for an existing component, composable, helper, or server utility before creating a new one.
+Start with `rg` across `app/components`, `app/composables`, `server/utils`, `server/api`, `shared`, and `packages/careers-cli` so new work fits the repo instead of adding a parallel pattern.
+
+Prefer extending or extracting existing pieces over creating one-off variants.
+If similar UI, validation, API plumbing, CLI formatting, auth checks, or data
+normalization already exists, reuse it directly or create a shared abstraction
+near the current owner. Keep abstractions small and grounded in real repeated
+behavior.
+
+Treat structural duplication as implementation work. When a DRY pass surfaces
+repeated components, copy-pasted request handlers, duplicated form logic, or
+parallel state helpers, fix the shared shape or split the cleanup into scoped
+follow-up issues rather than leaving only a note.
+
+## Working Rules
+
+- Keep changes scoped to the task. This repo often has active adjacent PRs.
+- Check `git status --short` before editing, before staging, and before final handoff.
+- Pin GitHub CLI commands with `gh --repo theFactoryHQ/factory-careers ...`.
+- Use Nuxt 4 `app/` plus root `server/` structure.
+- Use `env` from `server/utils/env.ts` in server code instead of direct `process.env` access.
+- For domain data, always scope server queries by `organizationId` from session.
+- Preserve tenant isolation and role checks when touching dashboard or API code.
+- Prefer typed schemas and structured parsers over ad hoc string manipulation.
+- Keep expected negative paths quiet and explicit; validation failures should return useful status codes without noisy production logs.
+- Follow [docs/reference/THEME.md](docs/reference/THEME.md) for visual work.
+- For UI work, preserve visible focus, Escape behavior, focus return, and keyboard support for custom listbox, menu, combobox, modal, and drawer patterns.
+- Do not edit unrelated OpenClaw, agent, machine-level config, or private personality files from this repo.
+
+## Important Areas
+
+- Public jobs and applications: `app/pages/jobs`, `app/pages/apply`, public API routes, upload handling, and application compliance tests.
+- Dashboard: `app/pages/dashboard`, `app/components`, `app/composables`, and dashboard-focused unit/e2e coverage.
+- Auth and access: Better Auth config, SSO providers, invitation links, join requests, signup domain allowlists, and RBAC helpers.
+- AI workflows: `server/utils/ai`, AI config routes, scoring tests, org `analysisContext`, and provider/model catalog behavior.
+- CLI: `packages/careers-cli`, `docs/CLI.md`, route coverage manifests, and CLI parity tests.
+- Database: `server/database`, Drizzle migrations, and `server/database/migrations/meta/_journal.json`.
+- Operations: `render.yaml`, Docker files, production env validation, backup rehearsals, and docs under `docs/operations`.
+
+## Pull Request Hygiene
+
+- Start from a clean branch or worktree when possible.
+- Use focused commits with prefixes such as `feat:`, `fix:`, `refactor:`, or `docs:`.
+- Agent-generated commits should use `git commit --no-verify`; then run the relevant checks manually.
+- Keep DCO requirements in mind for human-authored commits.
+- If API/shared contract files change, run `npm run preflight:cli-parity` and include CLI docs or tests as evidence when needed.
+- When concurrent schema work exists, check migration numbering and `_journal.json` early to avoid collision churn.
+- Before calling a PR ready, verify both code health and visible UX when the change is user-facing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thanks for contributing to Factory Careers.
 
 ## Before You Start
 
+- Read [AGENTS.md](AGENTS.md) for repo-specific agent context, working rules,
+  verification commands, and automation guidance.
 - Read [docs/reference/PRODUCT.md](docs/reference/PRODUCT.md), [docs/reference/ARCHITECTURE.md](docs/reference/ARCHITECTURE.md), and [docs/reference/ROADMAP.md](docs/reference/ROADMAP.md) for product and technical context.
 - For bug reports and feature ideas, use GitHub Issues.
 - For security reports, do **not** open a public issue. Follow [SECURITY.md](SECURITY.md).
@@ -26,14 +28,23 @@ npm run dev
 3. Ensure every commit includes a **DCO sign-off**.
 4. Open a pull request with a clear summary and testing notes.
 
+Agent-generated commits should use `git commit --no-verify`, then run the
+relevant checks manually before pushing.
+
 ### Local CI Preflight
 
 `npm install` configures git to use this repo's `.githooks` directory. The hooks catch the two most common PR failures before GitHub Actions spends a run:
 
 - `commit-msg` validates Conventional Commit syntax with the same allowed types as the PR title lint workflow.
+- `pre-commit` keeps `AGENTS.md` and `CLAUDE.md` identical for agent/tool compatibility.
 - `pre-push` runs `npm run preflight:pr`, which mirrors the required PR validation job: CLI parity evidence, unit tests, optional lint, typecheck, CLI smoke tests, production env contract validation, and build.
 
 Run `npm run prepare` if you need to reinstall the hooks in an existing checkout.
+
+Use `npm run check:conventions` after changing agent instructions,
+contributor docs, repo conventions, CLI docs, theme rules, API/shared contracts,
+or workflow-sensitive files. It runs the AGENTS/CLAUDE sync hook, focused
+convention tests, and the CLI parity guard.
 
 ### DCO Sign-off (Required)
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "vitest run",
     "test:unit": "vitest run",
     "test:smoke:ai-candidate-review": "vitest run --config vitest.smoke.config.ts tests/smoke/ai-candidate-review-context-smoke.smoke.ts",
+    "check:conventions": "bash scripts/check-conventions.sh",
     "preflight:pr": "node scripts/run-pr-validation-preflight.mjs",
     "preflight:cli-parity": "node scripts/run-pr-validation-preflight.mjs --step cli-parity",
     "typecheck": "nuxi typecheck",

--- a/scripts/check-conventions.sh
+++ b/scripts/check-conventions.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "==> Checking agent docs sync"
+bash .githooks/pre-commit
+
+echo "==> Running focused convention tests"
+npm run test:unit -- \
+  tests/unit/agent-guidance.test.ts \
+  tests/unit/git-hooks-preflight.test.ts \
+  tests/unit/merge-conflict-hygiene.test.ts \
+  tests/unit/theme-neutrality.test.ts \
+  tests/unit/cli-documentation.test.ts \
+  tests/unit/cli-parity-changed-files.test.ts \
+  tests/unit/cli-ci-coverage.test.ts
+
+echo "==> Checking CLI parity guard"
+npm run preflight:cli-parity
+
+echo "==> Convention checks passed"

--- a/tests/unit/agent-guidance.test.ts
+++ b/tests/unit/agent-guidance.test.ts
@@ -1,0 +1,54 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = process.cwd()
+
+function read(path: string): string {
+  return readFileSync(join(root, path), 'utf8')
+}
+
+describe('agent guidance', () => {
+  it('keeps AGENTS.md and CLAUDE.md identical with Factory Careers context', () => {
+    expect(existsSync(join(root, 'AGENTS.md'))).toBe(true)
+    expect(existsSync(join(root, 'CLAUDE.md'))).toBe(true)
+
+    const agents = read('AGENTS.md')
+
+    expect(read('CLAUDE.md')).toBe(agents)
+
+    for (const snippet of [
+      'Factory Careers',
+      'Nuxt 4',
+      'Authenticated CLI',
+      'organizationId',
+      'analysisContext',
+      'Do not hardcode org-specific business context',
+      'Search for an existing component, composable, helper, or server utility before creating a new one',
+      'Treat structural duplication as implementation work',
+      'gh --repo theFactoryHQ/factory-careers',
+      'npm run preflight:pr',
+      'docs/reference/THEME.md',
+      'Browser QA matters',
+    ]) {
+      expect(agents, `AGENTS.md missing ${snippet}`).toContain(snippet)
+    }
+  })
+
+  it('provides a fast convention check for agent-facing repo rules', () => {
+    const packageJson = JSON.parse(read('package.json'))
+
+    expect(packageJson.scripts['check:conventions']).toBe('bash scripts/check-conventions.sh')
+    expect(read('.githooks/pre-commit')).toContain('AGENTS.md and CLAUDE.md must stay in sync')
+    expect(read('scripts/check-conventions.sh')).toContain('Checking agent docs sync')
+    expect(read('scripts/check-conventions.sh')).toContain('npm run preflight:cli-parity')
+  })
+
+  it('points contributors to agent guidance and convention checks', () => {
+    const contributing = read('CONTRIBUTING.md')
+
+    expect(contributing).toContain('[AGENTS.md](AGENTS.md)')
+    expect(contributing).toContain('npm run check:conventions')
+    expect(contributing).toContain('Agent-generated commits should use `git commit --no-verify`')
+  })
+})


### PR DESCRIPTION
## Summary

- add synced root AGENTS.md and CLAUDE.md guidance tailored to Factory Careers
- add DRY/reuse rules that tell agents to search existing components, composables, helpers, server utilities, and CLI patterns before creating new ones
- add a pre-commit sync hook, check:conventions script, and regression coverage for the agent guidance contract
- update contributor docs to point agents and contributors at the new convention workflow

## Validation

- npm run check:conventions
- npm run preflight:pr (via pre-push)
