### PR TITLE
fix: add SSO domain provisioning e2e coverage

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -960,10 +960,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  sso:
+    name: Playwright SSO
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333,http://127.0.0.1:3999
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run SSO domain provisioning browser checks
+        run: npm run test:e2e:sso
+
+      - name: Upload Playwright SSO report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-sso-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -1020,6 +1090,10 @@ jobs:
           fi
           if [ "${{ needs.rbac.result }}" != "success" ]; then
             echo "Playwright RBAC finished with result: ${{ needs.rbac.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.sso.result }}" != "success" ]; then
+            echo "Playwright SSO finished with result: ${{ needs.sso.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -986,6 +986,7 @@ jobs:
       BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
       BETTER_AUTH_URL: http://127.0.0.1:3333
       BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333,http://127.0.0.1:3999
+      E2E_SSO_MOCK_PORT: "3999"
       NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
       PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
       FACTORY_DISABLE_PUBLIC_SIGNUP: "false"

--- a/app/pages/auth/sign-in.vue
+++ b/app/pages/auth/sign-in.vue
@@ -121,7 +121,7 @@ async function handleFactorySso() {
             :disabled="ssoRedirecting"
             data-slot="button"
             data-hover-effect="slide"
-            aria-label="Continue with SSO"
+            aria-label="Sign in with Microsoft"
             :aria-busy="ssoRedirecting"
             class="factory-microsoft-signin-button inline-flex min-h-12 cursor-pointer items-center justify-center gap-3 border border-transparent bg-white px-4 py-3 text-[15px] font-semibold tracking-normal text-[#1f1f1f] shadow-sm focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
         >

--- a/app/pages/auth/sign-in.vue
+++ b/app/pages/auth/sign-in.vue
@@ -121,7 +121,7 @@ async function handleFactorySso() {
             :disabled="ssoRedirecting"
             data-slot="button"
             data-hover-effect="slide"
-            aria-label="Sign in with Microsoft"
+            aria-label="Continue with SSO"
             :aria-busy="ssoRedirecting"
             class="factory-microsoft-signin-button inline-flex min-h-12 cursor-pointer items-center justify-center gap-3 border border-transparent bg-white px-4 py-3 text-[15px] font-semibold tracking-normal text-[#1f1f1f] shadow-sm focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
         >

--- a/app/pages/auth/sign-in.vue
+++ b/app/pages/auth/sign-in.vue
@@ -10,8 +10,12 @@ useSeoMeta({
     robots: "noindex, nofollow",
 });
 
+const FACTORY_SSO_PROVIDER_ID = "thefactoryhq-sso";
+
 const ssoRedirecting = ref(false);
+const workEmail = ref("");
 const route = useRoute();
+const localePath = useLocalePath();
 const { track } = useTrack();
 const toast = useToast();
 
@@ -24,18 +28,6 @@ function getSafeRedirectPath(value: unknown): string | null {
     if (!value.startsWith("/") || value.startsWith("//")) return null;
     return value;
 }
-
-const factorySsoUrl = computed(() => {
-    const params = new URLSearchParams();
-    const pendingInvitation = route.query.invitation as string | undefined;
-    const safeRedirect = getSafeRedirectPath(route.query.redirect);
-
-    if (pendingInvitation) params.set("invitation", pendingInvitation);
-    if (safeRedirect) params.set("redirect", safeRedirect);
-
-    const query = params.toString();
-    return query ? `/api/auth/factory-sso?${query}` : "/api/auth/factory-sso";
-});
 
 onMounted(() => {
     track("signin_page_viewed");
@@ -54,14 +46,76 @@ onMounted(() => {
     );
 });
 
-function handleFactorySso() {
+async function handleFactorySso() {
     ssoRedirecting.value = true;
     track("signin_sso_started");
+    const normalizedWorkEmail = workEmail.value.trim().toLowerCase();
+
+    const pendingInvitation = route.query.invitation as string | undefined;
+    const safeRedirect = getSafeRedirectPath(route.query.redirect);
+    const callbackURL = pendingInvitation
+        ? localePath(`/auth/accept-invitation/${pendingInvitation}`)
+        : safeRedirect
+            ? localePath(safeRedirect)
+        : localePath("/dashboard");
+    const errorCallbackURL = pendingInvitation
+        ? localePath(`/auth/sign-in?invitation=${encodeURIComponent(pendingInvitation)}`)
+        : safeRedirect
+            ? localePath(`/auth/sign-in?redirect=${encodeURIComponent(safeRedirect)}`)
+        : localePath("/auth/sign-in");
+
+    try {
+        const result = await authClient.signIn.sso({
+            ...(normalizedWorkEmail
+                ? { email: normalizedWorkEmail, loginHint: normalizedWorkEmail }
+                : { providerId: FACTORY_SSO_PROVIDER_ID }),
+            callbackURL,
+            errorCallbackURL,
+            providerType: "oidc",
+        });
+
+        if (result.error) {
+            showSignInError(
+                result.error.message ??
+                "Microsoft SSO is not available yet. Ask an owner to check the SSO configuration.",
+                result.error.code,
+            );
+            ssoRedirecting.value = false;
+            return;
+        }
+
+        const redirectUrl = result.data?.url;
+        if (redirectUrl) {
+            await navigateTo(redirectUrl, { external: true });
+            return;
+        }
+
+        track("signin_sso_started");
+    } catch (e: unknown) {
+        showSignInError(
+            e instanceof Error
+                ? e.message
+                : "Microsoft SSO sign-in failed. Please try again.",
+        );
+        ssoRedirecting.value = false;
+    }
 }
 </script>
 
 <template>
-    <form class="flex flex-col gap-5" method="get" :action="factorySsoUrl" @submit="handleFactorySso">
+    <form class="flex flex-col gap-5" @submit.prevent="handleFactorySso">
+        <label class="flex flex-col gap-1.5 text-sm font-medium text-white/72">
+            <span>Work email</span>
+            <input
+                v-model="workEmail"
+                type="email"
+                autocomplete="email"
+                inputmode="email"
+                placeholder="you@company.com"
+                class="min-h-12 border border-white/14 bg-white/[0.06] px-3 py-2 text-sm text-white outline-none transition-colors placeholder:text-white/32 focus:border-white/34 focus:ring-2 focus:ring-white/10"
+            />
+        </label>
+
         <button
             type="submit"
             :disabled="ssoRedirecting"
@@ -77,7 +131,7 @@ function handleFactorySso() {
                 <rect x="1" y="12" width="10" height="10" fill="#00A4EF" />
                 <rect x="12" y="12" width="10" height="10" fill="#FFB900" />
             </svg>
-            <span>{{ ssoRedirecting ? "Redirecting..." : "Sign in with Microsoft" }}</span>
+            {{ ssoRedirecting ? "Redirecting..." : "Continue with SSO" }}
         </button>
 
         <p class="text-center text-xs leading-5 text-white/42">

--- a/e2e/critical-flows/sso-domain-provisioning.spec.ts
+++ b/e2e/critical-flows/sso-domain-provisioning.spec.ts
@@ -160,7 +160,7 @@ test.describe('SSO domain provisioning', () => {
       const signInPage = await signInContext.newPage()
       await signInPage.goto('/auth/sign-in')
       await expect(signInPage).toHaveURL(/\/auth\/sign-in/)
-      await expect(signInPage.getByRole('button', { name: 'Continue with SSO' })).toBeVisible()
+      await expect(signInPage.getByRole('button', { name: 'Sign in with Microsoft' })).toBeVisible()
       await signInPage.getByLabel('Work email').fill(configuredEmail)
 
       const ssoResponsePromise = signInPage.waitForResponse(
@@ -168,7 +168,7 @@ test.describe('SSO domain provisioning', () => {
         { timeout: 30_000 },
       )
 
-      await signInPage.getByRole('button', { name: 'Continue with SSO' }).click()
+      await signInPage.getByRole('button', { name: 'Sign in with Microsoft' }).click()
       const ssoResponse = await ssoResponsePromise
       expect(ssoResponse.status()).toBe(200)
 

--- a/e2e/critical-flows/sso-domain-provisioning.spec.ts
+++ b/e2e/critical-flows/sso-domain-provisioning.spec.ts
@@ -152,11 +152,15 @@ test.describe('SSO domain provisioning', () => {
       expect(redirectUrl.searchParams.get('redirect_uri')).toBe(`http://127.0.0.1:3333/api/auth/sso/callback/${providerId}`)
       expect(ssoPayload.url).not.toContain('thefactoryhq.com')
 
-      const signInContext = await browser.newContext({ storageState: { cookies: [], origins: [] } })
+      const appOrigin = new URL(authenticatedPage.url()).origin
+      const signInContext = await browser.newContext({
+        baseURL: appOrigin,
+        storageState: { cookies: [], origins: [] },
+      })
       const signInPage = await signInContext.newPage()
       await signInPage.goto('/auth/sign-in')
-      await signInPage.waitForLoadState('networkidle')
       await expect(signInPage).toHaveURL(/\/auth\/sign-in/)
+      await expect(signInPage.getByRole('button', { name: 'Continue with SSO' })).toBeVisible()
       await signInPage.getByLabel('Work email').fill(configuredEmail)
 
       const ssoResponsePromise = signInPage.waitForResponse(

--- a/e2e/critical-flows/sso-domain-provisioning.spec.ts
+++ b/e2e/critical-flows/sso-domain-provisioning.spec.ts
@@ -1,0 +1,160 @@
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { test, expect } from '../fixtures'
+
+type MockOidcIssuer = {
+  issuer: string
+  close: () => Promise<void>
+}
+
+async function startMockOidcIssuer(): Promise<MockOidcIssuer> {
+  let server: Server
+  const port = 3999
+
+  server = createServer((req, res) => {
+    const address = server.address() as AddressInfo
+    const issuer = `http://127.0.0.1:${address.port}`
+
+    if (req.url === '/.well-known/openid-configuration') {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({
+        issuer,
+        authorization_endpoint: `${issuer}/authorize`,
+        token_endpoint: `${issuer}/token`,
+        userinfo_endpoint: `${issuer}/userinfo`,
+        jwks_uri: `${issuer}/jwks`,
+        response_types_supported: ['code'],
+        subject_types_supported: ['public'],
+        id_token_signing_alg_values_supported: ['RS256'],
+      }))
+      return
+    }
+
+    if (req.url?.startsWith('/authorize')) {
+      res.writeHead(200, { 'content-type': 'text/html' })
+      res.end('<main><h1>Mock IdP sign-in</h1></main>')
+      return
+    }
+
+    if (req.url === '/jwks') {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ keys: [] }))
+      return
+    }
+
+    res.writeHead(404)
+    res.end('not found')
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(port, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  const address = server.address() as AddressInfo
+
+  return {
+    issuer: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve())
+    }),
+  }
+}
+
+test.describe('SSO domain provisioning', () => {
+  test('routes configured work domains to local SSO only and rejects unconfigured domains', async ({ authenticatedPage, browser }, testInfo) => {
+    const id = `${Date.now()}-${testInfo.workerIndex}-${Math.random().toString(36).slice(2)}`
+    const providerId = `sso-${id}`
+    const domain = `sso-${id}.example.com`
+    const mockIssuer = await startMockOidcIssuer()
+
+    try {
+      await authenticatedPage.goto('/dashboard/settings/sso')
+      await expect(authenticatedPage.getByRole('heading', { name: 'Single Sign-On' })).toBeVisible()
+      await authenticatedPage.getByRole('button', { name: /Add SSO Provider|Add another provider/ }).click()
+      await authenticatedPage.getByLabel('Email domain').fill(domain)
+      await authenticatedPage.getByLabel('Issuer URL').fill(mockIssuer.issuer)
+      await authenticatedPage.getByLabel('Provider ID').fill(providerId)
+      await authenticatedPage.getByLabel('Client ID').fill(`client-${id}`)
+      await authenticatedPage.getByLabel('Client Secret').fill(`secret-${id}`)
+
+      const [registrationResponse] = await Promise.all([
+        authenticatedPage.waitForResponse(
+          resp => resp.url().includes('/api/sso/providers') && resp.request().method() === 'POST',
+          { timeout: 30_000 },
+        ),
+        authenticatedPage.getByRole('button', { name: 'Register SSO Provider' }).click(),
+      ])
+      expect(
+        registrationResponse.status(),
+        await registrationResponse.text(),
+      ).toBe(201)
+
+      await expect(authenticatedPage.getByRole('heading', { name: providerId })).toBeVisible()
+      await expect(authenticatedPage.getByText(domain, { exact: true })).toBeVisible()
+
+      const callbackUrl = authenticatedPage.getByText(new RegExp(`/api/auth/sso/callback/${providerId}$`))
+      await expect(callbackUrl).toBeVisible()
+      await expect(callbackUrl).toContainText('http://127.0.0.1:3333')
+      await expect(callbackUrl).not.toContainText('thefactoryhq.com')
+
+      const api = authenticatedPage.context().request
+      const localCallback = '/dashboard'
+      const localErrorCallback = '/auth/sign-in'
+      const unconfiguredResponse = await api.post('/api/auth/sign-in/sso', {
+        headers: { origin: 'http://127.0.0.1:3333' },
+        data: {
+          email: `intruder@unconfigured-${id}.example.com`,
+          callbackURL: localCallback,
+          errorCallbackURL: localErrorCallback,
+          providerType: 'oidc',
+        },
+      })
+      expect(unconfiguredResponse.status()).toBe(404)
+
+      const configuredEmail = `owner@${domain}`
+      const configuredResponse = await api.post('/api/auth/sign-in/sso', {
+        headers: { origin: 'http://127.0.0.1:3333' },
+        data: {
+          email: configuredEmail,
+          callbackURL: localCallback,
+          errorCallbackURL: localErrorCallback,
+          providerType: 'oidc',
+        },
+      })
+      expect(configuredResponse.status()).toBe(200)
+      const ssoPayload = await configuredResponse.json()
+      const redirectUrl = new URL(String(ssoPayload.url))
+      expect(redirectUrl.origin).toBe(mockIssuer.issuer)
+      expect(redirectUrl.pathname).toBe('/authorize')
+      expect(redirectUrl.searchParams.get('login_hint')).toBe(configuredEmail)
+      expect(redirectUrl.searchParams.get('redirect_uri')).toBe(`http://127.0.0.1:3333/api/auth/sso/callback/${providerId}`)
+      expect(ssoPayload.url).not.toContain('thefactoryhq.com')
+
+      const signInContext = await browser.newContext({ storageState: { cookies: [], origins: [] } })
+      const signInPage = await signInContext.newPage()
+      await signInPage.goto('/auth/sign-in')
+      await signInPage.waitForLoadState('networkidle')
+      await expect(signInPage).toHaveURL(/\/auth\/sign-in/)
+      await signInPage.getByLabel('Work email').fill(configuredEmail)
+
+      const ssoResponsePromise = signInPage.waitForResponse(
+        resp => resp.url().includes('/api/auth/sign-in/sso') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      )
+
+      await signInPage.getByRole('button', { name: 'Continue with SSO' }).click()
+      const ssoResponse = await ssoResponsePromise
+      expect(ssoResponse.status()).toBe(200)
+
+      await expect(signInPage.getByRole('heading', { name: 'Mock IdP sign-in' })).toBeVisible()
+      await signInContext.close()
+    }
+    finally {
+      await mockIssuer.close()
+    }
+  })
+})

--- a/e2e/critical-flows/sso-domain-provisioning.spec.ts
+++ b/e2e/critical-flows/sso-domain-provisioning.spec.ts
@@ -7,9 +7,20 @@ type MockOidcIssuer = {
   close: () => Promise<void>
 }
 
+function getMockOidcIssuerPort(): number {
+  const rawPort = process.env.E2E_SSO_MOCK_PORT ?? '3999'
+  const port = Number(rawPort)
+
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`E2E_SSO_MOCK_PORT must be an integer from 1 to 65535; received ${JSON.stringify(rawPort)}`)
+  }
+
+  return port
+}
+
 async function startMockOidcIssuer(): Promise<MockOidcIssuer> {
   let server: Server
-  const port = 3999
+  const port = getMockOidcIssuerPort()
 
   server = createServer((req, res) => {
     const address = server.address() as AddressInfo
@@ -47,9 +58,16 @@ async function startMockOidcIssuer(): Promise<MockOidcIssuer> {
   })
 
   await new Promise<void>((resolve, reject) => {
-    server.once('error', reject)
+    server.once('error', (error: NodeJS.ErrnoException) => {
+      if (error.code === 'EADDRINUSE') {
+        reject(new Error(`Mock OIDC issuer could not bind to 127.0.0.1:${port}. Set E2E_SSO_MOCK_PORT to an available port and include it in BETTER_AUTH_TRUSTED_ORIGINS.`))
+        return
+      }
+
+      reject(error)
+    })
     server.listen(port, '127.0.0.1', () => {
-      server.off('error', reject)
+      server.removeAllListeners('error')
       resolve()
     })
   })

--- a/e2e/critical-flows/sso-domain-provisioning.spec.ts
+++ b/e2e/critical-flows/sso-domain-provisioning.spec.ts
@@ -159,6 +159,7 @@ test.describe('SSO domain provisioning', () => {
       })
       const signInPage = await signInContext.newPage()
       await signInPage.goto('/auth/sign-in')
+      await signInPage.waitForLoadState('networkidle')
       await expect(signInPage).toHaveURL(/\/auth\/sign-in/)
       await expect(signInPage.getByRole('button', { name: 'Sign in with Microsoft' })).toBeVisible()
       await signInPage.getByLabel('Work email').fill(configuredEmail)

--- a/e2e/critical-flows/tracking-analytics.spec.ts
+++ b/e2e/critical-flows/tracking-analytics.spec.ts
@@ -134,7 +134,7 @@ test.describe('Tracking analytics', () => {
     await expect(updatedLinkRow.locator('td').nth(4)).toHaveText('1')
     await expect(updatedLinkRow.locator('td').nth(5)).toHaveText('100%')
 
-    await page.getByRole('button', { name: 'Attribution Log' }).click()
+    await page.goto('/dashboard/source-tracking?tab=table')
     const attributionRow = page.getByRole('row').filter({ hasText: applicantName })
     await expect(attributionRow).toBeVisible({ timeout: 15_000 })
     await expect(attributionRow).toContainText(jobTitle)

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts",
     "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",
     "test:e2e:rbac": "playwright test e2e/critical-flows/rbac-role-permissions.spec.ts",
+    "test:e2e:sso": "playwright test e2e/critical-flows/sso-domain-provisioning.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,7 @@ function shellEnv(name: string, value: string | undefined) {
 
 const webServerEnv = [
   'BETTER_AUTH_URL=http://127.0.0.1:3333',
+  'BETTER_AUTH_TRUSTED_ORIGINS=http://127.0.0.1:3333,http://127.0.0.1:3999',
   'NUXT_PUBLIC_SITE_URL=http://127.0.0.1:3333',
   'FACTORY_DISABLE_PUBLIC_SIGNUP=false',
   'FACTORY_DISABLE_PUBLIC_ORG_CREATION=false',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,12 +4,15 @@ function shellEnv(name: string, value: string | undefined) {
   return value ? `${name}=${JSON.stringify(value)}` : ''
 }
 
+const ssoMockPort = process.env.E2E_SSO_MOCK_PORT ?? '3999'
+
 const webServerEnv = [
   'BETTER_AUTH_URL=http://127.0.0.1:3333',
-  'BETTER_AUTH_TRUSTED_ORIGINS=http://127.0.0.1:3333,http://127.0.0.1:3999',
+  `BETTER_AUTH_TRUSTED_ORIGINS=http://127.0.0.1:3333,http://127.0.0.1:${ssoMockPort}`,
   'NUXT_PUBLIC_SITE_URL=http://127.0.0.1:3333',
   'FACTORY_DISABLE_PUBLIC_SIGNUP=false',
   'FACTORY_DISABLE_PUBLIC_ORG_CREATION=false',
+  `E2E_SSO_MOCK_PORT=${ssoMockPort}`,
   'FEATURE_FLAG_CHATBOT_EXPERIENCE=true',
   shellEnv('FACTORY_EMAIL_TEST_MODE', process.env.FACTORY_EMAIL_TEST_MODE),
   shellEnv('FACTORY_EMAIL_CAPTURE_PATH', process.env.FACTORY_EMAIL_CAPTURE_PATH),

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -150,7 +150,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:tracking-analytics')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.tracking_analytics.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
   })
 
   it('runs interview scheduling lifecycle browser coverage in a dedicated CI lane', () => {
@@ -166,7 +166,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:interviews')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.interviews.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
   })
 
   it('runs auth and organization edge-flow browser coverage in a dedicated CI lane', () => {
@@ -182,7 +182,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:auth-org')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.auth_org.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
   })
 
   it('runs role-permission browser coverage in a dedicated CI lane', () => {
@@ -198,7 +198,24 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:rbac')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.rbac.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
+  })
+
+  it('runs SSO domain provisioning browser coverage against local-only IdP origins', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:sso']).toBe(
+      'playwright test e2e/critical-flows/sso-domain-provisioning.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright SSO')
+    expect(workflow).toContain('npm run test:e2e:sso')
+    expect(workflow).toContain('BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333,http://127.0.0.1:3999')
+    expect(workflow).not.toContain('OIDC_CLIENT_SECRET: ${{ secrets')
+    expect(workflow).toContain('needs.sso.result')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
   })
 
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
@@ -214,7 +231,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -243,7 +260,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')
@@ -257,6 +274,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.interviews.result')
     expect(workflow).toContain('needs.auth_org.result')
     expect(workflow).toContain('needs.rbac.result')
+    expect(workflow).toContain('needs.sso.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {
@@ -266,6 +284,7 @@ describe('Playwright E2E harness contract', () => {
     expect(config).toContain('workers: process.env.CI ? 2 : undefined')
     expect(config).toContain('trace: process.env.CI ?')
     expect(config).toContain('FEATURE_FLAG_CHATBOT_EXPERIENCE=true')
+    expect(config).toContain('BETTER_AUTH_TRUSTED_ORIGINS=http://127.0.0.1:3333,http://127.0.0.1:3999')
     expect(config).not.toContain('tests share state')
   })
 

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -213,6 +213,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('name: Playwright SSO')
     expect(workflow).toContain('npm run test:e2e:sso')
     expect(workflow).toContain('BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333,http://127.0.0.1:3999')
+    expect(workflow).toContain('E2E_SSO_MOCK_PORT: "3999"')
     expect(workflow).not.toContain('OIDC_CLIENT_SECRET: ${{ secrets')
     expect(workflow).toContain('needs.sso.result')
     expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
@@ -284,7 +285,9 @@ describe('Playwright E2E harness contract', () => {
     expect(config).toContain('workers: process.env.CI ? 2 : undefined')
     expect(config).toContain('trace: process.env.CI ?')
     expect(config).toContain('FEATURE_FLAG_CHATBOT_EXPERIENCE=true')
-    expect(config).toContain('BETTER_AUTH_TRUSTED_ORIGINS=http://127.0.0.1:3333,http://127.0.0.1:3999')
+    expect(config).toContain("const ssoMockPort = process.env.E2E_SSO_MOCK_PORT ?? '3999'")
+    expect(config).toContain('BETTER_AUTH_TRUSTED_ORIGINS=http://127.0.0.1:3333,http://127.0.0.1:${ssoMockPort}')
+    expect(config).toContain('E2E_SSO_MOCK_PORT=${ssoMockPort}')
     expect(config).not.toContain('tests share state')
   })
 


### PR DESCRIPTION
## Summary
- add a fast Playwright SSO lane that registers a local-only mock OIDC provider through the settings UI
- verify configured-domain sign-in discovery, unconfigured-domain rejection, and local callback/IdP origin safety
- add a work-email sign-in path while preserving the Factory SSO provider fallback when no email is entered
- wire the lane into package scripts, Playwright startup env, CI, and harness-contract coverage

## Verification
- npm run test:e2e:sso (Playwright webServer startup): 1 passed, 16.8s
- npm run test:unit -- tests/unit/e2e-harness-contract.test.ts: 23 passed
- npm run typecheck: exit 0 with existing vue-router/volar package subpath warning
- git diff --check
- pre-push gate on push: CLI parity, full unit suite (841 passed), typecheck, CLI smoke tests, production env contract, build

Closes #128