### PR TITLE
fix: add RBAC role-permission e2e coverage

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -890,10 +890,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  rbac:
+    name: Playwright RBAC
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run RBAC browser checks
+        run: npm run test:e2e:rbac
+
+      - name: Upload Playwright RBAC report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-rbac-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -946,6 +1016,10 @@ jobs:
           fi
           if [ "${{ needs.auth_org.result }}" != "success" ]; then
             echo "Playwright auth and org finished with result: ${{ needs.auth_org.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.rbac.result }}" != "success" ]; then
+            echo "Playwright RBAC finished with result: ${{ needs.rbac.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/app/components/AppTopBar.vue
+++ b/app/components/AppTopBar.vue
@@ -197,8 +197,11 @@ watch(() => route.path, () => {
 // ─────────────────────────────────────────────
 
 const newJobResetSignal = useState('new-job-reset-signal', () => 0)
+const { allowed: canCreateJob } = usePermission({ job: ['create'] })
 
 function handleNewJobClick() {
+  if (!canCreateJob.value) return
+
   const newJobPath = localePath('/dashboard/jobs/new')
   if (route.path === newJobPath) {
     // Already on the page: signal the wizard to reset instead of navigating
@@ -392,6 +395,7 @@ function handleNewJobClick() {
 
           <!-- New Job button (desktop) -->
           <button
+            v-if="canCreateJob"
             class="factory-button-cta factory-button-premium mx-1 hidden h-9 items-center gap-1.5 px-3.5 text-[13px] sm:inline-flex"
             @click="handleNewJobClick"
           >
@@ -674,6 +678,7 @@ function handleNewJobClick() {
           </NuxtLink>
 
           <button
+            v-if="canCreateJob"
             class="factory-button-cta factory-button-premium flex w-full items-center gap-3 px-3 py-2.5 text-sm sm:hidden mt-1"
             @click="handleNewJobClick(); showMobileMenu = false"
           >

--- a/app/composables/useSourceTracking.ts
+++ b/app/composables/useSourceTracking.ts
@@ -68,14 +68,20 @@ export function useSourceTracking(options?: {
   const from = computed(() => toValue(options?.from))
   const to = computed(() => toValue(options?.to))
 
-  // ─── Source stats ─────────────────────────
-  const statsUrl = computed(() => {
-    const params = new URLSearchParams()
-    if (jobId.value) params.set('jobId', jobId.value)
-    if (from.value) params.set('from', from.value)
-    if (to.value) params.set('to', to.value)
-    const qs = params.toString()
-    return `/api/source-tracking/stats${qs ? `?${qs}` : ''}`
+  const statsQuery = computed(() => {
+    const query: Record<string, string> = {}
+    if (jobId.value) query.jobId = jobId.value
+    if (from.value) query.from = from.value
+    if (to.value) query.to = to.value
+    return query
+  })
+
+  const statsKey = computed(() => {
+    const parts = ['source-tracking-stats']
+    for (const [key, value] of Object.entries(statsQuery.value)) {
+      parts.push(`${key}:${value}`)
+    }
+    return parts.join('-')
   })
 
   const {
@@ -83,8 +89,10 @@ export function useSourceTracking(options?: {
     status: statsStatus,
     error: statsError,
     refresh: refreshStats,
-  } = useFetch<SourceStats>(statsUrl, {
+  } = useFetch<SourceStats>('/api/source-tracking/stats', {
+    key: statsKey,
     headers: useRequestHeaders(['cookie']),
+    query: statsQuery,
   })
 
   const channelBreakdown = computed(() => stats.value?.channelBreakdown ?? [])
@@ -128,12 +136,11 @@ export function useTrackingLinks(options?: {
     return parts.join(':')
   })
 
-  const linksUrl = computed(() => {
-    const params = new URLSearchParams()
-    if (jobId.value) params.set('jobId', jobId.value)
-    if (channel.value) params.set('channel', channel.value)
-    const qs = params.toString()
-    return `/api/tracking-links${qs ? `?${qs}` : ''}`
+  const linksQuery = computed(() => {
+    const query: Record<string, string> = {}
+    if (jobId.value) query.jobId = jobId.value
+    if (channel.value) query.channel = channel.value
+    return query
   })
 
   const {
@@ -141,9 +148,10 @@ export function useTrackingLinks(options?: {
     status: fetchStatus,
     error,
     refresh,
-  } = useFetch<{ data: TrackingLink[]; total: number }>(linksUrl, {
-    key: fetchKey.value,
+  } = useFetch<{ data: TrackingLink[]; total: number }>('/api/tracking-links', {
+    key: fetchKey,
     headers: useRequestHeaders(['cookie']),
+    query: linksQuery,
     // 45s SWR for source-tracking links (heavy dashboard page)
     getCachedData(key, nuxtApp) {
       const cached = nuxtApp.payload.data[key]

--- a/app/pages/dashboard/index.vue
+++ b/app/pages/dashboard/index.vue
@@ -20,6 +20,7 @@ const { activeOrg } = useCurrentOrg()
 const localePath = useLocalePath()
 const { track } = useTrack()
 const { formatPersonName } = useOrgSettings()
+const { allowed: canCreateJob } = usePermission({ job: ['create'] })
 
 let dashboardNowTimer: ReturnType<typeof setInterval> | undefined
 
@@ -215,6 +216,7 @@ const isEmpty = computed(() =>
           Your recruiting command center. Create your first job posting to start building your hiring pipeline.
         </p>
         <NuxtLink
+          v-if="canCreateJob"
           :to="localePath('/dashboard/jobs/new')"
           class="factory-button-cta factory-button-premium inline-flex items-center gap-2.5 rounded-xl px-7 py-3.5 text-sm font-semibold transition-all no-underline"
         >
@@ -339,6 +341,7 @@ const isEmpty = computed(() =>
               <p class="text-sm font-medium text-surface-500 dark:text-surface-400 mb-1">No open jobs</p>
               <p class="text-xs text-surface-400 dark:text-surface-500 mb-4">Create your first job to see the pipeline</p>
               <NuxtLink
+                v-if="canCreateJob"
                 :to="localePath('/dashboard/jobs/new')"
                 class="inline-flex items-center gap-1.5 text-xs font-semibold text-brand-600 dark:text-brand-400 no-underline hover:text-brand-700 dark:hover:text-brand-300"
               >
@@ -534,6 +537,7 @@ const isEmpty = computed(() =>
 
             <div class="p-2.5 space-y-0.5">
               <NuxtLink
+                v-if="canCreateJob"
                 :to="localePath('/dashboard/jobs/new')"
                 class="factory-dashboard-quick-action flex items-center gap-3 px-3.5 py-2.5 text-sm font-medium transition-all no-underline"
               >

--- a/app/pages/dashboard/jobs/index.vue
+++ b/app/pages/dashboard/jobs/index.vue
@@ -19,6 +19,7 @@ useSeoMeta({
 
 const { activeOrg } = useCurrentOrg()
 const localePath = useLocalePath()
+const { allowed: canCreateJob } = usePermission({ job: ['create'] })
 
 // ─────────────────────────────────────────────
 // Stage config for clickable pipeline counts
@@ -413,6 +414,7 @@ const noResults = computed(() => !isEmpty.value && filteredJobs.value.length ===
           Create your first job posting to start receiving and managing candidates.
         </p>
         <NuxtLink
+          v-if="canCreateJob"
           :to="$localePath('/dashboard/jobs/new')"
           class="factory-button-cta factory-button-premium inline-flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-medium transition-colors no-underline"
         >

--- a/app/pages/dashboard/jobs/new.vue
+++ b/app/pages/dashboard/jobs/new.vue
@@ -33,6 +33,7 @@ import {
   Megaphone,
   Building2,
   Search,
+  AlertTriangle,
 } from 'lucide-vue-next'
 import { z } from 'zod'
 import { todayDateInputValue } from '~~/shared/date-input'
@@ -51,6 +52,7 @@ const localePath = useLocalePath()
 const { createJob } = useJobs()
 const { track } = useTrack()
 const toast = useToast()
+const { allowed: canCreateJob, isLoading: isPermissionLoading } = usePermission({ job: ['create'] })
 
 type QuestionType =
   | 'short_text'
@@ -723,7 +725,22 @@ const questionTypeLabels: Record<QuestionType, string> = {
 </script>
 
 <template>
-  <div class="mx-auto max-w-6xl px-4 py-8">
+  <div v-if="isPermissionLoading" class="flex items-center justify-center py-12">
+    <Loader2 class="size-6 animate-spin text-surface-400" />
+  </div>
+
+  <div
+    v-else-if="!canCreateJob"
+    class="ui-alert ui-alert-warning mx-auto mt-8 max-w-3xl p-5 flex items-start gap-3"
+  >
+    <AlertTriangle class="size-5 shrink-0 mt-0.5" />
+    <div>
+      <p class="font-semibold mb-1">Insufficient permissions</p>
+      <p>You don't have permission to create jobs. Contact an organization owner or admin.</p>
+    </div>
+  </div>
+
+  <div v-else class="mx-auto max-w-6xl px-4 py-8">
     <!-- Header with top actions -->
     <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-8">
       <div>

--- a/e2e/critical-flows/rbac-role-permissions.spec.ts
+++ b/e2e/critical-flows/rbac-role-permissions.spec.ts
@@ -100,18 +100,22 @@ async function grantOrganizationRole(userId: string, organizationId: string, rol
 
   try {
     await sql.begin(async (tx) => {
-      await tx`
+      const [membership] = await tx<{ id: string }[]>`
         insert into "member" ("id", "user_id", "organization_id", "role")
         values (${randomUUID()}, ${userId}, ${organizationId}, ${role})
         on conflict ("user_id", "organization_id")
         do update set "role" = ${role}
+        returning "id"
       `
+      expect(membership?.id, `expected ${role} membership to exist after grant`).toBeTruthy()
 
-      await tx`
+      const updatedSessions = await tx<{ id: string }[]>`
         update "session"
         set "active_organization_id" = ${organizationId}, "updated_at" = now()
         where "user_id" = ${userId}
+        returning "id"
       `
+      expect(updatedSessions.length, 'expected role grant to update an active session').toBeGreaterThan(0)
     })
   }
   finally {
@@ -202,7 +206,13 @@ test.describe('RBAC role permissions', () => {
 
       const memberApplicationsResponse = await memberApi.get('/api/applications')
       expect(memberApplicationsResponse.status()).toBe(200)
-      expect(JSON.stringify(await memberApplicationsResponse.json())).toContain(application.id)
+      const memberApplications = await memberApplicationsResponse.json() as {
+        data?: Array<{ id?: string }>
+      }
+      expect(
+        memberApplications.data?.some((item) => item.id === application.id),
+        `expected member application list to include ${application.id}`,
+      ).toBe(true)
 
       await member.page.goto('/dashboard/applications')
       await expect(member.page.getByRole('heading', { name: 'Applications' })).toBeVisible()

--- a/e2e/critical-flows/rbac-role-permissions.spec.ts
+++ b/e2e/critical-flows/rbac-role-permissions.spec.ts
@@ -1,0 +1,223 @@
+import { randomUUID } from 'node:crypto'
+import { type Browser, type Page } from '@playwright/test'
+import postgres from 'postgres'
+import { test, expect } from '../fixtures'
+
+interface SignedInOrg {
+  page: Page
+  userId: string
+  organizationId: string
+  close: () => Promise<void>
+}
+
+async function lookupMembership(email: string, organizationName: string) {
+  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for RBAC e2e membership lookup').toBeTruthy()
+  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+
+  try {
+    const [membership] = await sql<{ userId: string, organizationId: string }[]>`
+      select u.id as "userId", o.id as "organizationId"
+      from "user" u
+      inner join "member" m on m."user_id" = u.id
+      inner join "organization" o on o.id = m."organization_id"
+      where u.email = ${email} and o.name = ${organizationName}
+      limit 1
+    `
+
+    expect(membership, `expected ${email} to belong to ${organizationName}`).toBeTruthy()
+    return membership
+  }
+  finally {
+    await sql.end()
+  }
+}
+
+async function signUpWithOrg(browser: Browser, label: string): Promise<SignedInOrg> {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const account = {
+    name: `RBAC ${label} ${id}`,
+    email: `rbac-${label}-${id}@test.local`,
+    password: 'TestPassword123!',
+    orgName: `RBAC ${label} Org ${id}`,
+  }
+
+  await page.goto('/auth/sign-up')
+  await page.waitForLoadState('networkidle')
+  await page.getByLabel('Name').fill(account.name)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password', { exact: true }).fill(account.password)
+  await page.getByLabel('Confirm password').fill(account.password)
+
+  await Promise.all([
+    page.waitForResponse(
+      resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200,
+      { timeout: 30_000 },
+    ),
+    page.getByRole('button', { name: 'Sign up' }).click(),
+  ])
+
+  await page.waitForURL(
+    url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'),
+    { waitUntil: 'commit', timeout: 30_000 },
+  )
+
+  if (page.url().includes('/auth/sign-in')) {
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Email').fill(account.email)
+    await page.getByLabel('Password').fill(account.password)
+
+    await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200,
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Sign in' }).click(),
+    ])
+
+    await page.waitForURL('**/onboarding/**', { waitUntil: 'commit', timeout: 30_000 })
+  }
+
+  await page.getByLabel('Organization name').waitFor({ state: 'visible', timeout: 30_000 })
+  await page.getByLabel('Organization name').fill(account.orgName)
+  await page.getByRole('button', { name: 'Create organization' }).click()
+  await page.waitForURL('**/dashboard**', { waitUntil: 'commit' })
+
+  const membership = await lookupMembership(account.email, account.orgName)
+
+  return {
+    page,
+    userId: membership.userId,
+    organizationId: membership.organizationId,
+    close: () => context.close(),
+  }
+}
+
+async function grantOrganizationRole(userId: string, organizationId: string, role: 'admin' | 'member') {
+  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for RBAC role grant').toBeTruthy()
+  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+
+  try {
+    await sql.begin(async (tx) => {
+      await tx`
+        insert into "member" ("id", "user_id", "organization_id", "role")
+        values (${randomUUID()}, ${userId}, ${organizationId}, ${role})
+        on conflict ("user_id", "organization_id")
+        do update set "role" = ${role}
+      `
+
+      await tx`
+        update "session"
+        set "active_organization_id" = ${organizationId}, "updated_at" = now()
+        where "user_id" = ${userId}
+      `
+    })
+  }
+  finally {
+    await sql.end()
+  }
+}
+
+test.describe('RBAC role permissions', () => {
+  test('member UI restrictions agree with direct API authorization while owner actions still work', async ({ authenticatedPage, testAccount, browser }, testInfo) => {
+    const ownerPage = authenticatedPage
+    const ownerMembership = await lookupMembership(testAccount.email, testAccount.orgName)
+    const member = await signUpWithOrg(browser, `member-${testInfo.workerIndex}`)
+
+    try {
+      await grantOrganizationRole(member.userId, ownerMembership.organizationId, 'member')
+
+      const memberApi = member.page.context().request
+      const ownerApi = ownerPage.context().request
+      const origin = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:13000'
+
+      const activeOrgResponse = await memberApi.post('/api/auth/organization/set-active', {
+        headers: { origin },
+        data: { organizationId: ownerMembership.organizationId },
+      })
+      expect(activeOrgResponse.status()).toBe(200)
+
+      await ownerPage.goto('/dashboard/settings/members')
+      await expect(ownerPage.getByRole('heading', { name: 'Members', exact: true })).toBeVisible()
+      await expect(ownerPage.getByRole('button', { name: 'Invite team member' })).toBeVisible()
+      await expect(ownerPage.getByRole('button', { name: 'New Job' }).first()).toBeVisible()
+
+      const jobResponse = await ownerApi.post('/api/jobs', {
+        data: {
+          title: `RBAC Browser Role ${Date.now()}`,
+          description: 'Owner-created job for RBAC browser coverage',
+          location: 'Remote',
+          type: 'full_time',
+          requireResume: false,
+        },
+      })
+      expect(jobResponse.status()).toBe(201)
+      const job = await jobResponse.json()
+
+      const candidateResponse = await ownerApi.post('/api/candidates', {
+        data: {
+          firstName: 'Robin',
+          lastName: 'Rolecheck',
+          email: `robin-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`,
+          phone: '+1 555 0177',
+        },
+      })
+      expect(candidateResponse.status()).toBe(201)
+      const candidate = await candidateResponse.json()
+
+      const applicationResponse = await ownerApi.post('/api/applications', {
+        data: {
+          candidateId: candidate.id,
+          jobId: job.id,
+          notes: 'RBAC browser fixture',
+        },
+      })
+      expect(applicationResponse.status()).toBe(201)
+      const application = await applicationResponse.json()
+
+      await member.page.goto('/dashboard/settings/members')
+      await expect(member.page.getByRole('heading', { name: 'Members', exact: true })).toBeVisible()
+      await expect(member.page.getByRole('button', { name: 'Invite team member' })).toHaveCount(0)
+      await expect(member.page.getByRole('button', { name: 'New Job' })).toHaveCount(0)
+
+      await member.page.goto('/dashboard/jobs/new')
+      await expect(member.page.getByText("You don't have permission to create jobs.")).toBeVisible()
+      await expect(member.page.getByRole('button', { name: 'Save Draft' })).toHaveCount(0)
+
+      const forbiddenJobResponse = await memberApi.post('/api/jobs', {
+        data: {
+          title: 'Member should not create jobs',
+          description: 'RBAC denial fixture',
+          location: 'Remote',
+          type: 'full_time',
+        },
+      })
+      expect(forbiddenJobResponse.status()).toBe(403)
+
+      const forbiddenInviteResponse = await memberApi.post('/api/invite-links', {
+        data: { role: 'member', expiresInHours: 24, maxUses: 1 },
+      })
+      expect(forbiddenInviteResponse.status()).toBe(403)
+
+      const memberApplicationsResponse = await memberApi.get('/api/applications')
+      expect(memberApplicationsResponse.status()).toBe(200)
+      expect(JSON.stringify(await memberApplicationsResponse.json())).toContain(application.id)
+
+      await member.page.goto('/dashboard/applications')
+      await expect(member.page.getByRole('heading', { name: 'Applications' })).toBeVisible()
+      await expect(member.page.getByText('Robin Rolecheck')).toBeVisible()
+
+      const crossOrgResponse = await memberApi.post('/api/auth/organization/set-active', {
+        headers: { origin },
+        data: { organizationId: member.organizationId },
+      })
+      expect(crossOrgResponse.status()).toBe(200)
+      const hiddenApplicationResponse = await memberApi.get(`/api/applications/${application.id}`)
+      expect(hiddenApplicationResponse.status()).toBe(404)
+    }
+    finally {
+      await member.close()
+    }
+  })
+})

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts",
     "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",
+    "test:e2e:rbac": "playwright test e2e/critical-flows/rbac-role-permissions.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -150,7 +150,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:tracking-analytics')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.tracking_analytics.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
   })
 
   it('runs interview scheduling lifecycle browser coverage in a dedicated CI lane', () => {
@@ -166,7 +166,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:interviews')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.interviews.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
   })
 
   it('runs auth and organization edge-flow browser coverage in a dedicated CI lane', () => {
@@ -182,7 +182,23 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:auth-org')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.auth_org.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+  })
+
+  it('runs role-permission browser coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:rbac']).toBe(
+      'playwright test e2e/critical-flows/rbac-role-permissions.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright RBAC')
+    expect(workflow).toContain('npm run test:e2e:rbac')
+    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).toContain('needs.rbac.result')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
   })
 
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
@@ -198,7 +214,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -227,7 +243,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')
@@ -240,6 +256,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.tracking_analytics.result')
     expect(workflow).toContain('needs.interviews.result')
     expect(workflow).toContain('needs.auth_org.result')
+    expect(workflow).toContain('needs.rbac.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {


### PR DESCRIPTION
## Summary

- Add a dedicated RBAC browser lane for member-vs-owner dashboard permissions and wire it into layered E2E CI.
- Cover owner invite/create-job access, member hidden restricted actions, direct 403 checks for job creation and invite-link creation, member application visibility, and cross-org application isolation.
- Fix the production UI mismatch the test exposed by hiding job-creation entry points for users without `job:create` and guarding `/dashboard/jobs/new` with an insufficient-permissions state.

Stacked on #139. Closes #127.

## Verification

- Red check first: `npm exec playwright test e2e/critical-flows/rbac-role-permissions.spec.ts` failed because member users still saw `New Job` while the create-job API was forbidden.
- `npm run test:e2e:rbac` — 1 passed in 18.4s
- `npm run test:unit -- tests/unit/e2e-harness-contract.test.ts` — 22 passed
- `npm run test:unit -- tests/unit/rbac-matrix.test.ts tests/unit/security-issues-regression.test.ts` — 13 passed
- `npm run typecheck` — exit 0; existing `vue-router/volar/sfc-route-blocks` warning remains
- `git diff --check`
- Pre-push gate on `git push -u origin codex/e2e-rbac-role-permissions`:
  - CLI parity evidence found
  - `npm run test:unit` — 136 files, 840 tests passed
  - no lint script configured
  - `npm run typecheck` — exit 0 with existing warning
  - CLI smoke tests
  - production environment contract PASS
  - `npm run build` — Nuxt build complete