### PR TITLE
fix: add auth recovery fake-mail e2e coverage

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -637,6 +637,7 @@ jobs:
       PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
       FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
       FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      FACTORY_ADMIN_SSO_ONLY: "false"
       FACTORY_EMAIL_TEST_MODE: capture
       FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-email.jsonl
       FACTORY_CAREERS_HIRING_INBOX: hiring-e2e@example.com

--- a/e2e/critical-flows/auth-recovery-fake-mail.spec.ts
+++ b/e2e/critical-flows/auth-recovery-fake-mail.spec.ts
@@ -1,0 +1,103 @@
+import { rm } from 'node:fs/promises'
+import { test, expect } from '../fixtures'
+import { type CapturedEmail, readCapturedEmails } from '../helpers/captured-emails'
+
+function extractResetUrl(email: CapturedEmail) {
+  const content = `${email.text}\n${email.html}`
+  const pathOrUrl = content
+    .match(/(?:https?:\/\/[^\s"'<>]+)?\/(?:api\/auth\/reset-password\/|auth\/reset-password)[^\s"'<>]*/)?.[0]
+    ?.replaceAll('&amp;', '&')
+  if (!pathOrUrl) return ''
+
+  return new URL(pathOrUrl, process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3333').toString()
+}
+
+test.describe('Auth recovery fake mail', () => {
+  test('resets a real user password through the captured reset email', async ({ authenticatedPage, testAccount, browser }) => {
+    const capturePath = process.env.FACTORY_EMAIL_CAPTURE_PATH
+    expect(capturePath, 'FACTORY_EMAIL_CAPTURE_PATH must be set for auth recovery E2E').toBeTruthy()
+    expect(process.env.FACTORY_EMAIL_TEST_MODE, 'auth recovery E2E must use capture mode, not a real provider').toBe('capture')
+    expect(process.env.FACTORY_ADMIN_SSO_ONLY, 'auth recovery E2E needs email/password auth enabled').toBe('false')
+
+    await expect(authenticatedPage.getByRole('heading', { name: /Dashboard|Welcome/i })).toBeVisible({ timeout: 30_000 })
+    await rm(capturePath!, { force: true })
+
+    const newPassword = `${testAccount.password}-Reset1`
+    const guestContext = await browser.newContext()
+    const guestPage = await guestContext.newPage()
+
+    await guestPage.goto('/auth/forgot-password')
+    await guestPage.waitForLoadState('networkidle')
+    await expect(guestPage.getByRole('heading', { name: 'Reset your password' })).toBeVisible()
+    await guestPage.getByLabel('Email').fill(testAccount.email)
+
+    await guestPage.getByRole('button', { name: 'Send reset link' }).click()
+    await expect(guestPage.getByText("If an account with that email exists, we've sent a password reset link.")).toBeVisible()
+
+    await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+      message: 'password reset email should be captured',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(1)
+
+    const capturedEmails = await readCapturedEmails(capturePath!)
+    const resetEmail = capturedEmails.find(email => email.subject === 'Reset your password — Factory Careers')
+    expect(resetEmail, 'password reset email should be captured').toBeTruthy()
+    expect(resetEmail?.renderError, 'password reset email should render successfully').toBeUndefined()
+    expect(resetEmail?.to).toContain(testAccount.email)
+    expect(resetEmail?.text).toContain('Reset your password')
+
+    const resetUrl = extractResetUrl(resetEmail!)
+    expect(resetUrl, 'reset email should contain a local reset URL').toBeTruthy()
+    const parsedResetUrl = new URL(resetUrl)
+    const apiToken = parsedResetUrl.pathname.match(/^\/api\/auth\/reset-password\/([^/]+)$/)?.[1]
+    expect(
+      parsedResetUrl.pathname === '/auth/reset-password' || Boolean(apiToken),
+      'reset email should link to a supported reset route',
+    ).toBe(true)
+    expect(parsedResetUrl.searchParams.get('token') ?? apiToken, 'reset email should include a reset token').toBeTruthy()
+    expect(parsedResetUrl.hostname).not.toBe('thefactoryhq.com')
+
+    const resetContext = await browser.newContext()
+    const resetPage = await resetContext.newPage()
+    await resetPage.goto(resetUrl)
+    await resetPage.waitForLoadState('networkidle')
+    await expect(resetPage.getByRole('heading', { name: 'Set new password' })).toBeVisible()
+    await resetPage.getByLabel('New password', { exact: true }).fill(newPassword)
+    await resetPage.getByLabel('Confirm new password').fill(newPassword)
+
+    const [resetResponse] = await Promise.all([
+      resetPage.waitForResponse(
+        resp => resp.url().includes('/api/auth/reset-password') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      resetPage.getByRole('button', { name: 'Reset password' }).click(),
+    ])
+    expect(resetResponse.status(), `Reset password API returned ${resetResponse.status()}`).toBe(200)
+    await expect(resetPage.getByText('Your password has been reset successfully.')).toBeVisible()
+    await resetContext.close()
+
+    const oldPasswordContext = await browser.newContext()
+    const oldPasswordPage = await oldPasswordContext.newPage()
+    const oldSignInResponse = await oldPasswordPage.request.post('/api/auth/sign-in/email', {
+      data: {
+        email: testAccount.email,
+        password: testAccount.password,
+      },
+    })
+    expect(oldSignInResponse.status(), 'old password should no longer sign in').toBeGreaterThanOrEqual(400)
+    await oldPasswordContext.close()
+
+    const newSignInResponse = await guestPage.request.post('/api/auth/sign-in/email', {
+      data: {
+        email: testAccount.email,
+        password: newPassword,
+      },
+    })
+    expect(newSignInResponse.status(), `new password sign-in returned ${newSignInResponse.status()}`).toBe(200)
+    await guestPage.goto('/dashboard')
+    await guestPage.waitForLoadState('networkidle')
+    await expect(guestPage.getByRole('heading', { name: /Dashboard|Welcome/i })).toBeVisible({ timeout: 30_000 })
+
+    await guestContext.close()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts",
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
-    "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts --workers=1",
+    "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts e2e/critical-flows/auth-recovery-fake-mail.spec.ts --workers=1",
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts",
     "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -126,16 +126,18 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:email']).toBe(
-      'playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts --workers=1',
+      'playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts e2e/critical-flows/auth-recovery-fake-mail.spec.ts --workers=1',
     )
     expect(workflow).toContain('name: Playwright email')
     expect(workflow).toContain('npm run test:e2e:email')
+    expect(workflow).toContain('FACTORY_ADMIN_SSO_ONLY: "false"')
     expect(workflow).toContain('FACTORY_EMAIL_TEST_MODE: capture')
     expect(workflow).toContain('FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-email.jsonl')
     expect(workflow).toContain('FACTORY_CAREERS_HIRING_INBOX: hiring-e2e@example.com')
     expect(workflow).toContain('FACTORY_CAREERS_PRIVACY_INBOX: privacy-e2e@example.com')
     expect(workflow).not.toContain('RESEND_API_KEY: ${{ secrets')
     expect(read('e2e/critical-flows/privacy-request-fake-mail.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
+    expect(read('e2e/critical-flows/auth-recovery-fake-mail.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
     expect(workflow).toContain('needs.email.result')
   })
 


### PR DESCRIPTION
## Summary
- add a fake-mail auth recovery E2E that exercises forgot-password, captured reset email, local Better Auth reset link, password update, and dashboard sign-in
- keep this in the existing fast email E2E lane with serial workers instead of adding another CI job
- pin the email E2E lane to `FACTORY_ADMIN_SSO_ONLY=false` so password recovery remains intentionally testable without real email provider secrets

Closes #134

## Verification
- Focused auth recovery spec: 1 passed (19.0s)
- `npm run test:e2e:email`: 3 passed (23.5s)
- `npm run test:unit -- tests/unit/e2e-harness-contract.test.ts`: 24 passed
- `npm run typecheck`: passed with known Vue package subpath warning
- `git diff --check`
- pre-push gate: full unit suite 846 passed, typecheck, CLI smoke, production env contract, build

## Notes
- Uses fake email capture only; no real lead/customer emails or provider credentials are involved.
