### PR TITLE
fix: reintegrate invitation management e2e

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -268,10 +268,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  ui:
+    name: Playwright UI
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run invitation management browser checks
+        run: npm run test:e2e:ui
+
+      - name: Upload Playwright UI report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-ui-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, uploads]
+    needs: [smoke, security-core, uploads, ui]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -288,6 +358,10 @@ jobs:
           fi
           if [ "${{ needs.uploads.result }}" != "success" ]; then
             echo "Playwright uploads finished with result: ${{ needs.uploads.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.ui.result }}" != "success" ]; then
+            echo "Playwright UI finished with result: ${{ needs.ui.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/e2e/critical-flows/invitation-management.spec.ts
+++ b/e2e/critical-flows/invitation-management.spec.ts
@@ -12,11 +12,10 @@ import { test, expect } from '../fixtures'
  * 6. Owner cancels the invitation
  */
 
-const INVITED_EMAIL = 'invited-member@test.local'
-
 test.describe('Invitation Management Flow', () => {
   test('owner can invite, resend, and cancel an invitation', async ({ authenticatedPage }) => {
     const page = authenticatedPage
+    const invitedEmail = `invited-member-${Date.now()}@test.local`
 
     // ── Navigate to Members page ──────────────────────────
     await page.goto('/dashboard/settings/members')
@@ -33,7 +32,7 @@ test.describe('Invitation Management Flow', () => {
     // Fill in the invite form
     const emailInput = page.getByPlaceholder('colleague@company.com')
     await emailInput.waitFor({ state: 'visible', timeout: 10_000 })
-    await emailInput.fill(INVITED_EMAIL)
+    await emailInput.fill(invitedEmail)
 
     // Submit the invitation and wait for the server mutation.
     const [inviteResponse] = await Promise.all([
@@ -46,13 +45,10 @@ test.describe('Invitation Management Flow', () => {
     ])
     expect(inviteResponse.status(), `Invite API returned ${inviteResponse.status()}`).toBe(200)
 
-    // Wait for success message
-    await expect(page.getByText(`Invitation sent to ${INVITED_EMAIL}`)).toBeVisible({ timeout: 15_000 })
-
     // ── Step 2: Verify pending invitation appears ─────────
     // The pending invitations section should now show
     await expect(page.getByText('Pending invitations')).toBeVisible({ timeout: 10_000 })
-    await expect(page.getByText(INVITED_EMAIL).last()).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByRole('link', { name: invitedEmail })).toBeVisible({ timeout: 10_000 })
 
     // ── Step 3: Resend the invitation ─────────────────────
     const resendButton = page.getByRole('button', { name: 'Resend' })
@@ -67,16 +63,13 @@ test.describe('Invitation Management Flow', () => {
     ])
     expect(resendResponse.status(), `Resend API returned ${resendResponse.status()}`).toBe(200)
 
-    // Wait for resend success message
-    await expect(page.getByText(`Invitation resent to ${INVITED_EMAIL}`)).toBeVisible({ timeout: 15_000 })
-
     // Invitation should still appear in the list
-    await expect(page.getByText(INVITED_EMAIL).last()).toBeVisible()
+    await expect(page.getByRole('link', { name: invitedEmail })).toBeVisible()
 
     // ── Step 4: Cancel the invitation ─────────────────────
     const pendingInviteRow = page
       .locator('.ui-list-row')
-      .filter({ has: page.getByRole('link', { name: INVITED_EMAIL }) })
+      .filter({ has: page.getByRole('link', { name: invitedEmail }) })
     await expect(pendingInviteRow).toBeVisible()
 
     const cancelButton = pendingInviteRow.getByRole('button', { name: 'Cancel' })
@@ -99,13 +92,13 @@ test.describe('Invitation Management Flow', () => {
     // After cancellation, the invitation should no longer appear
     // (or the pending invitations section could be hidden entirely if empty)
     const pendingSection = page.getByText('Pending invitations')
-    const invitedEmail = page.getByText(INVITED_EMAIL)
+    const invitedEmailLink = page.getByRole('link', { name: invitedEmail })
 
     // Either the section is gone or the email is no longer listed
     const isHidden = await pendingSection.isHidden().catch(() => true)
     if (!isHidden) {
       // Section still visible - email should not be in it
-      await expect(invitedEmail.last()).toBeHidden({ timeout: 10_000 })
+      await expect(invitedEmailLink).toBeHidden({ timeout: 10_000 })
     }
   })
 })

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -65,6 +65,15 @@ describe('Playwright E2E harness contract', () => {
     )
   })
 
+  it('runs invitation management browser coverage in a dedicated UI CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+
+    expect(workflow).toContain('name: Playwright UI')
+    expect(workflow).toContain('npm run test:e2e:ui')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui]')
+    expect(workflow).toContain('needs.ui.result')
+  })
+
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
     const packageJson = JSON.parse(read('package.json')) as {
@@ -78,7 +87,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads]')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -94,10 +103,11 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads]')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.uploads.result')
+    expect(workflow).toContain('needs.ui.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {


### PR DESCRIPTION
## Summary
- add a dedicated Playwright UI lane for invitation management coverage
- include the UI lane in the aggregate Playwright E2E status
- update the invitation flow assertions to verify persisted pending invitation state instead of stale toast copy
- keep fake S3 env present so Nuxt boots without touching real services

Closes #109

## Verification
- `PATH=/Users/douglasebanks/.nvm/versions/node/v22.22.0/bin:$PATH npm run test:unit -- tests/unit/e2e-harness-contract.test.ts`
- `env CI=true PATH=/opt/homebrew/bin:/Users/douglasebanks/.nvm/versions/node/v22.22.0/bin:$PATH DATABASE_URL=postgresql://factory_e2e:factory_e2e@127.0.0.1:55432/factory_careers_e2e BETTER_AUTH_SECRET=ci-e2e-auth-secret-with-at-least-32-chars BETTER_AUTH_URL=http://127.0.0.1:3333 BETTER_AUTH_TRUSTED_ORIGINS=http://127.0.0.1:3333 NUXT_PUBLIC_SITE_URL=http://127.0.0.1:3333 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3333 FACTORY_DISABLE_PUBLIC_SIGNUP=false FACTORY_DISABLE_PUBLIC_ORG_CREATION=false S3_ENDPOINT=http://127.0.0.1:9000 S3_ACCESS_KEY=e2e-access-key S3_SECRET_KEY=e2e-secret-key S3_BUCKET=factory-careers-e2e S3_REGION=us-east-1 S3_FORCE_PATH_STYLE=true S3_SKIP_BUCKET_INIT=true SMTP_FROM=e2e@example.com npm run test:e2e:ui`

## Stack note
This PR targets `codex/e2e-resume-upload` so it reviews only the #109 delta while #120 is still open. After #120 lands, this can be retargeted/rebased onto `main`.