### PR TITLE
fix: reintegrate candidate application e2e

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -310,10 +310,102 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  candidate:
+    name: Playwright candidate
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "false"
+      S3_SKIP_BUCKET_POLICY: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Start MinIO
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run -d --rm \
+            --name factory-careers-candidate-minio \
+            -e MINIO_ROOT_USER=e2e-access-key \
+            -e MINIO_ROOT_PASSWORD=e2e-secret-key \
+            -p 127.0.0.1:9000:9000 \
+            minio/minio server /data
+
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          docker logs factory-careers-candidate-minio
+          exit 1
+
+      - name: Run candidate application browser checks
+        run: npm run test:e2e:candidate
+
+      - name: Upload Playwright candidate report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-candidate-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, uploads, ui]
+    needs: [smoke, security-core, uploads, ui, candidate]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -334,6 +426,10 @@ jobs:
           fi
           if [ "${{ needs.ui.result }}" != "success" ]; then
             echo "Playwright UI finished with result: ${{ needs.ui.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.candidate.result }}" != "success" ]; then
+            echo "Playwright candidate finished with result: ${{ needs.candidate.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -223,25 +223,11 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Start MinIO
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker run -d --rm \
-            --name factory-careers-security-extended-minio \
-            -e MINIO_ROOT_USER=e2e-access-key \
-            -e MINIO_ROOT_PASSWORD=e2e-secret-key \
-            -p 127.0.0.1:9000:9000 \
-            minio/minio server /data
-
-          for _ in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
-              exit 0
-            fi
-            sleep 1
-          done
-
-          docker logs factory-careers-security-extended-minio
-          exit 1
+        uses: ./.github/actions/start-minio
+        with:
+          container-name: factory-careers-security-extended-minio
+          access-key: e2e-access-key
+          secret-key: e2e-secret-key
 
       - name: Run extended tenant isolation security checks
         run: npm run test:e2e:security:extended
@@ -463,25 +449,11 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Start MinIO
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker run -d --rm \
-            --name factory-careers-candidate-minio \
-            -e MINIO_ROOT_USER=e2e-access-key \
-            -e MINIO_ROOT_PASSWORD=e2e-secret-key \
-            -p 127.0.0.1:9000:9000 \
-            minio/minio server /data
-
-          for _ in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
-              exit 0
-            fi
-            sleep 1
-          done
-
-          docker logs factory-careers-candidate-minio
-          exit 1
+        uses: ./.github/actions/start-minio
+        with:
+          container-name: factory-careers-candidate-minio
+          access-key: e2e-access-key
+          secret-key: e2e-secret-key
 
       - name: Run candidate application browser checks
         run: npm run test:e2e:candidate

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -162,6 +162,99 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  security-extended:
+    name: Playwright security extended
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      FEATURE_FLAG_CHATBOT_EXPERIENCE: "true"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "false"
+      S3_SKIP_BUCKET_POLICY: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Start MinIO
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run -d --rm \
+            --name factory-careers-security-extended-minio \
+            -e MINIO_ROOT_USER=e2e-access-key \
+            -e MINIO_ROOT_PASSWORD=e2e-secret-key \
+            -p 127.0.0.1:9000:9000 \
+            minio/minio server /data
+
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          docker logs factory-careers-security-extended-minio
+          exit 1
+
+      - name: Run extended tenant isolation security checks
+        run: npm run test:e2e:security:extended
+
+      - name: Upload Playwright extended security report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-security-extended-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   uploads:
     name: Playwright uploads
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -405,7 +498,7 @@ jobs:
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, uploads, ui, candidate]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -418,6 +511,10 @@ jobs:
           fi
           if [ "${{ needs.security-core.result }}" != "success" ]; then
             echo "Playwright security core finished with result: ${{ needs.security-core.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.security-extended.result }}" != "success" ]; then
+            echo "Playwright security extended finished with result: ${{ needs.security-extended.result }}"
             exit 1
           fi
           if [ "${{ needs.uploads.result }}" != "success" ]; then

--- a/e2e/critical-flows/candidate-application.spec.ts
+++ b/e2e/critical-flows/candidate-application.spec.ts
@@ -1,5 +1,5 @@
-import { type Page } from '@playwright/test'
 import { test, expect, selectFactorySelectOption } from '../fixtures'
+import { advanceToSubmitButton } from '../helpers/application-form'
 
 /**
  * Critical flow: Candidate applies to a published job that contains every
@@ -93,24 +93,6 @@ const FIELD_TYPE_LABELS: Record<string, string> = {
   url: 'URL',
   checkbox: 'Checkbox (Yes/No)',
   file_upload: 'File Upload',
-}
-
-async function advanceToSubmitButton(page: Page) {
-  const submitButton = page.getByRole('button', { name: /submit/i })
-
-  for (let step = 0; step < 3; step += 1) {
-    if (await submitButton.isVisible()) {
-      return submitButton
-    }
-
-    const continueButton = page.getByRole('button', { name: 'Continue' }).first()
-    await expect(continueButton).toBeVisible({ timeout: 10_000 })
-    await expect(continueButton).toBeEnabled()
-    await continueButton.click()
-  }
-
-  await expect(submitButton).toBeVisible({ timeout: 10_000 })
-  return submitButton
 }
 
 /**

--- a/e2e/critical-flows/candidate-application.spec.ts
+++ b/e2e/critical-flows/candidate-application.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from '../fixtures'
+import { type Page } from '@playwright/test'
+import { test, expect, selectFactorySelectOption } from '../fixtures'
 
 /**
  * Critical flow: Candidate applies to a published job that contains every
@@ -92,6 +93,24 @@ const FIELD_TYPE_LABELS: Record<string, string> = {
   url: 'URL',
   checkbox: 'Checkbox (Yes/No)',
   file_upload: 'File Upload',
+}
+
+async function advanceToSubmitButton(page: Page) {
+  const submitButton = page.getByRole('button', { name: /submit/i })
+
+  for (let step = 0; step < 3; step += 1) {
+    if (await submitButton.isVisible()) {
+      return submitButton
+    }
+
+    const continueButton = page.getByRole('button', { name: 'Continue' }).first()
+    await expect(continueButton).toBeVisible({ timeout: 10_000 })
+    await expect(continueButton).toBeEnabled()
+    await continueButton.click()
+  }
+
+  await expect(submitButton).toBeVisible({ timeout: 10_000 })
+  return submitButton
 }
 
 /**
@@ -239,17 +258,15 @@ test.describe('Candidate Application Flow — All Custom Question Field Types', 
     await candidatePage.waitForLoadState('networkidle')
     await expect(candidatePage.getByRole('heading', { name: JOB_TITLE })).toBeVisible({ timeout: 15_000 })
 
-    // Wait for the form to be fully hydrated
-    await candidatePage.getByRole('button', { name: /submit/i }).waitFor({ state: 'visible', timeout: 15_000 })
-
     // ── Fill basic applicant info ─────────────────────────────────────────────
 
     await candidatePage.getByLabel('First name').fill(APPLICANT.firstName)
     await candidatePage.getByLabel('Last name').fill(APPLICANT.lastName)
     await candidatePage.getByLabel('Email').fill(APPLICANT.email)
     await candidatePage.getByLabel('Phone').fill(APPLICANT.phone)
-    await candidatePage.getByLabel(/Country/).selectOption({ label: 'United States' })
-    await candidatePage.getByLabel(/State/).selectOption({ label: 'California' })
+    await selectFactorySelectOption(candidatePage, /Country/, 'United States')
+    await selectFactorySelectOption(candidatePage, /State/, 'California')
+    await candidatePage.getByRole('button', { name: 'Continue' }).click()
 
     // ── Fill each custom question field type ──────────────────────────────────
 
@@ -310,6 +327,7 @@ test.describe('Candidate Application Flow — All Custom Question Field Types', 
 
     // ── Submit the application ────────────────────────────────────────────────
 
+    const submitButton = await advanceToSubmitButton(candidatePage)
     const [applyResponse] = await Promise.all([
       candidatePage.waitForResponse(
         resp =>
@@ -317,7 +335,7 @@ test.describe('Candidate Application Flow — All Custom Question Field Types', 
           resp.request().method() === 'POST',
         { timeout: 30_000 },
       ),
-      candidatePage.getByRole('button', { name: /submit/i }).click(),
+      submitButton.click(),
     ])
 
     // Verify the API responded with a 2xx status
@@ -513,7 +531,13 @@ test.describe('Candidate Application — Required Cover Letter Validation', () =
       .waitFor({ state: 'attached', timeout: 10_000 })
     await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().click()
 
-    // Step 2: Enable "Cover letter" requirement via radio group
+    // Step 2: Isolate this validation to cover letters; resume upload is
+    // covered by the dedicated upload lane.
+    const resumeRadioGroup = page.getByRole('radiogroup', { name: /Resume requirement/i })
+    await resumeRadioGroup.waitFor({ state: 'visible', timeout: 10_000 })
+    await resumeRadioGroup.getByRole('radio', { name: 'Off' }).click()
+
+    // Enable "Cover letter" requirement via radio group.
     const coverLetterRadioGroup = page.getByRole('radiogroup', { name: /Cover letter requirement/i })
     await coverLetterRadioGroup.waitFor({ state: 'visible', timeout: 10_000 })
     await coverLetterRadioGroup.getByRole('radio', { name: 'Required' }).click()
@@ -554,18 +578,20 @@ test.describe('Candidate Application — Required Cover Letter Validation', () =
 
     await candidatePage.goto(applicationLink)
     await candidatePage.waitForLoadState('networkidle')
-    await candidatePage.getByRole('button', { name: /submit/i }).waitFor({ state: 'visible', timeout: 15_000 })
-
-    // The cover letter textarea must be visible (requireCoverLetter=true)
-    await expect(candidatePage.locator('#coverLetterText')).toBeVisible({ timeout: 10_000 })
 
     // Fill required basic fields but leave cover letter EMPTY
     await candidatePage.getByLabel('First name').fill('Test')
     await candidatePage.getByLabel('Last name').fill('Applicant')
     await candidatePage.getByLabel('Email').fill(`test.applicant.${Date.now()}.r${testInfo.retry}@example.com`)
+    await selectFactorySelectOption(candidatePage, /Country/, 'United States')
+    await selectFactorySelectOption(candidatePage, /State/, 'California')
+    await candidatePage.getByRole('button', { name: 'Continue' }).click()
 
-    // Submit without cover letter — client validation must block it
-    await candidatePage.getByRole('button', { name: /submit/i }).click()
+    // The cover letter textarea must be visible (requireCoverLetter=true)
+    await expect(candidatePage.locator('#coverLetterText')).toBeVisible({ timeout: 10_000 })
+
+    // Continue without cover letter — step validation must block progress.
+    await candidatePage.getByRole('button', { name: 'Continue' }).click()
 
     // Error message should appear; the page should NOT navigate
     await expect(

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:e2e": "npx playwright test",
     "test:e2e:smoke": "playwright test e2e/critical-flows/dropdown-styling.spec.ts e2e/critical-flows/job-creation.spec.ts e2e/critical-flows/source-tracking.spec.ts",
     "test:e2e:uploads": "playwright test e2e/critical-flows/resume-upload.spec.ts",
+    "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,8 +70,23 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui]')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
     expect(workflow).toContain('needs.ui.result')
+  })
+
+  it('runs candidate application browser coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:candidate']).toBe(
+      'playwright test e2e/critical-flows/candidate-application.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright candidate')
+    expect(workflow).toContain('npm run test:e2e:candidate')
+    expect(workflow).toContain('factory-careers-candidate-minio')
+    expect(workflow).toContain('needs.candidate.result')
   })
 
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
@@ -87,7 +102,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui]')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -106,11 +121,12 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui]')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.uploads.result')
     expect(workflow).toContain('needs.ui.result')
+    expect(workflow).toContain('needs.candidate.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -102,7 +102,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -117,13 +117,24 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
   })
 
+  it('runs extended security checks in a separate CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+
+    expect(workflow).toContain('name: Playwright security extended')
+    expect(workflow).toContain('FEATURE_FLAG_CHATBOT_EXPERIENCE: "true"')
+    expect(workflow).toContain('npm run test:e2e:security:extended')
+    expect(workflow).toContain('factory-careers-security-extended-minio')
+    expect(workflow).toContain('needs.security-extended.result')
+  })
+
   it('keeps the branch-protection E2E status as an aggregate of the split jobs', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
+    expect(workflow).toContain('needs.security-extended.result')
     expect(workflow).toContain('needs.uploads.result')
     expect(workflow).toContain('needs.ui.result')
     expect(workflow).toContain('needs.candidate.result')


### PR DESCRIPTION
## Summary
- adds a dedicated `test:e2e:candidate` script for candidate application browser coverage
- wires a separate Playwright candidate CI lane with local Postgres and MinIO
- updates the candidate application spec for the current stepped public application flow
- extends the E2E harness contract so the candidate lane and aggregate check cannot drift silently

Stacked on #121. Closes #110.

## Verification
- `npm run test:unit -- tests/unit/e2e-harness-contract.test.ts`
- `npx playwright test e2e/critical-flows/candidate-application.spec.ts --grep "required cover letter"`
- `npm run test:e2e:candidate` (2 passed, 43.1s locally)
- pre-push preflight via `git push`: all unit tests, typecheck, CLI smoke, production env contract, build