### PR TITLE
fix: add auth org edge-flow e2e coverage

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -876,10 +876,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  auth_org:
+    name: Playwright auth and org
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run auth and organization browser checks
+        run: npm run test:e2e:auth-org
+
+      - name: Upload Playwright auth-org report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-auth-org-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -928,6 +998,10 @@ jobs:
           fi
           if [ "${{ needs.interviews.result }}" != "success" ]; then
             echo "Playwright interviews finished with result: ${{ needs.interviews.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.auth_org.result }}" != "success" ]; then
+            echo "Playwright auth and org finished with result: ${{ needs.auth_org.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/e2e/critical-flows/auth-org-edge-flows.spec.ts
+++ b/e2e/critical-flows/auth-org-edge-flows.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '../fixtures'
+
+async function signUpWithoutOrganization(page: import('@playwright/test').Page, account: {
+  name: string
+  email: string
+  password: string
+}) {
+  await page.goto('/auth/sign-up')
+  await page.waitForLoadState('networkidle')
+  await page.getByLabel('Name').fill(account.name)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password', { exact: true }).fill(account.password)
+  await page.getByLabel('Confirm password').fill(account.password)
+
+  await Promise.all([
+    page.waitForResponse(
+      resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200,
+      { timeout: 30_000 },
+    ),
+    page.getByRole('button', { name: 'Sign up' }).click(),
+  ])
+
+  await page.waitForURL(
+    url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'),
+    { waitUntil: 'commit', timeout: 30_000 },
+  )
+
+  if (page.url().includes('/auth/sign-in')) {
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Email').fill(account.email)
+    await page.getByLabel('Password').fill(account.password)
+
+    await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200,
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Sign in' }).click(),
+    ])
+
+    await page.waitForURL('**/onboarding/**', { waitUntil: 'networkidle', timeout: 30_000 })
+  } else {
+    await page.waitForLoadState('networkidle')
+  }
+}
+
+test.describe('Auth and organization edge flows', () => {
+  test('new user accepts an invite link through onboarding and lands in the invited organization', async ({ authenticatedPage, testAccount, browser }, testInfo) => {
+    const ownerPage = authenticatedPage
+    const unique = `${Date.now()}-r${testInfo.retry}`
+
+    const createLinkResponse = await ownerPage.request.post('/api/invite-links', {
+      data: {
+        role: 'member',
+        maxUses: 1,
+        expiresInHours: 24,
+      },
+    })
+    expect(createLinkResponse.status(), `Create invite link API returned ${createLinkResponse.status()}`).toBe(201)
+    const inviteLink = await createLinkResponse.json() as { token: string; maxUses: number; useCount: number }
+    expect(inviteLink.token, 'invite token must be returned for test-local acceptance').toMatch(/^[0-9a-f]{64}$/)
+    expect(inviteLink.maxUses).toBe(1)
+    expect(inviteLink.useCount).toBe(0)
+
+    const baseURL = testInfo.project.use.baseURL as string
+    const context = await browser.newContext({ baseURL })
+    const inviteePage = await context.newPage()
+
+    try {
+      const invitee = {
+        name: `Invitee ${unique}`,
+        email: `auth-org-invitee.${unique}@test.local`,
+        password: process.env.E2E_TEST_PASSWORD || 'TestPassword123!',
+      }
+
+      await signUpWithoutOrganization(inviteePage, invitee)
+
+      await expect(inviteePage.getByRole('heading', { name: 'Create your organization' })).toBeVisible({ timeout: 15_000 })
+      await inviteePage.getByRole('button', { name: 'Join an existing organization instead' }).click()
+      await expect(inviteePage.getByRole('heading', { name: 'Join an organization' })).toBeVisible()
+
+      await inviteePage.getByPlaceholder('Paste invite link or code').fill(`${baseURL}/join/${inviteLink.token}`)
+      const [acceptResponse] = await Promise.all([
+        inviteePage.waitForResponse(
+          resp => resp.url().includes('/api/invite-links/accept') && resp.request().method() === 'POST',
+          { timeout: 30_000 },
+        ),
+        inviteePage.getByRole('button', { name: 'Join' }).click(),
+      ])
+      expect(acceptResponse.status(), `Accept invite link API returned ${acceptResponse.status()}`).toBe(200)
+      const accepted = await acceptResponse.json() as { organizationName: string; role: string }
+      expect(accepted.organizationName).toBe(testAccount.orgName)
+      expect(accepted.role).toBe('member')
+
+      await expect(inviteePage.getByRole('heading', { name: "You're in!" })).toBeVisible({ timeout: 15_000 })
+      await inviteePage.waitForURL('**/dashboard', { waitUntil: 'networkidle', timeout: 30_000 })
+      await expect(inviteePage.getByRole('heading', { name: 'Welcome to Factory Careers' })).toBeVisible({ timeout: 15_000 })
+
+      await inviteePage.goto('/dashboard/settings', { waitUntil: 'networkidle' })
+      await expect(inviteePage.getByRole('heading', { name: 'General' })).toBeVisible({ timeout: 15_000 })
+      await expect(inviteePage.getByLabel('Organization name')).toHaveValue(testAccount.orgName)
+
+      const dashboardResponse = await inviteePage.request.get('/api/dashboard/stats')
+      expect(dashboardResponse.status(), `Dashboard stats API returned ${dashboardResponse.status()}`).toBe(200)
+    } finally {
+      await context.close()
+    }
+  })
+})

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts",
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts",
+    "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -150,7 +150,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:tracking-analytics')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.tracking_analytics.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
   })
 
   it('runs interview scheduling lifecycle browser coverage in a dedicated CI lane', () => {
@@ -166,7 +166,23 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:interviews')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.interviews.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+  })
+
+  it('runs auth and organization edge-flow browser coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:auth-org']).toBe(
+      'playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright auth and org')
+    expect(workflow).toContain('npm run test:e2e:auth-org')
+    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).toContain('needs.auth_org.result')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
   })
 
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
@@ -182,7 +198,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -208,7 +224,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')
@@ -220,6 +236,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.email.result')
     expect(workflow).toContain('needs.tracking_analytics.result')
     expect(workflow).toContain('needs.interviews.result')
+    expect(workflow).toContain('needs.auth_org.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {


### PR DESCRIPTION
## Summary

- Add a dedicated auth/org edge-flow Playwright lane and wire it into layered E2E CI.
- Cover invite-link acceptance through onboarding UI with a fresh signed-up user, no email provider.
- Assert invited member lands in dashboard, active org appears in settings, and authenticated dashboard API succeeds.

Stacked on #133. Closes #119.

## Verification

- `npm run test:e2e:auth-org` — 1 passed in 29.6s
- `npm run test:unit -- tests/unit/e2e-harness-contract.test.ts` — 21 passed
- `npm run typecheck` — exit 0; existing `vue-router/volar/sfc-route-blocks` warning remains
- `git diff --check`
- Pre-push gate on `git push -u origin codex/e2e-auth-org-edge-flows`:
  - CLI parity evidence found
  - `npm run test:unit` — 136 files, 839 tests passed
  - no lint script configured
  - `npm run typecheck` — exit 0 with existing warning
  - CLI smoke tests
  - production environment contract PASS
  - `npm run build` — Nuxt build complete