### PR TITLE
fix: reintegrate extended security e2e

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -176,6 +176,99 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  security-extended:
+    name: Playwright security extended
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      FEATURE_FLAG_CHATBOT_EXPERIENCE: "true"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "false"
+      S3_SKIP_BUCKET_POLICY: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Start MinIO
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run -d --rm \
+            --name factory-careers-security-extended-minio \
+            -e MINIO_ROOT_USER=e2e-access-key \
+            -e MINIO_ROOT_PASSWORD=e2e-secret-key \
+            -p 127.0.0.1:9000:9000 \
+            minio/minio server /data
+
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          docker logs factory-careers-security-extended-minio
+          exit 1
+
+      - name: Run extended tenant isolation security checks
+        run: npm run test:e2e:security:extended
+
+      - name: Upload Playwright extended security report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-security-extended-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   uploads:
     name: Playwright uploads
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -433,7 +526,7 @@ jobs:
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, uploads, ui, candidate]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -446,6 +539,10 @@ jobs:
           fi
           if [ "${{ needs.security-core.result }}" != "success" ]; then
             echo "Playwright security core finished with result: ${{ needs.security-core.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.security-extended.result }}" != "success" ]; then
+            echo "Playwright security extended finished with result: ${{ needs.security-extended.result }}"
             exit 1
           fi
           if [ "${{ needs.uploads.result }}" != "success" ]; then

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -102,7 +102,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -114,13 +114,24 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
   })
 
+  it('runs extended security checks in a separate CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+
+    expect(workflow).toContain('name: Playwright security extended')
+    expect(workflow).toContain('FEATURE_FLAG_CHATBOT_EXPERIENCE: "true"')
+    expect(workflow).toContain('npm run test:e2e:security:extended')
+    expect(workflow).toContain('factory-careers-security-extended-minio')
+    expect(workflow).toContain('needs.security-extended.result')
+  })
+
   it('keeps the branch-protection E2E status as an aggregate of the split jobs', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
+    expect(workflow).toContain('needs.security-extended.result')
     expect(workflow).toContain('needs.uploads.result')
     expect(workflow).toContain('needs.ui.result')
     expect(workflow).toContain('needs.candidate.result')


### PR DESCRIPTION
## Summary
- adds a dedicated `Playwright security extended` CI lane for `npm run test:e2e:security:extended`
- runs the lane with local Postgres, local MinIO, and `FEATURE_FLAG_CHATBOT_EXPERIENCE=true`
- updates the aggregate Playwright E2E check and harness contract so extended security cannot drift out of CI silently

Stacked on #122. Closes #111.

## Verification
- `npm run test:unit -- tests/unit/e2e-harness-contract.test.ts`
- `npm run test:e2e:security:extended` (2 passed, 41.1s locally)
- pre-push preflight via `git push`: all unit tests, typecheck, CLI smoke, production env contract, build