### PR TITLE
fix: reintegrate job lifecycle e2e

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -593,10 +593,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  job_lifecycle:
+    name: Playwright job lifecycle
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run job lifecycle browser checks
+        run: npm run test:e2e:job-lifecycle
+
+      - name: Upload Playwright job lifecycle report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-job-lifecycle-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -629,6 +699,10 @@ jobs:
           fi
           if [ "${{ needs.recruiter.result }}" != "success" ]; then
             echo "Playwright recruiter finished with result: ${{ needs.recruiter.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.job_lifecycle.result }}" != "success" ]; then
+            echo "Playwright job lifecycle finished with result: ${{ needs.job_lifecycle.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/e2e/critical-flows/job-lifecycle.spec.ts
+++ b/e2e/critical-flows/job-lifecycle.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '../fixtures'
+
+const JOB_TITLE = 'Lifecycle Close Test Job'
+const JOB_DESCRIPTION = 'A published job used to verify close/unpublish behavior.'
+const JOB_LOCATION = 'Remote'
+
+test.describe('Job lifecycle after publish', () => {
+  test('closing a published job updates the dashboard and blocks public applications', async ({ authenticatedPage, browser }, testInfo) => {
+    const page = authenticatedPage
+    const jobTitle = `${JOB_TITLE} ${Date.now()} r${testInfo.retry}`
+
+    await page.goto('/dashboard/jobs/new')
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Job title').waitFor({ state: 'visible', timeout: 15_000 })
+    await page.getByLabel('Job title').fill(jobTitle)
+    await page.locator('textarea').first().fill(JOB_DESCRIPTION)
+    await page.getByLabel('Location').fill(JOB_LOCATION)
+
+    await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().waitFor({ state: 'attached', timeout: 10_000 })
+    await expect(page.locator('form').getByRole('button', { name: 'Save & continue' }).first()).toBeEnabled({ timeout: 10_000 })
+    await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().click()
+
+    await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().waitFor({ state: 'attached', timeout: 10_000 })
+    await expect(page.locator('form').getByRole('button', { name: 'Save & continue' }).first()).toBeEnabled({ timeout: 10_000 })
+    await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().click()
+
+    await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().waitFor({ state: 'visible', timeout: 10_000 })
+    await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().click()
+
+    await expect(page.getByRole('heading', { name: /Ready to go\?/i })).toBeVisible({ timeout: 10_000 })
+    const publishButton = page.locator('form').getByRole('button', { name: /Publish & copy link/i })
+    await publishButton.waitFor({ state: 'visible', timeout: 10_000 })
+    const [publishResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/jobs/') && resp.request().method() === 'PATCH',
+        { timeout: 30_000 },
+      ),
+      publishButton.click(),
+    ])
+    expect([200, 201], `Publish API returned ${publishResponse.status()}`).toContain(publishResponse.status())
+    const publishedJob = await publishResponse.json() as { id: string; slug: string; status: string }
+    expect(publishedJob.id, 'published job id must be present').toBeTruthy()
+    expect(publishedJob.slug, 'published job slug must be present').toBeTruthy()
+    expect(publishedJob.status).toBe('open')
+    await expect(page.getByRole('heading', { name: 'Your job is live!' })).toBeVisible({ timeout: 30_000 })
+
+    const publicContext = await browser.newContext()
+    const publicPage = await publicContext.newPage()
+    await publicPage.goto(`/jobs/${publishedJob.slug}`)
+    await expect(publicPage.getByRole('heading', { name: jobTitle })).toBeVisible({ timeout: 15_000 })
+    await expect(publicPage.getByRole('link', { name: /apply/i }).first()).toBeVisible()
+
+    await page.goto(`/dashboard/jobs/${publishedJob.id}`)
+    await page.waitForLoadState('networkidle')
+    const dashboardBanner = page.getByRole('banner')
+    await expect(page.getByText(jobTitle).first()).toBeVisible({ timeout: 15_000 })
+    await expect(dashboardBanner).toContainText('Open')
+
+    const closeButton = page.getByRole('button', { name: /Close this job so new candidates can no longer apply/i })
+    await expect(closeButton).toBeVisible({ timeout: 15_000 })
+    const [closeResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes(`/api/jobs/${publishedJob.id}`) && resp.request().method() === 'PATCH',
+        { timeout: 30_000 },
+      ),
+      closeButton.click(),
+    ])
+    expect(closeResponse.status(), `Close API returned ${closeResponse.status()}`).toBe(200)
+    const closedJob = await closeResponse.json() as { id: string; status: string }
+    expect(closedJob).toEqual(expect.objectContaining({ id: publishedJob.id, status: 'closed' }))
+
+    const jobResponse = await page.request.get(`/api/jobs/${publishedJob.id}`)
+    expect(jobResponse.status(), `Job API returned ${jobResponse.status()}`).toBe(200)
+    await expect(await jobResponse.json()).toEqual(expect.objectContaining({ status: 'closed' }))
+    await expect(dashboardBanner).toContainText('Closed', { timeout: 10_000 })
+
+    await publicPage.goto(`/jobs/${publishedJob.slug}`)
+    await expect(publicPage.getByRole('heading', { name: 'Job Not Found' })).toBeVisible({ timeout: 15_000 })
+    await publicPage.goto(`/jobs/${publishedJob.slug}/apply`)
+    await expect(publicPage.getByRole('heading', { name: 'Position Not Found' })).toBeVisible({ timeout: 15_000 })
+
+    const applyAfterCloseResponse = await publicPage.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
+      data: {
+        firstName: 'Closed',
+        lastName: 'Applicant',
+        email: `closed.applicant.${Date.now()}.r${testInfo.retry}@example.com`,
+        country: 'United States',
+        state: 'CA',
+        responses: [],
+      },
+    })
+    expect(applyAfterCloseResponse.status(), 'Closed jobs must reject public application POSTs').toBe(404)
+    expect(await applyAfterCloseResponse.text()).toContain('not accepting applications')
+
+    await publicContext.close()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:e2e:uploads": "playwright test e2e/critical-flows/resume-upload.spec.ts",
     "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts",
+    "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -104,6 +104,21 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.recruiter.result')
   })
 
+  it('runs post-publish job lifecycle browser coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:job-lifecycle']).toBe(
+      'playwright test e2e/critical-flows/job-lifecycle.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright job lifecycle')
+    expect(workflow).toContain('npm run test:e2e:job-lifecycle')
+    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).toContain('needs.job_lifecycle.result')
+  })
+
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
     const packageJson = JSON.parse(read('package.json')) as {
@@ -117,7 +132,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -143,7 +158,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')
@@ -151,6 +166,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.ui.result')
     expect(workflow).toContain('needs.candidate.result')
     expect(workflow).toContain('needs.recruiter.result')
+    expect(workflow).toContain('needs.job_lifecycle.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {


### PR DESCRIPTION
## Summary
- adds focused post-publish job lifecycle coverage for closing an open job
- verifies the public job page is available before close, then unavailable after close
- verifies the dashboard state/API transition to `closed`
- verifies the public application POST is rejected after the job is closed
- wires `test:e2e:job-lifecycle` into a dedicated fast Playwright CI lane and aggregate E2E gate

Stacked on #124. Closes #115.

## Verification
- `npm run test:unit -- tests/unit/e2e-harness-contract.test.ts`
- `npm run test:e2e:job-lifecycle` (1 passed, 35.8s locally)
- `npm run typecheck`
- pre-push preflight via `git push`: all unit tests, typecheck, CLI smoke, production env contract, build