### PR TITLE
fix: add tracking analytics e2e coverage

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -736,10 +736,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  tracking_analytics:
+    name: Playwright tracking analytics
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run tracking analytics browser checks
+        run: npm run test:e2e:tracking-analytics
+
+      - name: Upload Playwright tracking analytics report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-tracking-analytics-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -780,6 +850,10 @@ jobs:
           fi
           if [ "${{ needs.email.result }}" != "success" ]; then
             echo "Playwright email finished with result: ${{ needs.email.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.tracking_analytics.result }}" != "success" ]; then
+            echo "Playwright tracking analytics finished with result: ${{ needs.tracking_analytics.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/app/composables/useSourceTracking.ts
+++ b/app/composables/useSourceTracking.ts
@@ -177,6 +177,7 @@ export function useTrackingLinks(options?: {
       method: 'POST',
       body: payload,
     })
+    clearNuxtData(fetchKey.value)
     await refresh()
     toast.success('Tracking link created')
     return created
@@ -196,12 +197,14 @@ export function useTrackingLinks(options?: {
       method: 'PATCH',
       body: payload,
     })
+    clearNuxtData(fetchKey.value)
     await refresh()
     return updated
   }
 
   async function deleteLink(id: string) {
     await $fetch(`/api/tracking-links/${id}`, { method: 'DELETE' })
+    clearNuxtData(fetchKey.value)
     await refresh()
     toast.success('Tracking link deleted')
   }

--- a/e2e/critical-flows/tracking-analytics.spec.ts
+++ b/e2e/critical-flows/tracking-analytics.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, selectFactorySelectOption } from '../fixtures'
+
+const JOB_TITLE = 'Tracking Analytics Test Job'
+const LINK_NAME = 'LinkedIn Analytics Campaign'
+const UTM_CAMPAIGN = 'tracking-analytics-e2e'
+
+test.describe('Tracking analytics', () => {
+  test('creates a tracking link and reflects tracked applications in recruiter analytics UI', async ({ authenticatedPage, browser }, testInfo) => {
+    const page = authenticatedPage
+    const unique = `${Date.now()}-r${testInfo.retry}`
+    const jobTitle = `${JOB_TITLE} ${unique}`
+    const linkName = `${LINK_NAME} ${unique}`
+    const applicant = {
+      firstName: 'Tracked',
+      lastName: 'Applicant',
+      email: `tracked.applicant.${unique}@example.com`,
+    }
+    const applicantName = `${applicant.firstName} ${applicant.lastName}`
+
+    await page.addInitScript(() => {
+      const copiedUrls: string[] = []
+      Object.defineProperty(window, '__copiedTrackingUrls', {
+        value: copiedUrls,
+        configurable: true,
+      })
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {
+          writeText: async (text: string) => {
+            copiedUrls.push(text)
+          },
+        },
+        configurable: true,
+      })
+    })
+
+    const createJobResponse = await page.request.post('/api/jobs', {
+      data: {
+        title: jobTitle,
+        description: 'A fast E2E job for tracking-link analytics.',
+        location: 'Remote',
+        requireResume: false,
+        requireCoverLetter: false,
+        applicationComplianceEnabled: false,
+        autoScoreOnApply: false,
+      },
+    })
+    expect(createJobResponse.status(), `Create job API returned ${createJobResponse.status()}`).toBe(201)
+    const createdJob = await createJobResponse.json() as { id: string; slug: string }
+    expect(createdJob.id, 'created job id must be present').toBeTruthy()
+    expect(createdJob.slug, 'created job slug must be present').toBeTruthy()
+
+    const publishJobResponse = await page.request.patch(`/api/jobs/${createdJob.id}`, {
+      data: { status: 'open' },
+    })
+    expect(publishJobResponse.status(), `Publish job API returned ${publishJobResponse.status()}`).toBe(200)
+    const publishedJob = await publishJobResponse.json() as { id: string; slug: string; status: string }
+    expect(publishedJob.status).toBe('open')
+
+    await page.goto('/dashboard/source-tracking?tab=links')
+    await expect(page.getByRole('heading', { name: 'Tracking', exact: true })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('button', { name: /New Link|Create Tracking Link/ }).first().click()
+    await expect(page.getByRole('heading', { name: 'Create Tracking Link' })).toBeVisible()
+    await page.getByLabel('Link Name').fill(linkName)
+    await selectFactorySelectOption(page, /Source Channel/, 'LinkedIn')
+    await page.getByText('UTM Parameters (optional)').click()
+    await page.getByLabel('utm_source').fill('linkedin')
+    await page.getByLabel('utm_medium').fill('social')
+    await page.getByLabel('utm_campaign').fill(UTM_CAMPAIGN)
+
+    const [createLinkResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/tracking-links') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.locator('form').getByRole('button', { name: 'Create Link' }).click(),
+    ])
+    expect(createLinkResponse.status(), `Create link API returned ${createLinkResponse.status()}`).toBe(201)
+    const trackingLink = await createLinkResponse.json() as { id: string; code: string }
+    expect(trackingLink.id, 'tracking link id must be present').toBeTruthy()
+    expect(trackingLink.code, 'tracking link code must be present').toBeTruthy()
+    await expect(page.getByRole('heading', { name: 'Create Tracking Link' })).toBeHidden({ timeout: 10_000 })
+
+    await page.getByRole('button', { name: 'Tracking Links' }).click()
+    const linkRow = page.getByRole('row').filter({ hasText: linkName })
+    await expect(linkRow).toBeVisible({ timeout: 15_000 })
+    await expect(linkRow).toContainText('?ref=')
+
+    await linkRow.getByRole('button', { name: 'Copy tracking URL' }).click()
+    const copiedUrls = await page.evaluate(() => (window as any).__copiedTrackingUrls as string[])
+    expect(copiedUrls.at(-1)).toContain(`/api/public/track/${encodeURIComponent(trackingLink.code)}`)
+
+    const candidateContext = await browser.newContext()
+    const candidatePage = await candidateContext.newPage()
+    await candidatePage.goto(`/api/public/track/${trackingLink.code}`)
+    await candidatePage.waitForURL('**/jobs?ref=*', { waitUntil: 'commit', timeout: 15_000 })
+    expect(new URL(candidatePage.url()).searchParams.get('ref')).toBe(trackingLink.code)
+
+    await candidatePage.getByRole('link', { name: jobTitle }).first().click()
+    await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}**`, { waitUntil: 'commit', timeout: 15_000 })
+    await candidatePage.getByRole('link', { name: 'Apply Now' }).first().click()
+    await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}/apply**`, { waitUntil: 'commit', timeout: 15_000 })
+    expect(new URL(candidatePage.url()).searchParams.get('ref')).toBe(trackingLink.code)
+
+    const applyResponse = await candidatePage.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
+      data: {
+        firstName: applicant.firstName,
+        lastName: applicant.lastName,
+        email: applicant.email,
+        country: 'United States',
+        state: 'CA',
+        ref: trackingLink.code,
+        utmSource: 'linkedin',
+        utmMedium: 'social',
+        utmCampaign: UTM_CAMPAIGN,
+        responses: [],
+      },
+    })
+    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
+
+    await expect.poll(async () => {
+      const response = await page.request.get(`/api/tracking-links/${trackingLink.id}`)
+      expect(response.status(), `Tracking link API returned ${response.status()}`).toBe(200)
+      const current = await response.json() as { clickCount: number; applicationCount: number }
+      return current
+    }, {
+      message: 'tracking link counters should include the click and submitted application',
+      timeout: 10_000,
+    }).toEqual(expect.objectContaining({ clickCount: 1, applicationCount: 1 }))
+
+    await page.goto('/dashboard/source-tracking?tab=links')
+    const updatedLinkRow = page.getByRole('row').filter({ hasText: linkName })
+    await expect(updatedLinkRow).toBeVisible({ timeout: 15_000 })
+    await expect(updatedLinkRow.locator('td').nth(3)).toHaveText('1')
+    await expect(updatedLinkRow.locator('td').nth(4)).toHaveText('1')
+    await expect(updatedLinkRow.locator('td').nth(5)).toHaveText('100%')
+
+    await page.getByRole('button', { name: 'Attribution Log' }).click()
+    const attributionRow = page.getByRole('row').filter({ hasText: applicantName })
+    await expect(attributionRow).toBeVisible({ timeout: 15_000 })
+    await expect(attributionRow).toContainText(jobTitle)
+    await expect(attributionRow).toContainText('LinkedIn')
+    await expect(attributionRow).toContainText(`via ${linkName}`)
+
+    await candidateContext.close()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts",
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
     "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts",
+    "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -137,6 +137,22 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.email.result')
   })
 
+  it('runs tracking-link creation and analytics browser coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:tracking-analytics']).toBe(
+      'playwright test e2e/critical-flows/tracking-analytics.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright tracking analytics')
+    expect(workflow).toContain('npm run test:e2e:tracking-analytics')
+    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).toContain('needs.tracking_analytics.result')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
+  })
+
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
     const packageJson = JSON.parse(read('package.json')) as {
@@ -150,7 +166,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -176,7 +192,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')


### PR DESCRIPTION
Stacked on #131. Closes #117.

## Summary
- Adds a focused tracking analytics Playwright lane covering recruiter tracking-link creation/copy, public tracking-link redirect, source-attributed application submission, and recruiter analytics UI assertions.
- Fixes stale tracking-link list refresh after create/update/delete by clearing the Nuxt data cache before refreshing.
- Wires the new lane into `test:e2e:tracking-analytics`, the E2E workflow, and the aggregate required E2E check.

## Verification
- `npm run test:unit -- tests/unit/e2e-harness-contract.test.ts` (19 passed)
- `npm run test:e2e:tracking-analytics` (1 passed, 28.9s locally with CI-style webServer)
- `npm run typecheck` (passes; existing vue-router Volar warning still emitted)
- `git diff --check`
- Pre-push full gate via `git push`: CLI parity, all unit tests (837 passed), typecheck, CLI smoke, production env contract, production build