### PR TITLE
fix: add fake mail e2e coverage

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -680,10 +680,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  tracking_analytics:
+    name: Playwright tracking analytics
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run tracking analytics browser checks
+        run: npm run test:e2e:tracking-analytics
+
+      - name: Upload Playwright tracking analytics report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-tracking-analytics-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -724,6 +794,10 @@ jobs:
           fi
           if [ "${{ needs.email.result }}" != "success" ]; then
             echo "Playwright email finished with result: ${{ needs.email.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.tracking_analytics.result }}" != "success" ]; then
+            echo "Playwright tracking analytics finished with result: ${{ needs.tracking_analytics.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -607,10 +607,83 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  email:
+    name: Playwright email
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      FACTORY_EMAIL_TEST_MODE: capture
+      FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-email.jsonl
+      FACTORY_CAREERS_HIRING_INBOX: hiring-e2e@example.com
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run fake-mail browser checks
+        run: npm run test:e2e:email
+
+      - name: Upload Playwright email report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-email-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -647,6 +720,10 @@ jobs:
           fi
           if [ "${{ needs.job_lifecycle.result }}" != "success" ]; then
             echo "Playwright job lifecycle finished with result: ${{ needs.job_lifecycle.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.email.result }}" != "success" ]; then
+            echo "Playwright email finished with result: ${{ needs.email.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/app/composables/useSourceTracking.ts
+++ b/app/composables/useSourceTracking.ts
@@ -177,6 +177,7 @@ export function useTrackingLinks(options?: {
       method: 'POST',
       body: payload,
     })
+    clearNuxtData(fetchKey.value)
     await refresh()
     toast.success('Tracking link created')
     return created
@@ -196,12 +197,14 @@ export function useTrackingLinks(options?: {
       method: 'PATCH',
       body: payload,
     })
+    clearNuxtData(fetchKey.value)
     await refresh()
     return updated
   }
 
   async function deleteLink(id: string) {
     await $fetch(`/api/tracking-links/${id}`, { method: 'DELETE' })
+    clearNuxtData(fetchKey.value)
     await refresh()
     toast.success('Tracking link deleted')
   }

--- a/e2e/critical-flows/fake-mail.spec.ts
+++ b/e2e/critical-flows/fake-mail.spec.ts
@@ -1,0 +1,149 @@
+import { readFile, rm } from "node:fs/promises";
+import type { Page } from "@playwright/test";
+import { test, expect, selectFactorySelectOption } from "../fixtures";
+
+const JOB_TITLE = "Email Capture Test Job";
+
+type CapturedEmail = {
+  from: string;
+  to: string[];
+  subject: string;
+  html: string;
+  text: string;
+  renderError?: string;
+};
+
+async function readCapturedEmails(capturePath: string): Promise<CapturedEmail[]> {
+  try {
+    const contents = await readFile(capturePath, "utf8");
+    return contents
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as CapturedEmail);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+
+    throw error;
+  }
+}
+
+async function advanceToSubmitButton(page: Page) {
+  const submitButton = page.getByRole("button", { name: /submit/i });
+
+  for (let step = 0; step < 3; step += 1) {
+    if (await submitButton.isVisible()) {
+      return submitButton;
+    }
+
+    const continueButton = page.getByRole("button", { name: "Continue" }).first();
+    await expect(continueButton).toBeVisible({ timeout: 10_000 });
+    await expect(continueButton).toBeEnabled();
+    await continueButton.click();
+  }
+
+  await expect(submitButton).toBeVisible({ timeout: 10_000 });
+  return submitButton;
+}
+
+test.describe("Fake mail capture", () => {
+  test("captures application receipt and hiring-team alert without external delivery", async ({ authenticatedPage, browser }, testInfo) => {
+    const capturePath = process.env.FACTORY_EMAIL_CAPTURE_PATH;
+    expect(capturePath, "FACTORY_EMAIL_CAPTURE_PATH must be set for fake-mail E2E").toBeTruthy();
+    expect(process.env.FACTORY_EMAIL_TEST_MODE, "E2E mail must use capture mode, not a real provider").toBe("capture");
+
+    await rm(capturePath!, { force: true });
+
+    const recruiterPage = authenticatedPage;
+    const jobTitle = `${JOB_TITLE} ${Date.now()} r${testInfo.retry}`;
+    const applicant = {
+      firstName: "Email",
+      lastName: "Candidate",
+      email: `email.candidate.${Date.now()}.r${testInfo.retry}@example.com`,
+    };
+    const applicantName = `${applicant.firstName} ${applicant.lastName}`;
+    const hiringInbox = process.env.FACTORY_CAREERS_HIRING_INBOX || "careers@thefactoryhq.com";
+    const organizationName = process.env.FACTORY_ORG_NAME || "Factory";
+
+    await recruiterPage.goto("/dashboard/jobs/new");
+    await recruiterPage.waitForLoadState("networkidle");
+    await recruiterPage.getByLabel("Job title").waitFor({ state: "visible", timeout: 15_000 });
+    await recruiterPage.getByLabel("Job title").fill(jobTitle);
+
+    await recruiterPage.locator("form").getByRole("button", { name: "Save & continue" }).first().waitFor({ state: "attached", timeout: 10_000 });
+    await expect(recruiterPage.locator("form").getByRole("button", { name: "Save & continue" }).first()).toBeEnabled({ timeout: 10_000 });
+    await recruiterPage.locator("form").getByRole("button", { name: "Save & continue" }).first().click();
+
+    const resumeRadioGroup = recruiterPage.getByRole("radiogroup", { name: /Resume requirement/i });
+    await resumeRadioGroup.waitFor({ state: "visible", timeout: 10_000 });
+    await resumeRadioGroup.getByRole("radio", { name: "Off" }).click();
+
+    await recruiterPage.locator("form").getByRole("button", { name: "Save & continue" }).first().click();
+    await recruiterPage.locator("form").getByRole("button", { name: "Save & continue" }).first().waitFor({ state: "visible", timeout: 10_000 });
+    await recruiterPage.locator("form").getByRole("button", { name: "Save & continue" }).first().click();
+
+    await expect(recruiterPage.getByRole("heading", { name: /Ready to go\?/i })).toBeVisible({ timeout: 10_000 });
+    const publishButton = recruiterPage.locator("form").getByRole("button", { name: /Publish & copy link/i });
+    await publishButton.waitFor({ state: "visible", timeout: 10_000 });
+
+    const [publishResponse] = await Promise.all([
+      recruiterPage.waitForResponse(
+        (resp) => resp.url().includes("/api/jobs/") && resp.request().method() === "PATCH",
+        { timeout: 30_000 },
+      ),
+      publishButton.click(),
+    ]);
+    expect([200, 201], `Publish API returned ${publishResponse.status()}`).toContain(publishResponse.status());
+    const publishedJob = await publishResponse.json() as { id: string; slug: string };
+    expect(publishedJob.slug, "published job slug must be present").toBeTruthy();
+    await expect(recruiterPage.getByRole("heading", { name: "Your job is live!" })).toBeVisible({ timeout: 30_000 });
+
+    const candidateContext = await browser.newContext();
+    const candidatePage = await candidateContext.newPage();
+    await candidatePage.goto(`/jobs/${publishedJob.slug}/apply`);
+    await candidatePage.waitForLoadState("networkidle");
+    await candidatePage.getByLabel("First name").fill(applicant.firstName);
+    await candidatePage.getByLabel("Last name").fill(applicant.lastName);
+    await candidatePage.getByLabel("Email").fill(applicant.email);
+    await selectFactorySelectOption(candidatePage, /Country/, "United States");
+    await selectFactorySelectOption(candidatePage, /State/, "California");
+
+    const submitButton = await advanceToSubmitButton(candidatePage);
+    const [applyResponse] = await Promise.all([
+      candidatePage.waitForResponse(
+        (resp) => resp.url().includes(`/api/public/jobs/${publishedJob.slug}/apply`) && resp.request().method() === "POST",
+        { timeout: 30_000 },
+      ),
+      submitButton.click(),
+    ]);
+    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201);
+    await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}/confirmation`, { waitUntil: "commit", timeout: 15_000 });
+    await expect(candidatePage.getByRole("heading", { name: "Application submitted" })).toBeVisible();
+
+    await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+      message: "application submission should capture receipt and team alert emails",
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(2);
+
+    const capturedEmails = await readCapturedEmails(capturePath!);
+    const receipt = capturedEmails.find((email) => email.subject === `Application received — ${jobTitle} at ${organizationName}`);
+    expect(receipt, "candidate receipt email should be captured").toBeTruthy();
+    expect(receipt?.renderError, "candidate receipt email should render successfully").toBeUndefined();
+    expect(receipt?.to).toContain(applicant.email);
+    expect(receipt?.text).toContain(applicantName);
+    expect(receipt?.text).toContain(jobTitle);
+    expect(receipt?.text).toContain(organizationName);
+
+    const teamAlert = capturedEmails.find((email) => email.subject === `New application: ${applicantName} for ${jobTitle}`);
+    expect(teamAlert, "hiring-team alert email should be captured").toBeTruthy();
+    expect(teamAlert?.renderError, "hiring-team alert email should render successfully").toBeUndefined();
+    expect(teamAlert?.to).toContain(hiringInbox);
+    expect(teamAlert?.text).toContain(applicantName);
+    expect(teamAlert?.text).toContain(applicant.email);
+    expect(teamAlert?.text).toContain(jobTitle);
+    expect(teamAlert?.text).toContain(`/dashboard/applications/`);
+
+    await candidateContext.close();
+  });
+});

--- a/e2e/critical-flows/tracking-analytics.spec.ts
+++ b/e2e/critical-flows/tracking-analytics.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, selectFactorySelectOption } from '../fixtures'
+
+const JOB_TITLE = 'Tracking Analytics Test Job'
+const LINK_NAME = 'LinkedIn Analytics Campaign'
+const UTM_CAMPAIGN = 'tracking-analytics-e2e'
+
+test.describe('Tracking analytics', () => {
+  test('creates a tracking link and reflects tracked applications in recruiter analytics UI', async ({ authenticatedPage, browser }, testInfo) => {
+    const page = authenticatedPage
+    const unique = `${Date.now()}-r${testInfo.retry}`
+    const jobTitle = `${JOB_TITLE} ${unique}`
+    const linkName = `${LINK_NAME} ${unique}`
+    const applicant = {
+      firstName: 'Tracked',
+      lastName: 'Applicant',
+      email: `tracked.applicant.${unique}@example.com`,
+    }
+    const applicantName = `${applicant.firstName} ${applicant.lastName}`
+
+    await page.addInitScript(() => {
+      const copiedUrls: string[] = []
+      Object.defineProperty(window, '__copiedTrackingUrls', {
+        value: copiedUrls,
+        configurable: true,
+      })
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {
+          writeText: async (text: string) => {
+            copiedUrls.push(text)
+          },
+        },
+        configurable: true,
+      })
+    })
+
+    const createJobResponse = await page.request.post('/api/jobs', {
+      data: {
+        title: jobTitle,
+        description: 'A fast E2E job for tracking-link analytics.',
+        location: 'Remote',
+        requireResume: false,
+        requireCoverLetter: false,
+        applicationComplianceEnabled: false,
+        autoScoreOnApply: false,
+      },
+    })
+    expect(createJobResponse.status(), `Create job API returned ${createJobResponse.status()}`).toBe(201)
+    const createdJob = await createJobResponse.json() as { id: string; slug: string }
+    expect(createdJob.id, 'created job id must be present').toBeTruthy()
+    expect(createdJob.slug, 'created job slug must be present').toBeTruthy()
+
+    const publishJobResponse = await page.request.patch(`/api/jobs/${createdJob.id}`, {
+      data: { status: 'open' },
+    })
+    expect(publishJobResponse.status(), `Publish job API returned ${publishJobResponse.status()}`).toBe(200)
+    const publishedJob = await publishJobResponse.json() as { id: string; slug: string; status: string }
+    expect(publishedJob.status).toBe('open')
+
+    await page.goto('/dashboard/source-tracking?tab=links')
+    await expect(page.getByRole('heading', { name: 'Tracking', exact: true })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('button', { name: /New Link|Create Tracking Link/ }).first().click()
+    await expect(page.getByRole('heading', { name: 'Create Tracking Link' })).toBeVisible()
+    await page.getByLabel('Link Name').fill(linkName)
+    await selectFactorySelectOption(page, /Source Channel/, 'LinkedIn')
+    await page.getByText('UTM Parameters (optional)').click()
+    await page.getByLabel('utm_source').fill('linkedin')
+    await page.getByLabel('utm_medium').fill('social')
+    await page.getByLabel('utm_campaign').fill(UTM_CAMPAIGN)
+
+    const [createLinkResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/tracking-links') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.locator('form').getByRole('button', { name: 'Create Link' }).click(),
+    ])
+    expect(createLinkResponse.status(), `Create link API returned ${createLinkResponse.status()}`).toBe(201)
+    const trackingLink = await createLinkResponse.json() as { id: string; code: string }
+    expect(trackingLink.id, 'tracking link id must be present').toBeTruthy()
+    expect(trackingLink.code, 'tracking link code must be present').toBeTruthy()
+    await expect(page.getByRole('heading', { name: 'Create Tracking Link' })).toBeHidden({ timeout: 10_000 })
+
+    await page.getByRole('button', { name: 'Tracking Links' }).click()
+    const linkRow = page.getByRole('row').filter({ hasText: linkName })
+    await expect(linkRow).toBeVisible({ timeout: 15_000 })
+    await expect(linkRow).toContainText('?ref=')
+
+    await linkRow.getByRole('button', { name: 'Copy tracking URL' }).click()
+    const copiedUrls = await page.evaluate(() => (window as any).__copiedTrackingUrls as string[])
+    expect(copiedUrls.at(-1)).toContain(`/api/public/track/${encodeURIComponent(trackingLink.code)}`)
+
+    const candidateContext = await browser.newContext()
+    const candidatePage = await candidateContext.newPage()
+    await candidatePage.goto(`/api/public/track/${trackingLink.code}`)
+    await candidatePage.waitForURL('**/jobs?ref=*', { waitUntil: 'commit', timeout: 15_000 })
+    expect(new URL(candidatePage.url()).searchParams.get('ref')).toBe(trackingLink.code)
+
+    await candidatePage.getByRole('link', { name: jobTitle }).first().click()
+    await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}**`, { waitUntil: 'commit', timeout: 15_000 })
+    await candidatePage.getByRole('link', { name: 'Apply Now' }).first().click()
+    await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}/apply**`, { waitUntil: 'commit', timeout: 15_000 })
+    expect(new URL(candidatePage.url()).searchParams.get('ref')).toBe(trackingLink.code)
+
+    const applyResponse = await candidatePage.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
+      data: {
+        firstName: applicant.firstName,
+        lastName: applicant.lastName,
+        email: applicant.email,
+        country: 'United States',
+        state: 'CA',
+        ref: trackingLink.code,
+        utmSource: 'linkedin',
+        utmMedium: 'social',
+        utmCampaign: UTM_CAMPAIGN,
+        responses: [],
+      },
+    })
+    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
+
+    await expect.poll(async () => {
+      const response = await page.request.get(`/api/tracking-links/${trackingLink.id}`)
+      expect(response.status(), `Tracking link API returned ${response.status()}`).toBe(200)
+      const current = await response.json() as { clickCount: number; applicationCount: number }
+      return current
+    }, {
+      message: 'tracking link counters should include the click and submitted application',
+      timeout: 10_000,
+    }).toEqual(expect.objectContaining({ clickCount: 1, applicationCount: 1 }))
+
+    await page.goto('/dashboard/source-tracking?tab=links')
+    const updatedLinkRow = page.getByRole('row').filter({ hasText: linkName })
+    await expect(updatedLinkRow).toBeVisible({ timeout: 15_000 })
+    await expect(updatedLinkRow.locator('td').nth(3)).toHaveText('1')
+    await expect(updatedLinkRow.locator('td').nth(4)).toHaveText('1')
+    await expect(updatedLinkRow.locator('td').nth(5)).toHaveText('100%')
+
+    await page.getByRole('button', { name: 'Attribution Log' }).click()
+    const attributionRow = page.getByRole('row').filter({ hasText: applicantName })
+    await expect(attributionRow).toBeVisible({ timeout: 15_000 })
+    await expect(attributionRow).toContainText(jobTitle)
+    await expect(attributionRow).toContainText('LinkedIn')
+    await expect(attributionRow).toContainText(`via ${linkName}`)
+
+    await candidateContext.close()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts",
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
     "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts",
+    "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts",
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
+    "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,20 @@
 import { defineConfig, devices } from '@playwright/test'
 
+function shellEnv(name: string, value: string | undefined) {
+  return value ? `${name}=${JSON.stringify(value)}` : ''
+}
+
+const webServerEnv = [
+  'BETTER_AUTH_URL=http://127.0.0.1:3333',
+  'NUXT_PUBLIC_SITE_URL=http://127.0.0.1:3333',
+  'FACTORY_DISABLE_PUBLIC_SIGNUP=false',
+  'FACTORY_DISABLE_PUBLIC_ORG_CREATION=false',
+  'FEATURE_FLAG_CHATBOT_EXPERIENCE=true',
+  shellEnv('FACTORY_EMAIL_TEST_MODE', process.env.FACTORY_EMAIL_TEST_MODE),
+  shellEnv('FACTORY_EMAIL_CAPTURE_PATH', process.env.FACTORY_EMAIL_CAPTURE_PATH),
+  shellEnv('FACTORY_CAREERS_HIRING_INBOX', process.env.FACTORY_CAREERS_HIRING_INBOX),
+].filter(Boolean).join(' ')
+
 /**
  * Playwright E2E configuration for Reqcore.
  *
@@ -46,7 +61,7 @@ export default defineConfig({
     ? {}
     : {
         webServer: {
-          command: 'BETTER_AUTH_URL=http://127.0.0.1:3333 NUXT_PUBLIC_SITE_URL=http://127.0.0.1:3333 FACTORY_DISABLE_PUBLIC_SIGNUP=false FACTORY_DISABLE_PUBLIC_ORG_CREATION=false FEATURE_FLAG_CHATBOT_EXPERIENCE=true npm run db:migrate && BETTER_AUTH_URL=http://127.0.0.1:3333 NUXT_PUBLIC_SITE_URL=http://127.0.0.1:3333 FACTORY_DISABLE_PUBLIC_SIGNUP=false FACTORY_DISABLE_PUBLIC_ORG_CREATION=false FEATURE_FLAG_CHATBOT_EXPERIENCE=true npx nuxt dev --port 3333 --host 127.0.0.1',
+          command: `${webServerEnv} npm run db:migrate && ${webServerEnv} npx nuxt dev --port 3333 --host 127.0.0.1`,
           url: 'http://127.0.0.1:3333',
           reuseExistingServer: true,
           timeout: process.env.CI ? 120_000 : 60_000,

--- a/server/api/public/jobs/[slug]/apply.post.ts
+++ b/server/api/public/jobs/[slug]/apply.post.ts
@@ -705,7 +705,7 @@ export default defineEventHandler(async (event) => {
     const candidateName = `${firstName} ${lastName}`.trim()
     const applicationUrl = `${resolveFactoryCareersBaseUrl()}/dashboard/applications/${newApplication.id}`
 
-    void sendApplicationReceiptEmail({
+    const receiptEmail = sendApplicationReceiptEmail({
       candidateEmail: email.toLowerCase(),
       candidateName,
       jobTitle: existingJob.title,
@@ -718,7 +718,7 @@ export default defineEventHandler(async (event) => {
       })
     })
 
-    void sendApplicationTeamAlertEmail({
+    const teamAlertEmail = sendApplicationTeamAlertEmail({
       candidateEmail: email.toLowerCase(),
       candidateName,
       jobTitle: existingJob.title,
@@ -731,6 +731,10 @@ export default defineEventHandler(async (event) => {
         error_message: err instanceof Error ? err.message : String(err),
       })
     })
+
+    if (env.FACTORY_EMAIL_TEST_MODE === 'capture') {
+      await Promise.all([receiptEmail, teamAlertEmail])
+    }
   }
 
   // ─────────────────────────────────────────────

--- a/server/api/public/jobs/[slug]/apply.post.ts
+++ b/server/api/public/jobs/[slug]/apply.post.ts
@@ -716,6 +716,9 @@ export default defineEventHandler(async (event) => {
         job_id: jobId,
         error_message: err instanceof Error ? err.message : String(err),
       })
+      if (env.FACTORY_EMAIL_TEST_MODE === 'capture') {
+        throw err
+      }
     })
 
     const teamAlertEmail = sendApplicationTeamAlertEmail({
@@ -730,6 +733,9 @@ export default defineEventHandler(async (event) => {
         job_id: jobId,
         error_message: err instanceof Error ? err.message : String(err),
       })
+      if (env.FACTORY_EMAIL_TEST_MODE === 'capture') {
+        throw err
+      }
     })
 
     if (env.FACTORY_EMAIL_TEST_MODE === 'capture') {

--- a/server/lib/email/client.ts
+++ b/server/lib/email/client.ts
@@ -1,15 +1,155 @@
 import { createEmailClient } from "@caffeinebounce/email";
+import { render } from "@react-email/render";
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { ReactNode } from "react";
 
 import { env } from "../../utils/env";
+
+type EmailClient = ReturnType<typeof createEmailClient>;
+type EmailSendPayload = Parameters<EmailClient["send"]>[0] & {
+  html?: string;
+  text?: string;
+  react?: ReactNode;
+};
+
+function normalizeRecipients(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map(String);
+  }
+
+  if (typeof value === "string") {
+    return [value];
+  }
+
+  return [];
+}
+
+function serializeReactPayload(value: unknown): string {
+  const seen = new WeakSet<object>();
+
+  return JSON.stringify(value, (key, nestedValue) => {
+    if (key === "_owner" || key === "_store") {
+      return undefined;
+    }
+
+    if (typeof nestedValue === "function") {
+      return `[function ${nestedValue.name || "anonymous"}]`;
+    }
+
+    if (typeof nestedValue === "symbol") {
+      return nestedValue.toString();
+    }
+
+    if (typeof nestedValue === "object" && nestedValue !== null) {
+      if (seen.has(nestedValue)) {
+        return "[circular]";
+      }
+      seen.add(nestedValue);
+    }
+
+    return nestedValue;
+  });
+}
+
+async function renderEmailPayload(payload: EmailSendPayload): Promise<{
+  html: string;
+  text: string;
+  renderError?: string;
+}> {
+  if (!payload.react) {
+    return {
+      html: payload.html ?? "",
+      text: payload.text ?? payload.html ?? "",
+    };
+  }
+
+  try {
+    const html = payload.html ?? await render(payload.react);
+    const text = payload.text ?? await render(payload.react, { plainText: true });
+    return { html, text };
+  } catch (error) {
+    const fallback = serializeReactPayload(payload.react);
+
+    return {
+      html: payload.html ?? fallback,
+      text: payload.text ?? fallback,
+      renderError: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+const FALLBACK_FROM = "Factory <hello@interviews.thefactoryhq.com>";
+
+function resolveDefaultFrom(): string {
+  return env.EMAIL_FROM || env.RESEND_FROM_EMAIL || FALLBACK_FROM;
+}
+
+function createCaptureEmailClient(defaultFrom: string): EmailClient {
+  const capturePath = env.FACTORY_EMAIL_CAPTURE_PATH;
+  if (!capturePath) {
+    throw new Error("FACTORY_EMAIL_CAPTURE_PATH is required when FACTORY_EMAIL_TEST_MODE=capture");
+  }
+
+  return {
+    resend: null,
+    defaultFrom,
+    send: (async (payload: EmailSendPayload) => {
+      const { html, text, renderError } = await renderEmailPayload(payload);
+      const captured = {
+        id: `capture_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+        createdAt: new Date().toISOString(),
+        from: payload.from ?? defaultFrom,
+        to: normalizeRecipients(payload.to),
+        subject: payload.subject ?? "",
+        html,
+        text,
+        renderError,
+        attachments: Array.isArray(payload.attachments)
+          ? payload.attachments.map((attachment) => ({
+              filename: typeof attachment === "object" && attachment !== null && "filename" in attachment
+                ? String(attachment.filename)
+                : undefined,
+              contentType: typeof attachment === "object" && attachment !== null && "contentType" in attachment
+                ? String(attachment.contentType)
+                : undefined,
+            }))
+          : [],
+      };
+
+      await mkdir(dirname(capturePath), { recursive: true });
+      await appendFile(capturePath, `${JSON.stringify(captured)}\n`, "utf8");
+
+      return {
+        data: { id: captured.id },
+        error: null,
+        headers: null,
+      };
+    }) as EmailClient["send"],
+  };
+}
 
 /**
  * Shared Resend-backed email client (same infrastructure as thefactoryhq.com main site).
  * Initialized once; falls back gracefully when RESEND_API_KEY is absent (dev / console mode).
  */
-export const emailClient = createEmailClient({
+const resendEmailClient = createEmailClient({
   apiKey: env.RESEND_API_KEY,
-  defaultFrom:
-    env.EMAIL_FROM ||
-    env.RESEND_FROM_EMAIL ||
-    "Factory <hello@interviews.thefactoryhq.com>",
+  defaultFrom: resolveDefaultFrom(),
 });
+
+export const emailClient: EmailClient = {
+  get resend() {
+    return resendEmailClient.resend;
+  },
+  get defaultFrom() {
+    return resolveDefaultFrom();
+  },
+  send: (async (...args: Parameters<EmailClient["send"]>) => {
+    if (env.FACTORY_EMAIL_TEST_MODE === "capture") {
+      return createCaptureEmailClient(resolveDefaultFrom()).send(...args);
+    }
+
+    return resendEmailClient.send(...args);
+  }) as EmailClient["send"],
+};

--- a/server/lib/email/templates.tsx
+++ b/server/lib/email/templates.tsx
@@ -16,6 +16,8 @@ import {
 import type { ReactNode } from "react";
 import { careersEmailConfig, careersEmailStyles as styles } from "./theme";
 
+const h = React.createElement;
+
 type EmailCta = {
   href: string;
   text: string;

--- a/server/lib/email/templates.tsx
+++ b/server/lib/email/templates.tsx
@@ -16,8 +16,6 @@ import {
 import type { ReactNode } from "react";
 import { careersEmailConfig, careersEmailStyles as styles } from "./theme";
 
-const h = React.createElement;
-
 type EmailCta = {
   href: string;
   text: string;

--- a/server/lib/email/templates.tsx
+++ b/server/lib/email/templates.tsx
@@ -16,6 +16,11 @@ import {
 import type { ReactNode } from "react";
 import { careersEmailConfig, careersEmailStyles as styles } from "./theme";
 
+// Nuxt's server transform emits these TSX templates against an in-scope `h`
+// factory in dev/test, so keep the binding explicit for React Email rendering.
+const h = React.createElement;
+void h;
+
 type EmailCta = {
   href: string;
   text: string;

--- a/server/utils/env.ts
+++ b/server/utils/env.ts
@@ -154,6 +154,15 @@ export const envSchema = z
      */
     EMAIL_FROM: emptyToUndefined.pipe(z.string().min(1)).optional(),
     /**
+     * Test-only email capture mode for E2E. When set to "capture", messages are
+     * written to FACTORY_EMAIL_CAPTURE_PATH instead of contacting Resend.
+     */
+    FACTORY_EMAIL_TEST_MODE: z
+      .preprocess((val) => (typeof val === "string" && val.trim() === "" ? undefined : val), z.enum(["capture"]))
+      .optional(),
+    /** JSONL path used by FACTORY_EMAIL_TEST_MODE=capture. */
+    FACTORY_EMAIL_CAPTURE_PATH: emptyToUndefined.pipe(z.string().min(1)).optional(),
+    /**
      * Secret used to sign unsubscribe links in marketing emails (via @caffeinebounce/email).
      * Required in production for the email system.
      */
@@ -309,6 +318,24 @@ export const envSchema = z
       })
     }
 
+    if (data.FACTORY_EMAIL_TEST_MODE === "capture") {
+      if (process.env.NODE_ENV === "production") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["FACTORY_EMAIL_TEST_MODE"],
+          message: "FACTORY_EMAIL_TEST_MODE=capture is not allowed in production.",
+        });
+      }
+
+      if (!data.FACTORY_EMAIL_CAPTURE_PATH) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["FACTORY_EMAIL_CAPTURE_PATH"],
+          message: "FACTORY_EMAIL_CAPTURE_PATH is required when FACTORY_EMAIL_TEST_MODE=capture.",
+        });
+      }
+    }
+
     // OIDC SSO requires all three vars or none — partial config is a misconfiguration.
     const oidcVars = [
       ["OIDC_CLIENT_ID", data.OIDC_CLIENT_ID],
@@ -411,7 +438,7 @@ export const env = new Proxy({} as z.infer<typeof envSchema>, {
             `Ensure these variables are set in the Render web service environment.\n` +
             `Required: DATABASE_URL, BETTER_AUTH_SECRET, S3_ENDPOINT, S3_ACCESS_KEY, S3_SECRET_KEY, S3_BUCKET\n` +
             `Required on Render: BETTER_AUTH_URL=https://careers.thefactoryhq.com\n` +
-            `Optional: BETTER_AUTH_TRUSTED_ORIGINS, S3_REGION (default: us-east-1), S3_FORCE_PATH_STYLE (default: true), S3_SKIP_BUCKET_POLICY, S3_SKIP_BUCKET_INIT, SKIP_RUNTIME_MIGRATIONS, TRUSTED_PROXY_IP, DEMO_ORG_SLUG, RESEND_API_KEY, RESEND_FROM_EMAIL, SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM, SMTP_SECURE, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, MICROSOFT_CALENDAR_AUTH_MODE, MICROSOFT_CALENDAR_CLIENT_ID, MICROSOFT_CALENDAR_CLIENT_SECRET, MICROSOFT_CALENDAR_TENANT_ID, FACTORY_CAREERS_CALENDAR_SYNC_SHARED, FACTORY_CAREERS_CALENDAR_USER_EMAILS, FACTORY_CAREERS_CALENDAR_SYNC_INTERVIEWERS, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL, OIDC_PROVIDER_NAME, AUTH_GOOGLE_CLIENT_ID, AUTH_GOOGLE_CLIENT_SECRET, AUTH_GITHUB_CLIENT_ID, AUTH_GITHUB_CLIENT_SECRET, AUTH_MICROSOFT_CLIENT_ID, AUTH_MICROSOFT_CLIENT_SECRET, AUTH_MICROSOFT_TENANT_ID, FACTORY_CAREERS_HIRING_INBOX, FACTORY_CAREERS_PRIVACY_INBOX, FACTORY_CAREERS_CLI_CLIENT_ID, FACTORY_ALLOWED_EMAIL_DOMAINS, FACTORY_INITIAL_OWNER_EMAILS\n`,
+            `Optional: BETTER_AUTH_TRUSTED_ORIGINS, S3_REGION (default: us-east-1), S3_FORCE_PATH_STYLE (default: true), S3_SKIP_BUCKET_POLICY, S3_SKIP_BUCKET_INIT, SKIP_RUNTIME_MIGRATIONS, TRUSTED_PROXY_IP, DEMO_ORG_SLUG, RESEND_API_KEY, RESEND_FROM_EMAIL, EMAIL_FROM, FACTORY_EMAIL_TEST_MODE, FACTORY_EMAIL_CAPTURE_PATH, SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM, SMTP_SECURE, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, MICROSOFT_CALENDAR_AUTH_MODE, MICROSOFT_CALENDAR_CLIENT_ID, MICROSOFT_CALENDAR_CLIENT_SECRET, MICROSOFT_CALENDAR_TENANT_ID, FACTORY_CAREERS_CALENDAR_SYNC_SHARED, FACTORY_CAREERS_CALENDAR_USER_EMAILS, FACTORY_CAREERS_CALENDAR_SYNC_INTERVIEWERS, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL, OIDC_PROVIDER_NAME, AUTH_GOOGLE_CLIENT_ID, AUTH_GOOGLE_CLIENT_SECRET, AUTH_GITHUB_CLIENT_ID, AUTH_GITHUB_CLIENT_SECRET, AUTH_MICROSOFT_CLIENT_ID, AUTH_MICROSOFT_CLIENT_SECRET, AUTH_MICROSOFT_TENANT_ID, FACTORY_CAREERS_HIRING_INBOX, FACTORY_CAREERS_PRIVACY_INBOX, FACTORY_CAREERS_CLI_CLIENT_ID, FACTORY_ALLOWED_EMAIL_DOMAINS, FACTORY_INITIAL_OWNER_EMAILS\n`,
         );
         throw result.error;
       }

--- a/tests/unit/cli-public-commands.test.ts
+++ b/tests/unit/cli-public-commands.test.ts
@@ -78,6 +78,7 @@ describe('CLI public commands', () => {
         email: 'ada@example.com',
         responses: [],
       })
+      expect(JSON.parse(String(init?.body))).not.toHaveProperty('emailTestMode')
       return Response.json({ success: true, applicationId: 'app_1' }, { status: 201 })
     })
     const stdout: string[] = []

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -119,6 +119,24 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.job_lifecycle.result')
   })
 
+  it('runs email-triggering browser coverage against a fake mail sink', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:email']).toBe(
+      'playwright test e2e/critical-flows/fake-mail.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright email')
+    expect(workflow).toContain('npm run test:e2e:email')
+    expect(workflow).toContain('FACTORY_EMAIL_TEST_MODE: capture')
+    expect(workflow).toContain('FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-email.jsonl')
+    expect(workflow).toContain('FACTORY_CAREERS_HIRING_INBOX: hiring-e2e@example.com')
+    expect(workflow).not.toContain('RESEND_API_KEY: ${{ secrets')
+    expect(workflow).toContain('needs.email.result')
+  })
+
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
     const packageJson = JSON.parse(read('package.json')) as {
@@ -132,7 +150,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -161,7 +179,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')
@@ -170,6 +188,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.candidate.result')
     expect(workflow).toContain('needs.recruiter.result')
     expect(workflow).toContain('needs.job_lifecycle.result')
+    expect(workflow).toContain('needs.email.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -137,6 +137,22 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.email.result')
   })
 
+  it('runs tracking-link creation and analytics browser coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:tracking-analytics']).toBe(
+      'playwright test e2e/critical-flows/tracking-analytics.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright tracking analytics')
+    expect(workflow).toContain('npm run test:e2e:tracking-analytics')
+    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).toContain('needs.tracking_analytics.result')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
+  })
+
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
     const packageJson = JSON.parse(read('package.json')) as {
@@ -150,7 +166,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -179,7 +195,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')


### PR DESCRIPTION
## Summary
- adds an explicit fake-mail capture mode that writes rendered email payloads to a JSONL sink for Playwright/Nitro tests
- adds focused application email E2E coverage for candidate receipt and hiring-team alert delivery boundaries without real providers
- fixes React Email template runtime rendering in Nuxt by ensuring JSX compiles to React elements
- wires `test:e2e:email` into a dedicated fast Playwright CI lane and the aggregate E2E gate

Stacked on #126. Closes #116.

## Verification
- `npm run test:e2e:email` (1 passed, 25.8s locally with CI-style webServer)
- `npm run test:unit -- tests/unit/cli-public-commands.test.ts tests/unit/e2e-harness-contract.test.ts tests/unit/application-email-branding.test.ts`
- `npm run typecheck`
- `npm run preflight:cli-parity`
- pre-push preflight via `git push`: CLI parity, all unit tests, typecheck, CLI smoke, production env contract, build