### PR TITLE
fix: add interview invitation response e2e coverage

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1016,10 +1016,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  sso:
+    name: Playwright SSO
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333,http://127.0.0.1:3999
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run SSO domain provisioning browser checks
+        run: npm run test:e2e:sso
+
+      - name: Upload Playwright SSO report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-sso-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -1076,6 +1146,10 @@ jobs:
           fi
           if [ "${{ needs.rbac.result }}" != "success" ]; then
             echo "Playwright RBAC finished with result: ${{ needs.rbac.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.sso.result }}" != "success" ]; then
+            echo "Playwright SSO finished with result: ${{ needs.sso.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -176,10 +176,102 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  uploads:
+    name: Playwright uploads
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "false"
+      S3_SKIP_BUCKET_POLICY: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Start MinIO
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run -d --rm \
+            --name factory-careers-uploads-minio \
+            -e MINIO_ROOT_USER=e2e-access-key \
+            -e MINIO_ROOT_PASSWORD=e2e-secret-key \
+            -p 127.0.0.1:9000:9000 \
+            minio/minio server /data
+
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          docker logs factory-careers-uploads-minio
+          exit 1
+
+      - name: Run resume upload browser checks
+        run: npm run test:e2e:uploads
+
+      - name: Upload Playwright upload report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-uploads-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core]
+    needs: [smoke, security-core, uploads]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -192,6 +284,10 @@ jobs:
           fi
           if [ "${{ needs.security-core.result }}" != "success" ]; then
             echo "Playwright security core finished with result: ${{ needs.security-core.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.uploads.result }}" != "success" ]; then
+            echo "Playwright uploads finished with result: ${{ needs.uploads.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -338,10 +338,102 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  candidate:
+    name: Playwright candidate
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "false"
+      S3_SKIP_BUCKET_POLICY: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Start MinIO
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run -d --rm \
+            --name factory-careers-candidate-minio \
+            -e MINIO_ROOT_USER=e2e-access-key \
+            -e MINIO_ROOT_PASSWORD=e2e-secret-key \
+            -p 127.0.0.1:9000:9000 \
+            minio/minio server /data
+
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          docker logs factory-careers-candidate-minio
+          exit 1
+
+      - name: Run candidate application browser checks
+        run: npm run test:e2e:candidate
+
+      - name: Upload Playwright candidate report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-candidate-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, uploads, ui]
+    needs: [smoke, security-core, uploads, ui, candidate]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -362,6 +454,10 @@ jobs:
           fi
           if [ "${{ needs.ui.result }}" != "success" ]; then
             echo "Playwright UI finished with result: ${{ needs.ui.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.candidate.result }}" != "success" ]; then
+            echo "Playwright candidate finished with result: ${{ needs.candidate.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,6 +44,8 @@ jobs:
       PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
       FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
       FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      FACTORY_EMAIL_TEST_MODE: capture
+      FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-interview-email.jsonl
       S3_ENDPOINT: http://127.0.0.1:9000
       S3_ACCESS_KEY: e2e-access-key
       S3_SECRET_KEY: e2e-secret-key

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -663,10 +663,83 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  email:
+    name: Playwright email
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      FACTORY_EMAIL_TEST_MODE: capture
+      FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-email.jsonl
+      FACTORY_CAREERS_HIRING_INBOX: hiring-e2e@example.com
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run fake-mail browser checks
+        run: npm run test:e2e:email
+
+      - name: Upload Playwright email report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-email-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -703,6 +776,10 @@ jobs:
           fi
           if [ "${{ needs.job_lifecycle.result }}" != "success" ]; then
             echo "Playwright job lifecycle finished with result: ${{ needs.job_lifecycle.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.email.result }}" != "success" ]; then
+            echo "Playwright email finished with result: ${{ needs.email.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -736,10 +736,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  tracking_analytics:
+    name: Playwright tracking analytics
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run tracking analytics browser checks
+        run: npm run test:e2e:tracking-analytics
+
+      - name: Upload Playwright tracking analytics report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-tracking-analytics-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -780,6 +850,10 @@ jobs:
           fi
           if [ "${{ needs.email.result }}" != "success" ]; then
             echo "Playwright email finished with result: ${{ needs.email.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.tracking_analytics.result }}" != "success" ]; then
+            echo "Playwright tracking analytics finished with result: ${{ needs.tracking_analytics.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -876,10 +876,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  auth_org:
+    name: Playwright auth and org
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run auth and organization browser checks
+        run: npm run test:e2e:auth-org
+
+      - name: Upload Playwright auth-org report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-auth-org-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -928,6 +998,10 @@ jobs:
           fi
           if [ "${{ needs.interviews.result }}" != "success" ]; then
             echo "Playwright interviews finished with result: ${{ needs.interviews.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.auth_org.result }}" != "success" ]; then
+            echo "Playwright auth and org finished with result: ${{ needs.auth_org.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -946,10 +946,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  rbac:
+    name: Playwright RBAC
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run RBAC browser checks
+        run: npm run test:e2e:rbac
+
+      - name: Upload Playwright RBAC report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-rbac-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -1002,6 +1072,10 @@ jobs:
           fi
           if [ "${{ needs.auth_org.result }}" != "success" ]; then
             echo "Playwright auth and org finished with result: ${{ needs.auth_org.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.rbac.result }}" != "success" ]; then
+            echo "Playwright RBAC finished with result: ${{ needs.rbac.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -523,10 +523,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  recruiter:
+    name: Playwright recruiter
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run recruiter application lifecycle browser checks
+        run: npm run test:e2e:recruiter
+
+      - name: Upload Playwright recruiter report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-recruiter-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -555,6 +625,10 @@ jobs:
           fi
           if [ "${{ needs.candidate.result }}" != "success" ]; then
             echo "Playwright candidate finished with result: ${{ needs.candidate.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.recruiter.result }}" != "success" ]; then
+            echo "Playwright recruiter finished with result: ${{ needs.recruiter.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -268,10 +268,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  ui:
+    name: Playwright UI
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run invitation management browser checks
+        run: npm run test:e2e:ui
+
+      - name: Upload Playwright UI report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-ui-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, uploads]
+    needs: [smoke, security-core, uploads, ui]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -288,6 +358,10 @@ jobs:
           fi
           if [ "${{ needs.uploads.result }}" != "success" ]; then
             echo "Playwright uploads finished with result: ${{ needs.uploads.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.ui.result }}" != "success" ]; then
+            echo "Playwright UI finished with result: ${{ needs.ui.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -593,10 +593,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  job_lifecycle:
+    name: Playwright job lifecycle
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run job lifecycle browser checks
+        run: npm run test:e2e:job-lifecycle
+
+      - name: Upload Playwright job lifecycle report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-job-lifecycle-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -629,6 +699,10 @@ jobs:
           fi
           if [ "${{ needs.recruiter.result }}" != "success" ]; then
             echo "Playwright recruiter finished with result: ${{ needs.recruiter.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.job_lifecycle.result }}" != "success" ]; then
+            echo "Playwright job lifecycle finished with result: ${{ needs.job_lifecycle.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -806,10 +806,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  interviews:
+    name: Playwright interviews
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run interview lifecycle browser checks
+        run: npm run test:e2e:interviews
+
+      - name: Upload Playwright interviews report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-interviews-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -854,6 +924,10 @@ jobs:
           fi
           if [ "${{ needs.tracking_analytics.result }}" != "success" ]; then
             echo "Playwright tracking analytics finished with result: ${{ needs.tracking_analytics.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.interviews.result }}" != "success" ]; then
+            echo "Playwright interviews finished with result: ${{ needs.interviews.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1087,10 +1087,82 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  ai_review:
+    name: Playwright AI review
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      FACTORY_AI_TEST_MODE: mock
+      FACTORY_AI_CAPTURE_PATH: /tmp/factory-careers-e2e-ai.jsonl
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run AI candidate review browser checks
+        run: npm run test:e2e:ai-review
+
+      - name: Upload Playwright AI review report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-ai-review-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -1151,6 +1223,10 @@ jobs:
           fi
           if [ "${{ needs.sso.result }}" != "success" ]; then
             echo "Playwright SSO finished with result: ${{ needs.sso.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.ai_review.result }}" != "success" ]; then
+            echo "Playwright AI review finished with result: ${{ needs.ai_review.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -696,6 +696,7 @@ jobs:
       FACTORY_EMAIL_TEST_MODE: capture
       FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-email.jsonl
       FACTORY_CAREERS_HIRING_INBOX: hiring-e2e@example.com
+      FACTORY_CAREERS_PRIVACY_INBOX: privacy-e2e@example.com
       S3_ENDPOINT: http://127.0.0.1:9000
       S3_ACCESS_KEY: e2e-access-key
       S3_SECRET_KEY: e2e-secret-key

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,8 +44,6 @@ jobs:
       PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
       FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
       FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
-      FACTORY_EMAIL_TEST_MODE: capture
-      FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-interview-email.jsonl
       S3_ENDPOINT: http://127.0.0.1:9000
       S3_ACCESS_KEY: e2e-access-key
       S3_SECRET_KEY: e2e-secret-key
@@ -840,6 +838,8 @@ jobs:
       PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
       FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
       FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      FACTORY_EMAIL_TEST_MODE: capture
+      FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-interview-email.jsonl
       S3_ENDPOINT: http://127.0.0.1:9000
       S3_ACCESS_KEY: e2e-access-key
       S3_SECRET_KEY: e2e-secret-key

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -693,6 +693,7 @@ jobs:
       PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
       FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
       FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      FACTORY_ADMIN_SSO_ONLY: "false"
       FACTORY_EMAIL_TEST_MODE: capture
       FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-email.jsonl
       FACTORY_CAREERS_HIRING_INBOX: hiring-e2e@example.com

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -176,6 +176,99 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  security-extended:
+    name: Playwright security extended
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3333
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3333
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      FEATURE_FLAG_CHATBOT_EXPERIENCE: "true"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "false"
+      S3_SKIP_BUCKET_POLICY: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Start MinIO
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run -d --rm \
+            --name factory-careers-security-extended-minio \
+            -e MINIO_ROOT_USER=e2e-access-key \
+            -e MINIO_ROOT_PASSWORD=e2e-secret-key \
+            -p 127.0.0.1:9000:9000 \
+            minio/minio server /data
+
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          docker logs factory-careers-security-extended-minio
+          exit 1
+
+      - name: Run extended tenant isolation security checks
+        run: npm run test:e2e:security:extended
+
+      - name: Upload Playwright extended security report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-security-extended-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   uploads:
     name: Playwright uploads
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -433,7 +526,7 @@ jobs:
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, uploads, ui, candidate]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -446,6 +539,10 @@ jobs:
           fi
           if [ "${{ needs.security-core.result }}" != "success" ]; then
             echo "Playwright security core finished with result: ${{ needs.security-core.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.security-extended.result }}" != "success" ]; then
+            echo "Playwright security extended finished with result: ${{ needs.security-extended.result }}"
             exit 1
           fi
           if [ "${{ needs.uploads.result }}" != "success" ]; then

--- a/app/components/AppTopBar.vue
+++ b/app/components/AppTopBar.vue
@@ -197,8 +197,11 @@ watch(() => route.path, () => {
 // ─────────────────────────────────────────────
 
 const newJobResetSignal = useState('new-job-reset-signal', () => 0)
+const { allowed: canCreateJob } = usePermission({ job: ['create'] })
 
 function handleNewJobClick() {
+  if (!canCreateJob.value) return
+
   const newJobPath = localePath('/dashboard/jobs/new')
   if (route.path === newJobPath) {
     // Already on the page: signal the wizard to reset instead of navigating
@@ -392,6 +395,7 @@ function handleNewJobClick() {
 
           <!-- New Job button (desktop) -->
           <button
+            v-if="canCreateJob"
             class="factory-button-cta factory-button-premium mx-1 hidden h-9 items-center gap-1.5 px-3.5 text-[13px] sm:inline-flex"
             @click="handleNewJobClick"
           >
@@ -674,6 +678,7 @@ function handleNewJobClick() {
           </NuxtLink>
 
           <button
+            v-if="canCreateJob"
             class="factory-button-cta factory-button-premium flex w-full items-center gap-3 px-3 py-2.5 text-sm sm:hidden mt-1"
             @click="handleNewJobClick(); showMobileMenu = false"
           >

--- a/app/components/InterviewScheduleSidebar.vue
+++ b/app/components/InterviewScheduleSidebar.vue
@@ -32,8 +32,8 @@ const createdInterview = ref<{ id: string; googleCalendarEventLink?: string | nu
 const { calendarStatus, isConnected: calendarConnected } = useCalendarIntegration()
 const calendarProviderLabel = computed(() => calendarStatus.value.providerLabel || 'Microsoft Calendar')
 
-const { data: sessionData } = await authClient.useSession(useFetch)
-const currentUserEmail = computed(() => sessionData.value?.user?.email ?? '')
+const sessionState = authClient.useSession()
+const currentUserEmail = computed(() => sessionState.value.data?.user?.email ?? '')
 
 const isAppManagedCalendar = computed(() => 
   calendarStatus.value.authMode === 'application' || calendarStatus.value.managedByAdmin === true
@@ -104,12 +104,16 @@ onMounted(() => {
   tomorrow.setDate(tomorrow.getDate() + 1)
   form.date = toDateString(tomorrow)
 
-  // Default both notifications on
+  // Default email on, but only enable calendar sync when a provider is configured.
   notifyViaEmail.value = true
-  notifyViaCalendar.value = true
+  notifyViaCalendar.value = canUseCalendar.value
 
   // Center default time (e.g. 10:00) vertically in the time slider list
   nextTick(() => centerTimeInSlider())
+})
+
+watch(canUseCalendar, (enabled) => {
+  if (!enabled) notifyViaCalendar.value = false
 })
 
 // Default the first interviewer to the current user once we have their email

--- a/app/composables/useInterviews.ts
+++ b/app/composables/useInterviews.ts
@@ -137,6 +137,7 @@ export function useInterviews(options?: {
         method: 'POST',
         body: payload,
       })
+      clearNuxtData(fetchKey.value)
       await refresh()
       return created
     } catch (error) {
@@ -160,6 +161,7 @@ export function useInterviews(options?: {
         method: 'PATCH',
         body: payload,
       })
+      clearNuxtData(fetchKey.value)
       await refresh()
       return updated
     } catch (error) {
@@ -171,6 +173,7 @@ export function useInterviews(options?: {
   async function deleteInterviewById(id: string) {
     try {
       await $fetch(`/api/interviews/${id}`, { method: 'DELETE' })
+      clearNuxtData(fetchKey.value)
       await refresh()
     } catch (error) {
       handlePreviewReadOnlyError(error)

--- a/app/composables/useSourceTracking.ts
+++ b/app/composables/useSourceTracking.ts
@@ -177,6 +177,7 @@ export function useTrackingLinks(options?: {
       method: 'POST',
       body: payload,
     })
+    clearNuxtData(fetchKey.value)
     await refresh()
     toast.success('Tracking link created')
     return created
@@ -196,12 +197,14 @@ export function useTrackingLinks(options?: {
       method: 'PATCH',
       body: payload,
     })
+    clearNuxtData(fetchKey.value)
     await refresh()
     return updated
   }
 
   async function deleteLink(id: string) {
     await $fetch(`/api/tracking-links/${id}`, { method: 'DELETE' })
+    clearNuxtData(fetchKey.value)
     await refresh()
     toast.success('Tracking link deleted')
   }

--- a/app/pages/auth/sign-in.vue
+++ b/app/pages/auth/sign-in.vue
@@ -13,6 +13,7 @@ useSeoMeta({
 const FACTORY_SSO_PROVIDER_ID = "thefactoryhq-sso";
 
 const ssoRedirecting = ref(false);
+const workEmail = ref("");
 const route = useRoute();
 const localePath = useLocalePath();
 const { track } = useTrack();
@@ -47,6 +48,7 @@ onMounted(() => {
 
 async function handleFactorySso() {
     ssoRedirecting.value = true;
+    const normalizedWorkEmail = workEmail.value.trim().toLowerCase();
 
     const pendingInvitation = route.query.invitation as string | undefined;
     const safeRedirect = getSafeRedirectPath(route.query.redirect);
@@ -63,7 +65,9 @@ async function handleFactorySso() {
 
     try {
         const result = await authClient.signIn.sso({
-            providerId: FACTORY_SSO_PROVIDER_ID,
+            ...(normalizedWorkEmail
+                ? { email: normalizedWorkEmail, loginHint: normalizedWorkEmail }
+                : { providerId: FACTORY_SSO_PROVIDER_ID }),
             callbackURL,
             errorCallbackURL,
             providerType: "oidc",
@@ -99,6 +103,18 @@ async function handleFactorySso() {
 
 <template>
     <form class="flex flex-col gap-5" @submit.prevent="handleFactorySso">
+        <label class="flex flex-col gap-1.5 text-sm font-medium text-white/72">
+            <span>Work email</span>
+            <input
+                v-model="workEmail"
+                type="email"
+                autocomplete="email"
+                inputmode="email"
+                placeholder="you@company.com"
+                class="min-h-12 border border-white/14 bg-white/[0.06] px-3 py-2 text-sm text-white outline-none transition-colors placeholder:text-white/32 focus:border-white/34 focus:ring-2 focus:ring-white/10"
+            />
+        </label>
+
         <button
             type="submit"
             :disabled="ssoRedirecting"
@@ -110,7 +126,7 @@ async function handleFactorySso() {
                 <rect x="1" y="12" width="10" height="10" fill="#00A4EF" />
                 <rect x="12" y="12" width="10" height="10" fill="#FFB900" />
             </svg>
-            {{ ssoRedirecting ? "Redirecting..." : "Continue with Microsoft" }}
+            {{ ssoRedirecting ? "Redirecting..." : "Continue with SSO" }}
         </button>
 
         <p class="text-center text-xs leading-5 text-white/42">

--- a/app/pages/dashboard/applications/[id].vue
+++ b/app/pages/dashboard/applications/[id].vue
@@ -86,6 +86,10 @@ const { isEditingNotes, notesInput, isSavingNotes, notesSaveStatus, notesTextare
   save: notes => updateApplication({ notes }),
 })
 
+function openInterviewScheduler() {
+  showInterviewSidebar.value = true
+}
+
 async function scoreCurrentApplication() {
   if (!application.value) return
   await scoreApplicationCandidate(applicationId, {
@@ -171,7 +175,7 @@ async function scoreCurrentApplication() {
           </button>
           <button
             class="inline-flex shrink-0 cursor-pointer items-center gap-1 whitespace-nowrap border border-white/16 bg-black px-2.5 py-1.5 text-[10px] font-semibold uppercase leading-none tracking-normal text-white/80 hover:border-brand-500 hover:bg-brand-500/12 hover:text-white transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500/40"
-            @click="showInterviewSidebar = true"
+            @click="openInterviewScheduler"
           >
             <Calendar class="size-3" />
             Schedule Interview

--- a/app/pages/dashboard/index.vue
+++ b/app/pages/dashboard/index.vue
@@ -20,6 +20,7 @@ const { activeOrg } = useCurrentOrg()
 const localePath = useLocalePath()
 const { track } = useTrack()
 const { formatPersonName } = useOrgSettings()
+const { allowed: canCreateJob } = usePermission({ job: ['create'] })
 
 let dashboardNowTimer: ReturnType<typeof setInterval> | undefined
 
@@ -215,6 +216,7 @@ const isEmpty = computed(() =>
           Your recruiting command center. Create your first job posting to start building your hiring pipeline.
         </p>
         <NuxtLink
+          v-if="canCreateJob"
           :to="localePath('/dashboard/jobs/new')"
           class="factory-button-cta factory-button-premium inline-flex items-center gap-2.5 rounded-xl px-7 py-3.5 text-sm font-semibold transition-all no-underline"
         >
@@ -339,6 +341,7 @@ const isEmpty = computed(() =>
               <p class="text-sm font-medium text-surface-500 dark:text-surface-400 mb-1">No open jobs</p>
               <p class="text-xs text-surface-400 dark:text-surface-500 mb-4">Create your first job to see the pipeline</p>
               <NuxtLink
+                v-if="canCreateJob"
                 :to="localePath('/dashboard/jobs/new')"
                 class="inline-flex items-center gap-1.5 text-xs font-semibold text-brand-600 dark:text-brand-400 no-underline hover:text-brand-700 dark:hover:text-brand-300"
               >
@@ -534,6 +537,7 @@ const isEmpty = computed(() =>
 
             <div class="p-2.5 space-y-0.5">
               <NuxtLink
+                v-if="canCreateJob"
                 :to="localePath('/dashboard/jobs/new')"
                 class="factory-dashboard-quick-action flex items-center gap-3 px-3.5 py-2.5 text-sm font-medium transition-all no-underline"
               >

--- a/app/pages/dashboard/interviews/[id].vue
+++ b/app/pages/dashboard/interviews/[id].vue
@@ -12,6 +12,8 @@ import {
   getInterviewStatusLabel,
   getInterviewTransitionButtonClass,
   getInterviewTransitionLabel,
+  getCandidateResponseIconClass,
+  getCandidateResponseLabel,
 } from '~/utils/status-display'
 import { formatPhoneNumber } from '~/utils/phone-format'
 
@@ -404,6 +406,23 @@ const localePath = useLocalePath()
         >
           <CheckCheck class="size-3.5" />
           Invitation sent <TimelineDateLink :date="interview.invitationSentAt" class="text-success-600 dark:text-success-400">{{ formatDate(interview.invitationSentAt) }}</TimelineDateLink>
+        </div>
+        <!-- Candidate response status -->
+        <div
+          v-if="interview.candidateResponse !== 'pending'"
+          class="mt-2 flex flex-wrap items-center gap-1.5 text-xs"
+          :class="getCandidateResponseIconClass(interview.candidateResponse)"
+        >
+          <Check class="size-3.5" />
+          <span>Candidate response</span>
+          <span class="font-semibold">{{ getCandidateResponseLabel(interview.candidateResponse) }}</span>
+          <TimelineDateLink
+            v-if="interview.candidateRespondedAt"
+            :date="interview.candidateRespondedAt"
+            class="opacity-80"
+          >
+            {{ formatDate(interview.candidateRespondedAt) }}
+          </TimelineDateLink>
         </div>
         <!-- Calendar sync status -->
         <div

--- a/app/pages/dashboard/jobs/index.vue
+++ b/app/pages/dashboard/jobs/index.vue
@@ -19,6 +19,7 @@ useSeoMeta({
 
 const { activeOrg } = useCurrentOrg()
 const localePath = useLocalePath()
+const { allowed: canCreateJob } = usePermission({ job: ['create'] })
 
 // ─────────────────────────────────────────────
 // Stage config for clickable pipeline counts
@@ -413,6 +414,7 @@ const noResults = computed(() => !isEmpty.value && filteredJobs.value.length ===
           Create your first job posting to start receiving and managing candidates.
         </p>
         <NuxtLink
+          v-if="canCreateJob"
           :to="$localePath('/dashboard/jobs/new')"
           class="factory-button-cta factory-button-premium inline-flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-medium transition-colors no-underline"
         >

--- a/app/pages/dashboard/jobs/new.vue
+++ b/app/pages/dashboard/jobs/new.vue
@@ -33,6 +33,7 @@ import {
   Megaphone,
   Building2,
   Search,
+  AlertTriangle,
 } from 'lucide-vue-next'
 import { z } from 'zod'
 import { todayDateInputValue } from '~~/shared/date-input'
@@ -51,6 +52,7 @@ const localePath = useLocalePath()
 const { createJob } = useJobs()
 const { track } = useTrack()
 const toast = useToast()
+const { allowed: canCreateJob, isLoading: isPermissionLoading } = usePermission({ job: ['create'] })
 
 type QuestionType =
   | 'short_text'
@@ -723,7 +725,22 @@ const questionTypeLabels: Record<QuestionType, string> = {
 </script>
 
 <template>
-  <div class="mx-auto max-w-6xl px-4 py-8">
+  <div v-if="isPermissionLoading" class="flex items-center justify-center py-12">
+    <Loader2 class="size-6 animate-spin text-surface-400" />
+  </div>
+
+  <div
+    v-else-if="!canCreateJob"
+    class="ui-alert ui-alert-warning mx-auto mt-8 max-w-3xl p-5 flex items-start gap-3"
+  >
+    <AlertTriangle class="size-5 shrink-0 mt-0.5" />
+    <div>
+      <p class="font-semibold mb-1">Insufficient permissions</p>
+      <p>You don't have permission to create jobs. Contact an organization owner or admin.</p>
+    </div>
+  </div>
+
+  <div v-else class="mx-auto max-w-6xl px-4 py-8">
     <!-- Header with top actions -->
     <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-8">
       <div>

--- a/app/pages/dashboard/source-tracking/index.vue
+++ b/app/pages/dashboard/source-tracking/index.vue
@@ -264,6 +264,15 @@ const initialTab = (['overview', 'links', 'table'] as const).includes(route.quer
   ? (route.query.tab as 'overview' | 'links' | 'table')
   : 'overview'
 const showTab = ref<'overview' | 'links' | 'table'>(initialTab)
+
+function selectTab(tab: 'overview' | 'links' | 'table') {
+  showTab.value = tab
+  if (tab !== 'table') {
+    selectedChannel.value = undefined
+    return
+  }
+  refreshStats()
+}
 </script>
 
 <template>
@@ -363,7 +372,7 @@ const showTab = ref<'overview' | 'links' | 'table'>(initialTab)
           :key="tab.key"
           class="ui-tab flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium -mb-px transition-colors"
           :class="showTab === tab.key ? 'ui-tab-active' : 'ui-tab-inactive'"
-          @click="showTab = tab.key; if (tab.key !== 'table') selectedChannel = undefined"
+          @click="selectTab(tab.key)"
         >
           <component :is="tab.icon" class="size-4" />
           {{ tab.label }}

--- a/e2e/critical-flows/ai-candidate-review.spec.ts
+++ b/e2e/critical-flows/ai-candidate-review.spec.ts
@@ -1,0 +1,305 @@
+import { randomUUID } from 'node:crypto'
+import { readFile, rm } from 'node:fs/promises'
+import postgres from 'postgres'
+import { test, expect, selectFactorySelectOption } from '../fixtures'
+
+type CapturedAiRequest = {
+  schemaName: string
+  system: string
+  prompt: string
+  provider: string
+  model: string
+}
+
+type ApplicationLookup = {
+  applicationId: string
+  candidateId: string
+  organizationId: string
+}
+
+async function readCapturedAiRequests(capturePath: string): Promise<CapturedAiRequest[]> {
+  try {
+    const contents = await readFile(capturePath, 'utf8')
+    return contents
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as CapturedAiRequest)
+  }
+  catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return []
+    throw error
+  }
+}
+
+async function lookupApplicationByEmail(email: string): Promise<ApplicationLookup> {
+  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for AI candidate review E2E').toBeTruthy()
+  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+
+  try {
+    const [row] = await sql<ApplicationLookup[]>`
+      select
+        a.id as "applicationId",
+        c.id as "candidateId",
+        a.organization_id as "organizationId"
+      from application a
+      inner join candidate c on c.id = a.candidate_id
+      where c.email = ${email}
+      order by a.created_at desc
+      limit 1
+    `
+
+    expect(row, `expected application for ${email}`).toBeTruthy()
+    return row!
+  }
+  finally {
+    await sql.end()
+  }
+}
+
+async function seedParsedResume(params: {
+  organizationId: string
+  candidateId: string
+  resumeText: string
+}) {
+  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+  const documentId = randomUUID()
+
+  try {
+    await sql`
+      insert into document (
+        id,
+        organization_id,
+        candidate_id,
+        type,
+        storage_key,
+        original_filename,
+        mime_type,
+        size_bytes,
+        parsed_content
+      )
+      values (
+        ${documentId},
+        ${params.organizationId},
+        ${params.candidateId},
+        'resume',
+        ${`${params.organizationId}/${params.candidateId}/${documentId}.txt`},
+        'deterministic-resume.txt',
+        'text/plain',
+        ${params.resumeText.length},
+        ${sql.json({ text: params.resumeText })}
+      )
+    `
+  }
+  finally {
+    await sql.end()
+  }
+}
+
+async function seedCrossTenantSentinel(sentinel: string) {
+  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+  const orgId = randomUUID()
+  const candidateId = randomUUID()
+  const jobId = randomUUID()
+  const applicationId = randomUUID()
+  const documentId = randomUUID()
+
+  try {
+    await sql.begin(async (tx) => {
+      await tx`
+        insert into organization (id, name, slug)
+        values (${orgId}, ${`Sentinel Org ${orgId.slice(0, 8)}`}, ${`sentinel-${orgId.slice(0, 8)}`})
+      `
+      await tx`
+        insert into job (id, organization_id, title, slug, description, status, active_from)
+        values (${jobId}, ${orgId}, 'Sentinel Role', ${`sentinel-role-${jobId.slice(0, 8)}`}, ${sentinel}, 'open', now())
+      `
+      await tx`
+        insert into candidate (id, organization_id, first_name, last_name, email)
+        values (${candidateId}, ${orgId}, 'Cross', 'Tenant', ${`cross-tenant-${candidateId}@example.com`})
+      `
+      await tx`
+        insert into application (id, organization_id, candidate_id, job_id, cover_letter_text)
+        values (${applicationId}, ${orgId}, ${candidateId}, ${jobId}, ${sentinel})
+      `
+      await tx`
+        insert into document (
+          id,
+          organization_id,
+          candidate_id,
+          type,
+          storage_key,
+          original_filename,
+          mime_type,
+          size_bytes,
+          parsed_content
+        )
+        values (
+          ${documentId},
+          ${orgId},
+          ${candidateId},
+          'resume',
+          ${`${orgId}/${candidateId}/${documentId}.txt`},
+          'sentinel-resume.txt',
+          'text/plain',
+          ${sentinel.length},
+          ${tx.json({ text: sentinel })}
+        )
+      `
+    })
+  }
+  finally {
+    await sql.end()
+  }
+}
+
+test.describe('AI candidate review', () => {
+  test('scores a submitted candidate through the dashboard using deterministic local AI', async ({ authenticatedPage, browser }, testInfo) => {
+    const capturePath = process.env.FACTORY_AI_CAPTURE_PATH
+    expect(process.env.FACTORY_AI_TEST_MODE, 'AI E2E must use mock mode, not a real provider').toBe('mock')
+    expect(capturePath, 'FACTORY_AI_CAPTURE_PATH must be set for AI E2E').toBeTruthy()
+    await rm(capturePath!, { force: true })
+
+    const page = authenticatedPage
+    const runId = `${Date.now()}-${testInfo.workerIndex}-${testInfo.retry}`
+    const sentinel = `CROSS_TENANT_SENTINEL_${runId}`
+    const jobTitle = `AI Review Principal Advisor ${runId}`
+    const applicant = {
+      firstName: 'Avery',
+      lastName: 'Advisor',
+      email: `avery.advisor.${runId}@example.com`,
+      resumeText: `Avery advised professional athletes, entertainment founders, and family-office clients on media ventures, private investments, and brand partnerships. ${runId}`,
+    }
+
+    await seedCrossTenantSentinel(sentinel)
+
+    const aiConfigResponse = await page.request.post('/api/ai-config', {
+      data: {
+        name: 'Local deterministic AI',
+        provider: 'openai',
+        model: 'factory-e2e-candidate-review',
+        apiKey: 'fake-local-only-key',
+        maxTokens: 2048,
+        isDefaultAnalysis: true,
+      },
+    })
+    expect(aiConfigResponse.status(), `AI config API returned ${aiConfigResponse.status()}`).toBe(201)
+
+    const createJobResponse = await page.request.post('/api/jobs', {
+      data: {
+        title: jobTitle,
+        description: 'Advise athletes, entertainers, and founders on private investments, media ventures, business management, and brand services.',
+        location: 'New York, NY',
+        type: 'full_time',
+        requireResume: false,
+        requireCoverLetter: false,
+        autoScoreOnApply: false,
+        applicationComplianceEnabled: false,
+      },
+    })
+    expect(createJobResponse.status(), `Create job API returned ${createJobResponse.status()}`).toBe(201)
+    const job = await createJobResponse.json() as { id: string, slug: string }
+
+    const criteriaResponse = await page.request.post(`/api/jobs/${job.id}/criteria`, {
+      data: {
+        criteria: [{
+          key: 'domain_relevance',
+          name: 'Factory Domain Relevance',
+          description: 'Relevant experience with athletes, entertainers, founders, investments, media, and business management.',
+          category: 'experience',
+          maxScore: 10,
+          weight: 100,
+          displayOrder: 0,
+        }],
+      },
+    })
+    expect(criteriaResponse.status(), `Criteria API returned ${criteriaResponse.status()}`).toBe(201)
+
+    const publishResponse = await page.request.patch(`/api/jobs/${job.id}`, {
+      data: { status: 'open' },
+    })
+    expect(publishResponse.status(), `Publish API returned ${publishResponse.status()}`).toBe(200)
+
+    const candidateContext = await browser.newContext()
+    const candidatePage = await candidateContext.newPage()
+    await candidatePage.goto(`/jobs/${job.slug}/apply`)
+    await candidatePage.waitForLoadState('networkidle')
+    await expect(candidatePage.getByRole('heading', { name: jobTitle })).toBeVisible({ timeout: 15_000 })
+    await candidatePage.getByLabel('First name').fill(applicant.firstName)
+    await candidatePage.getByLabel('Last name').fill(applicant.lastName)
+    await candidatePage.getByLabel('Email').fill(applicant.email)
+    await selectFactorySelectOption(candidatePage, /Country/, 'United States')
+    await selectFactorySelectOption(candidatePage, /State/, 'New York')
+
+    const [applyResponse] = await Promise.all([
+      candidatePage.waitForResponse(
+        resp => resp.url().includes(`/api/public/jobs/${job.slug}/apply`) && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      candidatePage.getByRole('button', { name: /submit/i }).click(),
+    ])
+    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
+    await candidatePage.waitForURL(`**/jobs/${job.slug}/confirmation`, { waitUntil: 'commit', timeout: 15_000 })
+    await candidateContext.close()
+
+    const application = await lookupApplicationByEmail(applicant.email)
+    await seedParsedResume({
+      organizationId: application.organizationId,
+      candidateId: application.candidateId,
+      resumeText: applicant.resumeText,
+    })
+
+    await page.goto(`/dashboard/applications/${application.applicationId}`)
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('heading', { name: `${applicant.firstName} ${applicant.lastName}` })).toBeVisible({ timeout: 15_000 })
+
+    const [analysisResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes(`/api/applications/${application.applicationId}/analyze`) && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Run Analysis' }).click(),
+    ])
+    expect(analysisResponse.status(), `Analysis API returned ${analysisResponse.status()}`).toBe(200)
+    const analysis = await analysisResponse.json() as { compositeScore: number, summary: string, analysisRunId: string }
+    expect(analysis).toMatchObject({
+      compositeScore: 90,
+      summary: 'Deterministic E2E review: strong Factory-domain alignment for this candidate.',
+    })
+    expect(analysis.analysisRunId).toBeTruthy()
+
+    await expect(page.getByText('90')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Deterministic E2E review: strong Factory-domain alignment for this candidate.')).toBeVisible({ timeout: 15_000 })
+
+    const scoresResponse = await page.request.get(`/api/applications/${application.applicationId}/scores`)
+    expect(scoresResponse.status(), `Scores API returned ${scoresResponse.status()}`).toBe(200)
+    const scores = await scoresResponse.json() as {
+      compositeScore: number
+      latestRun: { id: string, summary: string | null } | null
+      scores: Array<{ criterionKey: string, score: number, evidence: string }>
+    }
+    expect(scores.compositeScore).toBe(90)
+    expect(scores.latestRun).toMatchObject({
+      id: analysis.analysisRunId,
+      summary: 'Deterministic E2E review: strong Factory-domain alignment for this candidate.',
+    })
+    expect(scores.scores).toContainEqual(expect.objectContaining({
+      criterionKey: 'domain_relevance',
+      score: 9,
+      evidence: expect.stringContaining('athletes, entertainers, founders, media, and investments'),
+    }))
+
+    await expect.poll(async () => (await readCapturedAiRequests(capturePath!)).length, {
+      message: 'AI mock provider should capture the scoring request',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(1)
+
+    const captured = (await readCapturedAiRequests(capturePath!)).find(request => request.schemaName === 'CandidateScoring')
+    expect(captured, 'candidate scoring request should be captured').toBeTruthy()
+    expect(captured?.provider).toBe('openai')
+    expect(captured?.model).toBe('factory-e2e-candidate-review')
+    expect(captured?.prompt).toContain(applicant.resumeText)
+    expect(captured?.prompt).toContain(jobTitle)
+    expect(captured?.prompt).not.toContain(sentinel)
+    expect(captured?.system).not.toContain(sentinel)
+  })
+})

--- a/e2e/critical-flows/auth-org-edge-flows.spec.ts
+++ b/e2e/critical-flows/auth-org-edge-flows.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '../fixtures'
+
+async function signUpWithoutOrganization(page: import('@playwright/test').Page, account: {
+  name: string
+  email: string
+  password: string
+}) {
+  await page.goto('/auth/sign-up')
+  await page.waitForLoadState('networkidle')
+  await page.getByLabel('Name').fill(account.name)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password', { exact: true }).fill(account.password)
+  await page.getByLabel('Confirm password').fill(account.password)
+
+  await Promise.all([
+    page.waitForResponse(
+      resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200,
+      { timeout: 30_000 },
+    ),
+    page.getByRole('button', { name: 'Sign up' }).click(),
+  ])
+
+  await page.waitForURL(
+    url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'),
+    { waitUntil: 'commit', timeout: 30_000 },
+  )
+
+  if (page.url().includes('/auth/sign-in')) {
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Email').fill(account.email)
+    await page.getByLabel('Password').fill(account.password)
+
+    await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200,
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Sign in' }).click(),
+    ])
+
+    await page.waitForURL('**/onboarding/**', { waitUntil: 'networkidle', timeout: 30_000 })
+  } else {
+    await page.waitForLoadState('networkidle')
+  }
+}
+
+test.describe('Auth and organization edge flows', () => {
+  test('new user accepts an invite link through onboarding and lands in the invited organization', async ({ authenticatedPage, testAccount, browser }, testInfo) => {
+    const ownerPage = authenticatedPage
+    const unique = `${Date.now()}-r${testInfo.retry}`
+
+    const createLinkResponse = await ownerPage.request.post('/api/invite-links', {
+      data: {
+        role: 'member',
+        maxUses: 1,
+        expiresInHours: 24,
+      },
+    })
+    expect(createLinkResponse.status(), `Create invite link API returned ${createLinkResponse.status()}`).toBe(201)
+    const inviteLink = await createLinkResponse.json() as { token: string; maxUses: number; useCount: number }
+    expect(inviteLink.token, 'invite token must be returned for test-local acceptance').toMatch(/^[0-9a-f]{64}$/)
+    expect(inviteLink.maxUses).toBe(1)
+    expect(inviteLink.useCount).toBe(0)
+
+    const baseURL = testInfo.project.use.baseURL as string
+    const context = await browser.newContext({ baseURL })
+    const inviteePage = await context.newPage()
+
+    try {
+      const invitee = {
+        name: `Invitee ${unique}`,
+        email: `auth-org-invitee.${unique}@test.local`,
+        password: process.env.E2E_TEST_PASSWORD || 'TestPassword123!',
+      }
+
+      await signUpWithoutOrganization(inviteePage, invitee)
+
+      await expect(inviteePage.getByRole('heading', { name: 'Create your organization' })).toBeVisible({ timeout: 15_000 })
+      await inviteePage.getByRole('button', { name: 'Join an existing organization instead' }).click()
+      await expect(inviteePage.getByRole('heading', { name: 'Join an organization' })).toBeVisible()
+
+      await inviteePage.getByPlaceholder('Paste invite link or code').fill(`${baseURL}/join/${inviteLink.token}`)
+      const [acceptResponse] = await Promise.all([
+        inviteePage.waitForResponse(
+          resp => resp.url().includes('/api/invite-links/accept') && resp.request().method() === 'POST',
+          { timeout: 30_000 },
+        ),
+        inviteePage.getByRole('button', { name: 'Join' }).click(),
+      ])
+      expect(acceptResponse.status(), `Accept invite link API returned ${acceptResponse.status()}`).toBe(200)
+      const accepted = await acceptResponse.json() as { organizationName: string; role: string }
+      expect(accepted.organizationName).toBe(testAccount.orgName)
+      expect(accepted.role).toBe('member')
+
+      await expect(inviteePage.getByRole('heading', { name: "You're in!" })).toBeVisible({ timeout: 15_000 })
+      await inviteePage.waitForURL('**/dashboard', { waitUntil: 'networkidle', timeout: 30_000 })
+      await expect(inviteePage.getByRole('heading', { name: 'Welcome to Factory Careers' })).toBeVisible({ timeout: 15_000 })
+
+      await inviteePage.goto('/dashboard/settings', { waitUntil: 'networkidle' })
+      await expect(inviteePage.getByRole('heading', { name: 'General' })).toBeVisible({ timeout: 15_000 })
+      await expect(inviteePage.getByLabel('Organization name')).toHaveValue(testAccount.orgName)
+
+      const dashboardResponse = await inviteePage.request.get('/api/dashboard/stats')
+      expect(dashboardResponse.status(), `Dashboard stats API returned ${dashboardResponse.status()}`).toBe(200)
+    } finally {
+      await context.close()
+    }
+  })
+})

--- a/e2e/critical-flows/auth-recovery-fake-mail.spec.ts
+++ b/e2e/critical-flows/auth-recovery-fake-mail.spec.ts
@@ -1,0 +1,112 @@
+import { readFile, rm } from 'node:fs/promises'
+import { test, expect } from '../fixtures'
+
+type CapturedEmail = {
+  to: string[]
+  subject: string
+  html: string
+  text: string
+  renderError?: string
+}
+
+async function readCapturedEmails(capturePath: string): Promise<CapturedEmail[]> {
+  try {
+    const contents = await readFile(capturePath, 'utf8')
+    return contents
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as CapturedEmail)
+  }
+  catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return []
+    throw error
+  }
+}
+
+function extractResetUrl(email: CapturedEmail) {
+  const content = `${email.text}\n${email.html}`
+  return content.match(/http:\/\/127\.0\.0\.1:3333\/api\/auth\/reset-password\/[^\s"'<>]+/)?.[0] ?? ''
+}
+
+test.describe('Auth recovery fake mail', () => {
+  test('resets a real user password through the captured reset email', async ({ authenticatedPage, testAccount, browser }) => {
+    const capturePath = process.env.FACTORY_EMAIL_CAPTURE_PATH
+    expect(capturePath, 'FACTORY_EMAIL_CAPTURE_PATH must be set for auth recovery E2E').toBeTruthy()
+    expect(process.env.FACTORY_EMAIL_TEST_MODE, 'auth recovery E2E must use capture mode, not a real provider').toBe('capture')
+    expect(process.env.FACTORY_ADMIN_SSO_ONLY, 'auth recovery E2E needs email/password auth enabled').toBe('false')
+
+    await expect(authenticatedPage.getByRole('heading', { name: /Dashboard|Welcome/i })).toBeVisible({ timeout: 30_000 })
+    await rm(capturePath!, { force: true })
+
+    const newPassword = `${testAccount.password}-Reset1`
+    const guestContext = await browser.newContext()
+    const guestPage = await guestContext.newPage()
+
+    await guestPage.goto('/auth/forgot-password')
+    await guestPage.waitForLoadState('networkidle')
+    await expect(guestPage.getByRole('heading', { name: 'Reset your password' })).toBeVisible()
+    await guestPage.getByLabel('Email').fill(testAccount.email)
+
+    await guestPage.getByRole('button', { name: 'Send reset link' }).click()
+    await expect(guestPage.getByText("If an account with that email exists, we've sent a password reset link.")).toBeVisible()
+
+    await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+      message: 'password reset email should be captured',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(1)
+
+    const capturedEmails = await readCapturedEmails(capturePath!)
+    const resetEmail = capturedEmails.find(email => email.subject === 'Reset your password — Factory Careers')
+    expect(resetEmail, 'password reset email should be captured').toBeTruthy()
+    expect(resetEmail?.renderError, 'password reset email should render successfully').toBeUndefined()
+    expect(resetEmail?.to).toContain(testAccount.email)
+    expect(resetEmail?.text).toContain('Reset your password')
+
+    const resetUrl = extractResetUrl(resetEmail!)
+    expect(resetUrl, 'reset email should contain a local reset URL').toContain('/api/auth/reset-password/')
+    expect(resetUrl).not.toContain('thefactoryhq.com')
+
+    const resetContext = await browser.newContext()
+    const resetPage = await resetContext.newPage()
+    await resetPage.goto(resetUrl)
+    await resetPage.waitForLoadState('networkidle')
+    await expect(resetPage.getByRole('heading', { name: 'Set new password' })).toBeVisible()
+    await resetPage.getByLabel('New password', { exact: true }).fill(newPassword)
+    await resetPage.getByLabel('Confirm new password').fill(newPassword)
+
+    const [resetResponse] = await Promise.all([
+      resetPage.waitForResponse(
+        resp => resp.url().includes('/api/auth/reset-password') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      resetPage.getByRole('button', { name: 'Reset password' }).click(),
+    ])
+    expect(resetResponse.status(), `Reset password API returned ${resetResponse.status()}`).toBe(200)
+    await expect(resetPage.getByText('Your password has been reset successfully.')).toBeVisible()
+    await resetContext.close()
+
+    const oldPasswordContext = await browser.newContext()
+    const oldPasswordPage = await oldPasswordContext.newPage()
+    const oldSignInResponse = await oldPasswordPage.request.post('/api/auth/sign-in/email', {
+      data: {
+        email: testAccount.email,
+        password: testAccount.password,
+      },
+    })
+    expect(oldSignInResponse.status(), 'old password should no longer sign in').toBeGreaterThanOrEqual(400)
+    await oldPasswordContext.close()
+
+    const newSignInResponse = await guestPage.request.post('/api/auth/sign-in/email', {
+      data: {
+        email: testAccount.email,
+        password: newPassword,
+      },
+    })
+    expect(newSignInResponse.status(), `new password sign-in returned ${newSignInResponse.status()}`).toBe(200)
+    await guestPage.goto('/dashboard')
+    await guestPage.waitForLoadState('networkidle')
+    await expect(guestPage.getByRole('heading', { name: /Dashboard|Welcome/i })).toBeVisible({ timeout: 30_000 })
+
+    await guestContext.close()
+  })
+})

--- a/e2e/critical-flows/candidate-application.spec.ts
+++ b/e2e/critical-flows/candidate-application.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from '../fixtures'
+import { type Page } from '@playwright/test'
+import { test, expect, selectFactorySelectOption } from '../fixtures'
 
 /**
  * Critical flow: Candidate applies to a published job that contains every
@@ -92,6 +93,24 @@ const FIELD_TYPE_LABELS: Record<string, string> = {
   url: 'URL',
   checkbox: 'Checkbox (Yes/No)',
   file_upload: 'File Upload',
+}
+
+async function advanceToSubmitButton(page: Page) {
+  const submitButton = page.getByRole('button', { name: /submit/i })
+
+  for (let step = 0; step < 3; step += 1) {
+    if (await submitButton.isVisible()) {
+      return submitButton
+    }
+
+    const continueButton = page.getByRole('button', { name: 'Continue' }).first()
+    await expect(continueButton).toBeVisible({ timeout: 10_000 })
+    await expect(continueButton).toBeEnabled()
+    await continueButton.click()
+  }
+
+  await expect(submitButton).toBeVisible({ timeout: 10_000 })
+  return submitButton
 }
 
 /**
@@ -239,17 +258,15 @@ test.describe('Candidate Application Flow — All Custom Question Field Types', 
     await candidatePage.waitForLoadState('networkidle')
     await expect(candidatePage.getByRole('heading', { name: JOB_TITLE })).toBeVisible({ timeout: 15_000 })
 
-    // Wait for the form to be fully hydrated
-    await candidatePage.getByRole('button', { name: /submit/i }).waitFor({ state: 'visible', timeout: 15_000 })
-
     // ── Fill basic applicant info ─────────────────────────────────────────────
 
     await candidatePage.getByLabel('First name').fill(APPLICANT.firstName)
     await candidatePage.getByLabel('Last name').fill(APPLICANT.lastName)
     await candidatePage.getByLabel('Email').fill(APPLICANT.email)
     await candidatePage.getByLabel('Phone').fill(APPLICANT.phone)
-    await candidatePage.getByLabel(/Country/).selectOption({ label: 'United States' })
-    await candidatePage.getByLabel(/State/).selectOption({ label: 'California' })
+    await selectFactorySelectOption(candidatePage, /Country/, 'United States')
+    await selectFactorySelectOption(candidatePage, /State/, 'California')
+    await candidatePage.getByRole('button', { name: 'Continue' }).click()
 
     // ── Fill each custom question field type ──────────────────────────────────
 
@@ -310,6 +327,7 @@ test.describe('Candidate Application Flow — All Custom Question Field Types', 
 
     // ── Submit the application ────────────────────────────────────────────────
 
+    const submitButton = await advanceToSubmitButton(candidatePage)
     const [applyResponse] = await Promise.all([
       candidatePage.waitForResponse(
         resp =>
@@ -317,7 +335,7 @@ test.describe('Candidate Application Flow — All Custom Question Field Types', 
           resp.request().method() === 'POST',
         { timeout: 30_000 },
       ),
-      candidatePage.getByRole('button', { name: /submit/i }).click(),
+      submitButton.click(),
     ])
 
     // Verify the API responded with a 2xx status
@@ -513,7 +531,13 @@ test.describe('Candidate Application — Required Cover Letter Validation', () =
       .waitFor({ state: 'attached', timeout: 10_000 })
     await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().click()
 
-    // Step 2: Enable "Cover letter" requirement via radio group
+    // Step 2: Isolate this validation to cover letters; resume upload is
+    // covered by the dedicated upload lane.
+    const resumeRadioGroup = page.getByRole('radiogroup', { name: /Resume requirement/i })
+    await resumeRadioGroup.waitFor({ state: 'visible', timeout: 10_000 })
+    await resumeRadioGroup.getByRole('radio', { name: 'Off' }).click()
+
+    // Enable "Cover letter" requirement via radio group.
     const coverLetterRadioGroup = page.getByRole('radiogroup', { name: /Cover letter requirement/i })
     await coverLetterRadioGroup.waitFor({ state: 'visible', timeout: 10_000 })
     await coverLetterRadioGroup.getByRole('radio', { name: 'Required' }).click()
@@ -554,18 +578,20 @@ test.describe('Candidate Application — Required Cover Letter Validation', () =
 
     await candidatePage.goto(applicationLink)
     await candidatePage.waitForLoadState('networkidle')
-    await candidatePage.getByRole('button', { name: /submit/i }).waitFor({ state: 'visible', timeout: 15_000 })
-
-    // The cover letter textarea must be visible (requireCoverLetter=true)
-    await expect(candidatePage.locator('#coverLetterText')).toBeVisible({ timeout: 10_000 })
 
     // Fill required basic fields but leave cover letter EMPTY
     await candidatePage.getByLabel('First name').fill('Test')
     await candidatePage.getByLabel('Last name').fill('Applicant')
     await candidatePage.getByLabel('Email').fill(`test.applicant.${Date.now()}.r${testInfo.retry}@example.com`)
+    await selectFactorySelectOption(candidatePage, /Country/, 'United States')
+    await selectFactorySelectOption(candidatePage, /State/, 'California')
+    await candidatePage.getByRole('button', { name: 'Continue' }).click()
 
-    // Submit without cover letter — client validation must block it
-    await candidatePage.getByRole('button', { name: /submit/i }).click()
+    // The cover letter textarea must be visible (requireCoverLetter=true)
+    await expect(candidatePage.locator('#coverLetterText')).toBeVisible({ timeout: 10_000 })
+
+    // Continue without cover letter — step validation must block progress.
+    await candidatePage.getByRole('button', { name: 'Continue' }).click()
 
     // Error message should appear; the page should NOT navigate
     await expect(

--- a/e2e/critical-flows/fake-mail.spec.ts
+++ b/e2e/critical-flows/fake-mail.spec.ts
@@ -1,0 +1,149 @@
+import { readFile, rm } from "node:fs/promises";
+import type { Page } from "@playwright/test";
+import { test, expect, selectFactorySelectOption } from "../fixtures";
+
+const JOB_TITLE = "Email Capture Test Job";
+
+type CapturedEmail = {
+  from: string;
+  to: string[];
+  subject: string;
+  html: string;
+  text: string;
+  renderError?: string;
+};
+
+async function readCapturedEmails(capturePath: string): Promise<CapturedEmail[]> {
+  try {
+    const contents = await readFile(capturePath, "utf8");
+    return contents
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as CapturedEmail);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+
+    throw error;
+  }
+}
+
+async function advanceToSubmitButton(page: Page) {
+  const submitButton = page.getByRole("button", { name: /submit/i });
+
+  for (let step = 0; step < 3; step += 1) {
+    if (await submitButton.isVisible()) {
+      return submitButton;
+    }
+
+    const continueButton = page.getByRole("button", { name: "Continue" }).first();
+    await expect(continueButton).toBeVisible({ timeout: 10_000 });
+    await expect(continueButton).toBeEnabled();
+    await continueButton.click();
+  }
+
+  await expect(submitButton).toBeVisible({ timeout: 10_000 });
+  return submitButton;
+}
+
+test.describe("Fake mail capture", () => {
+  test("captures application receipt and hiring-team alert without external delivery", async ({ authenticatedPage, browser }, testInfo) => {
+    const capturePath = process.env.FACTORY_EMAIL_CAPTURE_PATH;
+    expect(capturePath, "FACTORY_EMAIL_CAPTURE_PATH must be set for fake-mail E2E").toBeTruthy();
+    expect(process.env.FACTORY_EMAIL_TEST_MODE, "E2E mail must use capture mode, not a real provider").toBe("capture");
+
+    await rm(capturePath!, { force: true });
+
+    const recruiterPage = authenticatedPage;
+    const jobTitle = `${JOB_TITLE} ${Date.now()} r${testInfo.retry}`;
+    const applicant = {
+      firstName: "Email",
+      lastName: "Candidate",
+      email: `email.candidate.${Date.now()}.r${testInfo.retry}@example.com`,
+    };
+    const applicantName = `${applicant.firstName} ${applicant.lastName}`;
+    const hiringInbox = process.env.FACTORY_CAREERS_HIRING_INBOX || "careers@thefactoryhq.com";
+    const organizationName = process.env.FACTORY_ORG_NAME || "Factory";
+
+    await recruiterPage.goto("/dashboard/jobs/new");
+    await recruiterPage.waitForLoadState("networkidle");
+    await recruiterPage.getByLabel("Job title").waitFor({ state: "visible", timeout: 15_000 });
+    await recruiterPage.getByLabel("Job title").fill(jobTitle);
+
+    await recruiterPage.locator("form").getByRole("button", { name: "Save & continue" }).first().waitFor({ state: "attached", timeout: 10_000 });
+    await expect(recruiterPage.locator("form").getByRole("button", { name: "Save & continue" }).first()).toBeEnabled({ timeout: 10_000 });
+    await recruiterPage.locator("form").getByRole("button", { name: "Save & continue" }).first().click();
+
+    const resumeRadioGroup = recruiterPage.getByRole("radiogroup", { name: /Resume requirement/i });
+    await resumeRadioGroup.waitFor({ state: "visible", timeout: 10_000 });
+    await resumeRadioGroup.getByRole("radio", { name: "Off" }).click();
+
+    await recruiterPage.locator("form").getByRole("button", { name: "Save & continue" }).first().click();
+    await recruiterPage.locator("form").getByRole("button", { name: "Save & continue" }).first().waitFor({ state: "visible", timeout: 10_000 });
+    await recruiterPage.locator("form").getByRole("button", { name: "Save & continue" }).first().click();
+
+    await expect(recruiterPage.getByRole("heading", { name: /Ready to go\?/i })).toBeVisible({ timeout: 10_000 });
+    const publishButton = recruiterPage.locator("form").getByRole("button", { name: /Publish & copy link/i });
+    await publishButton.waitFor({ state: "visible", timeout: 10_000 });
+
+    const [publishResponse] = await Promise.all([
+      recruiterPage.waitForResponse(
+        (resp) => resp.url().includes("/api/jobs/") && resp.request().method() === "PATCH",
+        { timeout: 30_000 },
+      ),
+      publishButton.click(),
+    ]);
+    expect([200, 201], `Publish API returned ${publishResponse.status()}`).toContain(publishResponse.status());
+    const publishedJob = await publishResponse.json() as { id: string; slug: string };
+    expect(publishedJob.slug, "published job slug must be present").toBeTruthy();
+    await expect(recruiterPage.getByRole("heading", { name: "Your job is live!" })).toBeVisible({ timeout: 30_000 });
+
+    const candidateContext = await browser.newContext();
+    const candidatePage = await candidateContext.newPage();
+    await candidatePage.goto(`/jobs/${publishedJob.slug}/apply`);
+    await candidatePage.waitForLoadState("networkidle");
+    await candidatePage.getByLabel("First name").fill(applicant.firstName);
+    await candidatePage.getByLabel("Last name").fill(applicant.lastName);
+    await candidatePage.getByLabel("Email").fill(applicant.email);
+    await selectFactorySelectOption(candidatePage, /Country/, "United States");
+    await selectFactorySelectOption(candidatePage, /State/, "California");
+
+    const submitButton = await advanceToSubmitButton(candidatePage);
+    const [applyResponse] = await Promise.all([
+      candidatePage.waitForResponse(
+        (resp) => resp.url().includes(`/api/public/jobs/${publishedJob.slug}/apply`) && resp.request().method() === "POST",
+        { timeout: 30_000 },
+      ),
+      submitButton.click(),
+    ]);
+    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201);
+    await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}/confirmation`, { waitUntil: "commit", timeout: 15_000 });
+    await expect(candidatePage.getByRole("heading", { name: "Application submitted" })).toBeVisible();
+
+    await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+      message: "application submission should capture receipt and team alert emails",
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(2);
+
+    const capturedEmails = await readCapturedEmails(capturePath!);
+    const receipt = capturedEmails.find((email) => email.subject === `Application received — ${jobTitle} at ${organizationName}`);
+    expect(receipt, "candidate receipt email should be captured").toBeTruthy();
+    expect(receipt?.renderError, "candidate receipt email should render successfully").toBeUndefined();
+    expect(receipt?.to).toContain(applicant.email);
+    expect(receipt?.text).toContain(applicantName);
+    expect(receipt?.text).toContain(jobTitle);
+    expect(receipt?.text).toContain(organizationName);
+
+    const teamAlert = capturedEmails.find((email) => email.subject === `New application: ${applicantName} for ${jobTitle}`);
+    expect(teamAlert, "hiring-team alert email should be captured").toBeTruthy();
+    expect(teamAlert?.renderError, "hiring-team alert email should render successfully").toBeUndefined();
+    expect(teamAlert?.to).toContain(hiringInbox);
+    expect(teamAlert?.text).toContain(applicantName);
+    expect(teamAlert?.text).toContain(applicant.email);
+    expect(teamAlert?.text).toContain(jobTitle);
+    expect(teamAlert?.text).toContain(`/dashboard/applications/`);
+
+    await candidateContext.close();
+  });
+});

--- a/e2e/critical-flows/interview-invitation-response.spec.ts
+++ b/e2e/critical-flows/interview-invitation-response.spec.ts
@@ -1,0 +1,172 @@
+import { readFile, rm } from 'node:fs/promises'
+import { test, expect } from '../fixtures'
+
+const JOB_TITLE = 'Interview Invitation Response Test Job'
+const INTERVIEW_TITLE = 'Candidate response screen'
+
+type CapturedEmail = {
+  to: string[]
+  subject: string
+  html: string
+  text: string
+  renderError?: string
+}
+
+async function readCapturedEmails(capturePath: string): Promise<CapturedEmail[]> {
+  try {
+    const contents = await readFile(capturePath, 'utf8')
+    return contents
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as CapturedEmail)
+  }
+  catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return []
+    throw error
+  }
+}
+
+function extractAcceptUrl(email: CapturedEmail) {
+  const content = `${email.text}\n${email.html}`
+  return content.match(/http:\/\/127\.0\.0\.1:3333\/interview\/respond\?token=[A-Za-z0-9._%-]+/)?.[0] ?? ''
+}
+
+test.describe('Interview invitation response', () => {
+  test('captures the invitation email and records the candidate response', async ({ authenticatedPage, browser }, testInfo) => {
+    const capturePath = process.env.FACTORY_EMAIL_CAPTURE_PATH
+    expect(capturePath, 'FACTORY_EMAIL_CAPTURE_PATH must be set for interview invitation E2E').toBeTruthy()
+    expect(process.env.FACTORY_EMAIL_TEST_MODE, 'Interview invitation E2E must use capture mode').toBe('capture')
+
+    await rm(capturePath!, { force: true })
+
+    const page = authenticatedPage
+    const unique = `${Date.now()}-r${testInfo.retry}`
+    const jobTitle = `${JOB_TITLE} ${unique}`
+    const applicant = {
+      firstName: 'Response',
+      lastName: 'Candidate',
+      email: `interview.response.${unique}@example.com`,
+    }
+    const applicantName = `${applicant.firstName} ${applicant.lastName}`
+
+    const createJobResponse = await page.request.post('/api/jobs', {
+      data: {
+        title: jobTitle,
+        description: 'A fast E2E job for interview invitation responses.',
+        location: 'Remote',
+        requireResume: false,
+        requireCoverLetter: false,
+        applicationComplianceEnabled: false,
+        autoScoreOnApply: false,
+      },
+    })
+    expect(createJobResponse.status(), `Create job API returned ${createJobResponse.status()}`).toBe(201)
+    const createdJob = await createJobResponse.json() as { id: string; slug: string }
+
+    const publishJobResponse = await page.request.patch(`/api/jobs/${createdJob.id}`, {
+      data: { status: 'open' },
+    })
+    expect(publishJobResponse.status(), `Publish job API returned ${publishJobResponse.status()}`).toBe(200)
+    const publishedJob = await publishJobResponse.json() as { slug: string }
+
+    const applyResponse = await page.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
+      data: {
+        firstName: applicant.firstName,
+        lastName: applicant.lastName,
+        email: applicant.email,
+        country: 'United States',
+        state: 'CA',
+        responses: [],
+      },
+    })
+    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
+
+    const applicationsResponse = await page.request.get(`/api/applications?jobId=${createdJob.id}&limit=10`)
+    expect(applicationsResponse.status(), `Applications API returned ${applicationsResponse.status()}`).toBe(200)
+    const applications = await applicationsResponse.json() as {
+      data: Array<{ id: string; candidateEmail: string }>
+    }
+    const application = applications.data.find(item => item.candidateEmail === applicant.email)
+    expect(application?.id, 'application id must be discoverable after public apply').toBeTruthy()
+
+    await page.goto(`/dashboard/applications/${application!.id}`, { waitUntil: 'networkidle' })
+    await expect(page.getByRole('heading', { name: new RegExp(applicantName) })).toBeVisible({ timeout: 15_000 })
+    const quickActions = page.locator('.ui-panel').filter({ hasText: 'Quick actions' })
+    await quickActions.getByRole('button', { name: 'Schedule Interview' }).click()
+    await expect(page.getByRole('heading', { name: 'Schedule Interview' })).toBeVisible({ timeout: 15_000 })
+
+    const emailCheckbox = page.getByRole('checkbox', { name: /Standard email/i })
+    await expect(emailCheckbox).toBeChecked()
+    const calendarCheckbox = page.getByRole('checkbox', { name: /Calendar|Microsoft|Google/i }).first()
+    await expect(calendarCheckbox, 'calendar sync should be disabled when no provider is configured').not.toBeChecked()
+
+    await page.getByLabel('Title').fill(`${INTERVIEW_TITLE} ${unique}`)
+    await page.getByRole('button', { name: '30m' }).click()
+
+    const [scheduleResponse, invitationResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/interviews') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.waitForResponse(
+        resp => resp.url().includes('/send-invitation') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Schedule Interview' }).last().click(),
+    ])
+    expect(scheduleResponse.status(), `Schedule interview API returned ${scheduleResponse.status()}`).toBe(201)
+    expect(invitationResponse.status(), `Send invitation API returned ${invitationResponse.status()}`).toBe(200)
+    const createdInterview = await scheduleResponse.json() as { id: string; calendarEventProvider?: string | null; googleCalendarEventId?: string | null }
+    expect(createdInterview.id, 'created interview id must be present').toBeTruthy()
+    expect(createdInterview.calendarEventProvider ?? null).toBeNull()
+    expect(createdInterview.googleCalendarEventId ?? null).toBeNull()
+
+    await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+      message: 'interview scheduling should capture the candidate invitation email',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(1)
+
+    const invitation = (await readCapturedEmails(capturePath!))
+      .find(email =>
+        email.subject.startsWith(`Interview Invitation: ${jobTitle} at `)
+        && email.to.includes(applicant.email),
+      )
+    expect(invitation, 'candidate interview invitation email should be captured').toBeTruthy()
+    expect(invitation?.renderError, 'candidate interview invitation email should render successfully').toBeUndefined()
+    expect(invitation?.to).toContain(applicant.email)
+    expect(invitation?.text).toContain(applicantName)
+    expect(invitation?.text).toContain(jobTitle)
+
+    const acceptUrl = extractAcceptUrl(invitation!)
+    expect(acceptUrl, 'invitation email should contain a local accept URL').toContain('/interview/respond?token=')
+    expect(acceptUrl).not.toContain('thefactoryhq.com')
+
+    const candidateContext = await browser.newContext()
+    const candidatePage = await candidateContext.newPage()
+    await candidatePage.goto(acceptUrl, { waitUntil: 'networkidle' })
+    await expect(candidatePage.getByRole('heading', { name: 'Interview Invitation' })).toBeVisible({ timeout: 15_000 })
+    await expect(candidatePage.getByText(`${INTERVIEW_TITLE} ${unique}`)).toBeVisible()
+    await expect(candidatePage.getByText(jobTitle)).toBeVisible()
+
+    const [candidateResponse] = await Promise.all([
+      candidatePage.waitForResponse(
+        resp => resp.url().includes('/api/public/interviews/respond') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      candidatePage.getByRole('button', { name: 'Accept Interview' }).click(),
+    ])
+    expect(candidateResponse.status(), `Candidate response API returned ${candidateResponse.status()}`).toBe(200)
+    await expect(candidatePage.getByRole('heading', { name: 'Response Recorded' })).toBeVisible({ timeout: 15_000 })
+    await candidateContext.close()
+
+    const interviewResponse = await page.request.get(`/api/interviews/${createdInterview.id}`)
+    expect(interviewResponse.status(), `Interview detail API returned ${interviewResponse.status()}`).toBe(200)
+    const updatedInterview = await interviewResponse.json() as { candidateResponse: string; candidateRespondedAt: string | null }
+    expect(updatedInterview.candidateResponse).toBe('accepted')
+    expect(updatedInterview.candidateRespondedAt).toBeTruthy()
+
+    await page.goto(`/dashboard/interviews/${createdInterview.id}`, { waitUntil: 'networkidle' })
+    await expect(page.getByText('Candidate response', { exact: true })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Accepted', { exact: true })).toBeVisible()
+  })
+})

--- a/e2e/critical-flows/interview-lifecycle.spec.ts
+++ b/e2e/critical-flows/interview-lifecycle.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '../fixtures'
+
+const JOB_TITLE = 'Interview Lifecycle Test Job'
+const INTERVIEW_TITLE = 'Candidate screen'
+
+test.describe('Interview scheduling lifecycle', () => {
+  test('schedules an interview from the application UI and marks it complete from the dashboard', async ({ authenticatedPage }, testInfo) => {
+    const page = authenticatedPage
+    const unique = `${Date.now()}-r${testInfo.retry}`
+    const jobTitle = `${JOB_TITLE} ${unique}`
+    const applicant = {
+      firstName: 'Interview',
+      lastName: 'Candidate',
+      email: `interview.candidate.${unique}@example.com`,
+    }
+    const applicantName = `${applicant.firstName} ${applicant.lastName}`
+
+    const createJobResponse = await page.request.post('/api/jobs', {
+      data: {
+        title: jobTitle,
+        description: 'A fast E2E job for interview scheduling.',
+        location: 'Remote',
+        requireResume: false,
+        requireCoverLetter: false,
+        applicationComplianceEnabled: false,
+        autoScoreOnApply: false,
+      },
+    })
+    expect(createJobResponse.status(), `Create job API returned ${createJobResponse.status()}`).toBe(201)
+    const createdJob = await createJobResponse.json() as { id: string; slug: string }
+
+    const publishJobResponse = await page.request.patch(`/api/jobs/${createdJob.id}`, {
+      data: { status: 'open' },
+    })
+    expect(publishJobResponse.status(), `Publish job API returned ${publishJobResponse.status()}`).toBe(200)
+    const publishedJob = await publishJobResponse.json() as { slug: string }
+
+    const applyResponse = await page.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
+      data: {
+        firstName: applicant.firstName,
+        lastName: applicant.lastName,
+        email: applicant.email,
+        country: 'United States',
+        state: 'CA',
+        responses: [],
+      },
+    })
+    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
+
+    const applicationsResponse = await page.request.get(`/api/applications?jobId=${createdJob.id}&limit=10`)
+    expect(applicationsResponse.status(), `Applications API returned ${applicationsResponse.status()}`).toBe(200)
+    const applications = await applicationsResponse.json() as {
+      data: Array<{ id: string; candidateEmail: string }>
+    }
+    const application = applications.data.find(item => item.candidateEmail === applicant.email)
+    expect(application?.id, 'application id must be discoverable after public apply').toBeTruthy()
+
+    await page.goto(`/dashboard/applications/${application!.id}`, { waitUntil: 'networkidle' })
+    await expect(page.getByRole('heading', { name: new RegExp(applicantName) })).toBeVisible({ timeout: 15_000 })
+    const quickActions = page.locator('.ui-panel').filter({ hasText: 'Quick actions' })
+    await quickActions.getByRole('button', { name: 'Schedule Interview' }).click()
+    await expect(page.getByRole('heading', { name: 'Schedule Interview' })).toBeVisible({ timeout: 15_000 })
+
+    const emailCheckbox = page.getByRole('checkbox', { name: /Standard email/i })
+    await expect(emailCheckbox).toBeChecked()
+    await emailCheckbox.uncheck()
+
+    const calendarCheckbox = page.getByRole('checkbox', { name: /Calendar|Microsoft|Google/i }).first()
+    await expect(calendarCheckbox, 'calendar sync should be disabled when no provider is configured').not.toBeChecked()
+
+    await page.getByLabel('Title').fill(`${INTERVIEW_TITLE} ${unique}`)
+    await page.getByRole('button', { name: '30m' }).click()
+
+    const [scheduleResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/interviews') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Schedule Interview' }).last().click(),
+    ])
+    expect(scheduleResponse.status(), `Schedule interview API returned ${scheduleResponse.status()}`).toBe(201)
+    const createdInterview = await scheduleResponse.json() as { id: string; calendarEventProvider?: string | null; googleCalendarEventId?: string | null }
+    expect(createdInterview.id, 'created interview id must be present').toBeTruthy()
+    expect(createdInterview.calendarEventProvider ?? null).toBeNull()
+    expect(createdInterview.googleCalendarEventId ?? null).toBeNull()
+    await expect(page.getByRole('heading', { name: 'Interview Scheduled' })).toBeVisible({ timeout: 15_000 })
+
+    await page.goto('/dashboard/interviews', { waitUntil: 'networkidle' })
+    const interviewRow = page.locator('.ui-list-row').filter({ hasText: `${INTERVIEW_TITLE} ${unique}` })
+    await expect(interviewRow).toBeVisible({ timeout: 15_000 })
+    await expect(interviewRow).toContainText(applicantName)
+    await expect(interviewRow).toContainText(jobTitle)
+    await expect(interviewRow).toContainText('30min')
+    await expect(interviewRow).toContainText('Scheduled')
+
+    const [completeResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes(`/api/interviews/${createdInterview.id}`) && resp.request().method() === 'PATCH',
+        { timeout: 30_000 },
+      ),
+      interviewRow.getByRole('button', { name: 'Complete' }).click(),
+    ])
+    expect(completeResponse.status(), `Complete interview API returned ${completeResponse.status()}`).toBe(200)
+    await expect(interviewRow.getByText('Completed', { exact: true })).toBeVisible({ timeout: 15_000 })
+    await expect(interviewRow.getByRole('button', { name: 'Complete' })).toHaveCount(0)
+
+    await page.reload()
+    const reloadedRow = page.locator('.ui-list-row').filter({ hasText: `${INTERVIEW_TITLE} ${unique}` })
+    await expect(reloadedRow).toBeVisible({ timeout: 15_000 })
+    await expect(reloadedRow.getByText('Completed', { exact: true })).toBeVisible()
+  })
+})

--- a/e2e/critical-flows/invitation-management.spec.ts
+++ b/e2e/critical-flows/invitation-management.spec.ts
@@ -12,11 +12,10 @@ import { test, expect } from '../fixtures'
  * 6. Owner cancels the invitation
  */
 
-const INVITED_EMAIL = 'invited-member@test.local'
-
 test.describe('Invitation Management Flow', () => {
   test('owner can invite, resend, and cancel an invitation', async ({ authenticatedPage }) => {
     const page = authenticatedPage
+    const invitedEmail = `invited-member-${Date.now()}@test.local`
 
     // ── Navigate to Members page ──────────────────────────
     await page.goto('/dashboard/settings/members')
@@ -33,7 +32,7 @@ test.describe('Invitation Management Flow', () => {
     // Fill in the invite form
     const emailInput = page.getByPlaceholder('colleague@company.com')
     await emailInput.waitFor({ state: 'visible', timeout: 10_000 })
-    await emailInput.fill(INVITED_EMAIL)
+    await emailInput.fill(invitedEmail)
 
     // Submit the invitation and wait for the server mutation.
     const [inviteResponse] = await Promise.all([
@@ -46,13 +45,10 @@ test.describe('Invitation Management Flow', () => {
     ])
     expect(inviteResponse.status(), `Invite API returned ${inviteResponse.status()}`).toBe(200)
 
-    // Wait for success message
-    await expect(page.getByText(`Invitation sent to ${INVITED_EMAIL}`)).toBeVisible({ timeout: 15_000 })
-
     // ── Step 2: Verify pending invitation appears ─────────
     // The pending invitations section should now show
     await expect(page.getByText('Pending invitations')).toBeVisible({ timeout: 10_000 })
-    await expect(page.getByText(INVITED_EMAIL).last()).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByRole('link', { name: invitedEmail })).toBeVisible({ timeout: 10_000 })
 
     // ── Step 3: Resend the invitation ─────────────────────
     const resendButton = page.getByRole('button', { name: 'Resend' })
@@ -67,16 +63,13 @@ test.describe('Invitation Management Flow', () => {
     ])
     expect(resendResponse.status(), `Resend API returned ${resendResponse.status()}`).toBe(200)
 
-    // Wait for resend success message
-    await expect(page.getByText(`Invitation resent to ${INVITED_EMAIL}`)).toBeVisible({ timeout: 15_000 })
-
     // Invitation should still appear in the list
-    await expect(page.getByText(INVITED_EMAIL).last()).toBeVisible()
+    await expect(page.getByRole('link', { name: invitedEmail })).toBeVisible()
 
     // ── Step 4: Cancel the invitation ─────────────────────
     const pendingInviteRow = page
       .locator('.ui-list-row')
-      .filter({ has: page.getByRole('link', { name: INVITED_EMAIL }) })
+      .filter({ has: page.getByRole('link', { name: invitedEmail }) })
     await expect(pendingInviteRow).toBeVisible()
 
     const cancelButton = pendingInviteRow.getByRole('button', { name: 'Cancel' })
@@ -99,13 +92,13 @@ test.describe('Invitation Management Flow', () => {
     // After cancellation, the invitation should no longer appear
     // (or the pending invitations section could be hidden entirely if empty)
     const pendingSection = page.getByText('Pending invitations')
-    const invitedEmail = page.getByText(INVITED_EMAIL)
+    const invitedEmailLink = page.getByRole('link', { name: invitedEmail })
 
     // Either the section is gone or the email is no longer listed
     const isHidden = await pendingSection.isHidden().catch(() => true)
     if (!isHidden) {
       // Section still visible - email should not be in it
-      await expect(invitedEmail.last()).toBeHidden({ timeout: 10_000 })
+      await expect(invitedEmailLink).toBeHidden({ timeout: 10_000 })
     }
   })
 })

--- a/e2e/critical-flows/job-lifecycle.spec.ts
+++ b/e2e/critical-flows/job-lifecycle.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '../fixtures'
+
+const JOB_TITLE = 'Lifecycle Close Test Job'
+const JOB_DESCRIPTION = 'A published job used to verify close/unpublish behavior.'
+const JOB_LOCATION = 'Remote'
+
+test.describe('Job lifecycle after publish', () => {
+  test('closing a published job updates the dashboard and blocks public applications', async ({ authenticatedPage, browser }, testInfo) => {
+    const page = authenticatedPage
+    const jobTitle = `${JOB_TITLE} ${Date.now()} r${testInfo.retry}`
+
+    await page.goto('/dashboard/jobs/new')
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Job title').waitFor({ state: 'visible', timeout: 15_000 })
+    await page.getByLabel('Job title').fill(jobTitle)
+    await page.locator('textarea').first().fill(JOB_DESCRIPTION)
+    await page.getByLabel('Location').fill(JOB_LOCATION)
+
+    await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().waitFor({ state: 'attached', timeout: 10_000 })
+    await expect(page.locator('form').getByRole('button', { name: 'Save & continue' }).first()).toBeEnabled({ timeout: 10_000 })
+    await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().click()
+
+    await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().waitFor({ state: 'attached', timeout: 10_000 })
+    await expect(page.locator('form').getByRole('button', { name: 'Save & continue' }).first()).toBeEnabled({ timeout: 10_000 })
+    await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().click()
+
+    await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().waitFor({ state: 'visible', timeout: 10_000 })
+    await page.locator('form').getByRole('button', { name: 'Save & continue' }).first().click()
+
+    await expect(page.getByRole('heading', { name: /Ready to go\?/i })).toBeVisible({ timeout: 10_000 })
+    const publishButton = page.locator('form').getByRole('button', { name: /Publish & copy link/i })
+    await publishButton.waitFor({ state: 'visible', timeout: 10_000 })
+    const [publishResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/jobs/') && resp.request().method() === 'PATCH',
+        { timeout: 30_000 },
+      ),
+      publishButton.click(),
+    ])
+    expect([200, 201], `Publish API returned ${publishResponse.status()}`).toContain(publishResponse.status())
+    const publishedJob = await publishResponse.json() as { id: string; slug: string; status: string }
+    expect(publishedJob.id, 'published job id must be present').toBeTruthy()
+    expect(publishedJob.slug, 'published job slug must be present').toBeTruthy()
+    expect(publishedJob.status).toBe('open')
+    await expect(page.getByRole('heading', { name: 'Your job is live!' })).toBeVisible({ timeout: 30_000 })
+
+    const publicContext = await browser.newContext()
+    const publicPage = await publicContext.newPage()
+    await publicPage.goto(`/jobs/${publishedJob.slug}`)
+    await expect(publicPage.getByRole('heading', { name: jobTitle })).toBeVisible({ timeout: 15_000 })
+    await expect(publicPage.getByRole('link', { name: /apply/i }).first()).toBeVisible()
+
+    await page.goto(`/dashboard/jobs/${publishedJob.id}`)
+    await page.waitForLoadState('networkidle')
+    const dashboardBanner = page.getByRole('banner')
+    await expect(page.getByText(jobTitle).first()).toBeVisible({ timeout: 15_000 })
+    await expect(dashboardBanner).toContainText('Open')
+
+    const closeButton = page.getByRole('button', { name: /Close this job so new candidates can no longer apply/i })
+    await expect(closeButton).toBeVisible({ timeout: 15_000 })
+    const [closeResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes(`/api/jobs/${publishedJob.id}`) && resp.request().method() === 'PATCH',
+        { timeout: 30_000 },
+      ),
+      closeButton.click(),
+    ])
+    expect(closeResponse.status(), `Close API returned ${closeResponse.status()}`).toBe(200)
+    const closedJob = await closeResponse.json() as { id: string; status: string }
+    expect(closedJob).toEqual(expect.objectContaining({ id: publishedJob.id, status: 'closed' }))
+
+    const jobResponse = await page.request.get(`/api/jobs/${publishedJob.id}`)
+    expect(jobResponse.status(), `Job API returned ${jobResponse.status()}`).toBe(200)
+    await expect(await jobResponse.json()).toEqual(expect.objectContaining({ status: 'closed' }))
+    await expect(dashboardBanner).toContainText('Closed', { timeout: 10_000 })
+
+    await publicPage.goto(`/jobs/${publishedJob.slug}`)
+    await expect(publicPage.getByRole('heading', { name: 'Job Not Found' })).toBeVisible({ timeout: 15_000 })
+    await publicPage.goto(`/jobs/${publishedJob.slug}/apply`)
+    await expect(publicPage.getByRole('heading', { name: 'Position Not Found' })).toBeVisible({ timeout: 15_000 })
+
+    const applyAfterCloseResponse = await publicPage.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
+      data: {
+        firstName: 'Closed',
+        lastName: 'Applicant',
+        email: `closed.applicant.${Date.now()}.r${testInfo.retry}@example.com`,
+        country: 'United States',
+        state: 'CA',
+        responses: [],
+      },
+    })
+    expect(applyAfterCloseResponse.status(), 'Closed jobs must reject public application POSTs').toBe(404)
+    expect(await applyAfterCloseResponse.text()).toContain('not accepting applications')
+
+    await publicContext.close()
+  })
+})

--- a/e2e/critical-flows/privacy-request-fake-mail.spec.ts
+++ b/e2e/critical-flows/privacy-request-fake-mail.spec.ts
@@ -1,0 +1,169 @@
+import { readFile, rm } from 'node:fs/promises'
+import { test, expect } from '../fixtures'
+import postgres from 'postgres'
+
+type CapturedEmail = {
+  to: string[]
+  subject: string
+  html: string
+  text: string
+  renderError?: string
+}
+
+type PrivacyRequestRecord = {
+  id: string
+  status: string
+  requesterName: string
+  requesterEmail: string
+  stateOfResidence: string
+  details: string | null
+  verificationTokenHash: string
+  verifiedAt: Date | null
+}
+
+async function readCapturedEmails(capturePath: string): Promise<CapturedEmail[]> {
+  try {
+    const contents = await readFile(capturePath, 'utf8')
+    return contents
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as CapturedEmail)
+  }
+  catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return []
+    throw error
+  }
+}
+
+async function lookupPrivacyRequest(requesterEmail: string) {
+  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for privacy request e2e coverage').toBeTruthy()
+  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+
+  try {
+    const [request] = await sql<PrivacyRequestRecord[]>`
+      select
+        id,
+        status,
+        requester_name as "requesterName",
+        requester_email as "requesterEmail",
+        state_of_residence as "stateOfResidence",
+        details,
+        verification_token_hash as "verificationTokenHash",
+        verified_at as "verifiedAt"
+      from privacy_request
+      where requester_email = ${requesterEmail}
+      order by created_at desc
+      limit 1
+    `
+
+    return request ?? null
+  }
+  finally {
+    await sql.end()
+  }
+}
+
+function extractVerifyUrl(email: CapturedEmail) {
+  const content = `${email.text}\n${email.html}`
+  return content.match(/http:\/\/127\.0\.0\.1:3333\/api\/privacy-requests\/verify\?token=[^\s"'<>]+/)?.[0] ?? ''
+}
+
+test.describe('Privacy request fake mail', () => {
+  test('verifies deletion request persistence, fake-mail verification, and confirmation', async ({ page }, testInfo) => {
+    const capturePath = process.env.FACTORY_EMAIL_CAPTURE_PATH
+    expect(capturePath, 'FACTORY_EMAIL_CAPTURE_PATH must be set for privacy request E2E').toBeTruthy()
+    expect(process.env.FACTORY_EMAIL_TEST_MODE, 'E2E mail must use capture mode, not a real provider').toBe('capture')
+
+    await rm(capturePath!, { force: true })
+
+    const id = `${Date.now()}-${testInfo.workerIndex}-${Math.random().toString(36).slice(2)}`
+    const requester = {
+      name: `Privacy Requester ${id}`,
+      email: `privacy.requester.${id}@example.com`,
+      state: 'California',
+      context: `Candidate role context ${id}`,
+      details: `Please review deletion for application fixture ${id}.`,
+    }
+    const privacyInbox = process.env.FACTORY_CAREERS_PRIVACY_INBOX || 'legal@thefactoryhq.com'
+
+    await page.goto('/privacy/delete-request')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('heading', { name: 'Request deletion of applicant information' })).toBeVisible()
+    await page.getByLabel('Name').fill(requester.name)
+    await page.getByLabel('Email').fill(requester.email)
+    await page.getByLabel('State of residence').selectOption(requester.state)
+    await page.getByLabel('Role or application context').fill(requester.context)
+    await page.getByLabel('Details').fill(requester.details)
+
+    const [submitResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/privacy-requests') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Submit deletion request' }).click(),
+    ])
+    expect(submitResponse.status()).toBe(202)
+    await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible()
+
+    await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+      message: 'privacy request should capture requester verification and internal alert emails',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(2)
+
+    const request = await lookupPrivacyRequest(requester.email)
+    expect(request, 'privacy request should be persisted').toBeTruthy()
+    expect(request).toMatchObject({
+      status: 'submitted',
+      requesterName: requester.name,
+      requesterEmail: requester.email,
+      stateOfResidence: requester.state,
+      verifiedAt: null,
+    })
+    expect(request?.details).toContain(requester.context)
+    expect(request?.details).toContain(requester.details)
+    expect(request?.verificationTokenHash).toMatch(/^[a-f0-9]{64}$/)
+
+    const capturedEmails = await readCapturedEmails(capturePath!)
+    const verificationEmail = capturedEmails.find((email) => email.subject === 'Verify your deletion request — Factory Careers')
+    expect(verificationEmail, 'requester verification email should be captured').toBeTruthy()
+    expect(verificationEmail?.renderError, 'requester verification email should render successfully').toBeUndefined()
+    expect(verificationEmail?.to).toContain(requester.email)
+    expect(verificationEmail?.text).toContain(requester.name)
+    expect(verificationEmail?.text).toContain('Verify your deletion request')
+
+    const verifyUrl = extractVerifyUrl(verificationEmail!)
+    expect(verifyUrl, 'verification email should contain a local verification URL').toContain('/api/privacy-requests/verify?token=')
+    expect(verifyUrl).not.toContain(request.verificationTokenHash)
+    expect(verifyUrl).not.toContain('thefactoryhq.com')
+
+    const internalAlert = capturedEmails.find((email) => email.subject === `Privacy deletion request: ${requester.email}`)
+    expect(internalAlert, 'privacy-team alert email should be captured').toBeTruthy()
+    expect(internalAlert?.renderError, 'privacy-team alert email should render successfully').toBeUndefined()
+    expect(internalAlert?.to).toContain(privacyInbox)
+    expect(internalAlert?.text).toContain(requester.name)
+    expect(internalAlert?.text).toContain(requester.email)
+    expect(internalAlert?.text).toContain(requester.state)
+
+    const verifyResponse = await page.request.get(verifyUrl)
+    expect(verifyResponse.status()).toBe(200)
+    await expect.poll(async () => (await lookupPrivacyRequest(requester.email))?.status, {
+      message: 'privacy request should move to verified after opening the verification URL',
+      timeout: 10_000,
+    }).toBe('verified')
+
+    const verifiedRequest = await lookupPrivacyRequest(requester.email)
+    expect(verifiedRequest?.verifiedAt).toBeTruthy()
+
+    await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+      message: 'privacy verification should capture confirmation email',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(3)
+
+    const confirmationEmail = (await readCapturedEmails(capturePath!))
+      .find((email) => email.subject === 'Deletion request verified — Factory Careers')
+    expect(confirmationEmail, 'requester confirmation email should be captured').toBeTruthy()
+    expect(confirmationEmail?.renderError, 'requester confirmation email should render successfully').toBeUndefined()
+    expect(confirmationEmail?.to).toContain(requester.email)
+    expect(confirmationEmail?.text).toContain('Request verified')
+  })
+})

--- a/e2e/critical-flows/rbac-role-permissions.spec.ts
+++ b/e2e/critical-flows/rbac-role-permissions.spec.ts
@@ -1,0 +1,223 @@
+import { randomUUID } from 'node:crypto'
+import { type Browser, type Page } from '@playwright/test'
+import postgres from 'postgres'
+import { test, expect } from '../fixtures'
+
+interface SignedInOrg {
+  page: Page
+  userId: string
+  organizationId: string
+  close: () => Promise<void>
+}
+
+async function lookupMembership(email: string, organizationName: string) {
+  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for RBAC e2e membership lookup').toBeTruthy()
+  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+
+  try {
+    const [membership] = await sql<{ userId: string, organizationId: string }[]>`
+      select u.id as "userId", o.id as "organizationId"
+      from "user" u
+      inner join "member" m on m."user_id" = u.id
+      inner join "organization" o on o.id = m."organization_id"
+      where u.email = ${email} and o.name = ${organizationName}
+      limit 1
+    `
+
+    expect(membership, `expected ${email} to belong to ${organizationName}`).toBeTruthy()
+    return membership
+  }
+  finally {
+    await sql.end()
+  }
+}
+
+async function signUpWithOrg(browser: Browser, label: string): Promise<SignedInOrg> {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const account = {
+    name: `RBAC ${label} ${id}`,
+    email: `rbac-${label}-${id}@test.local`,
+    password: 'TestPassword123!',
+    orgName: `RBAC ${label} Org ${id}`,
+  }
+
+  await page.goto('/auth/sign-up')
+  await page.waitForLoadState('networkidle')
+  await page.getByLabel('Name').fill(account.name)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password', { exact: true }).fill(account.password)
+  await page.getByLabel('Confirm password').fill(account.password)
+
+  await Promise.all([
+    page.waitForResponse(
+      resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200,
+      { timeout: 30_000 },
+    ),
+    page.getByRole('button', { name: 'Sign up' }).click(),
+  ])
+
+  await page.waitForURL(
+    url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'),
+    { waitUntil: 'commit', timeout: 30_000 },
+  )
+
+  if (page.url().includes('/auth/sign-in')) {
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Email').fill(account.email)
+    await page.getByLabel('Password').fill(account.password)
+
+    await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200,
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Sign in' }).click(),
+    ])
+
+    await page.waitForURL('**/onboarding/**', { waitUntil: 'commit', timeout: 30_000 })
+  }
+
+  await page.getByLabel('Organization name').waitFor({ state: 'visible', timeout: 30_000 })
+  await page.getByLabel('Organization name').fill(account.orgName)
+  await page.getByRole('button', { name: 'Create organization' }).click()
+  await page.waitForURL('**/dashboard**', { waitUntil: 'commit' })
+
+  const membership = await lookupMembership(account.email, account.orgName)
+
+  return {
+    page,
+    userId: membership.userId,
+    organizationId: membership.organizationId,
+    close: () => context.close(),
+  }
+}
+
+async function grantOrganizationRole(userId: string, organizationId: string, role: 'admin' | 'member') {
+  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for RBAC role grant').toBeTruthy()
+  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+
+  try {
+    await sql.begin(async (tx) => {
+      await tx`
+        insert into "member" ("id", "user_id", "organization_id", "role")
+        values (${randomUUID()}, ${userId}, ${organizationId}, ${role})
+        on conflict ("user_id", "organization_id")
+        do update set "role" = ${role}
+      `
+
+      await tx`
+        update "session"
+        set "active_organization_id" = ${organizationId}, "updated_at" = now()
+        where "user_id" = ${userId}
+      `
+    })
+  }
+  finally {
+    await sql.end()
+  }
+}
+
+test.describe('RBAC role permissions', () => {
+  test('member UI restrictions agree with direct API authorization while owner actions still work', async ({ authenticatedPage, testAccount, browser }, testInfo) => {
+    const ownerPage = authenticatedPage
+    const ownerMembership = await lookupMembership(testAccount.email, testAccount.orgName)
+    const member = await signUpWithOrg(browser, `member-${testInfo.workerIndex}`)
+
+    try {
+      await grantOrganizationRole(member.userId, ownerMembership.organizationId, 'member')
+
+      const memberApi = member.page.context().request
+      const ownerApi = ownerPage.context().request
+      const origin = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:13000'
+
+      const activeOrgResponse = await memberApi.post('/api/auth/organization/set-active', {
+        headers: { origin },
+        data: { organizationId: ownerMembership.organizationId },
+      })
+      expect(activeOrgResponse.status()).toBe(200)
+
+      await ownerPage.goto('/dashboard/settings/members')
+      await expect(ownerPage.getByRole('heading', { name: 'Members', exact: true })).toBeVisible()
+      await expect(ownerPage.getByRole('button', { name: 'Invite team member' })).toBeVisible()
+      await expect(ownerPage.getByRole('button', { name: 'New Job' }).first()).toBeVisible()
+
+      const jobResponse = await ownerApi.post('/api/jobs', {
+        data: {
+          title: `RBAC Browser Role ${Date.now()}`,
+          description: 'Owner-created job for RBAC browser coverage',
+          location: 'Remote',
+          type: 'full_time',
+          requireResume: false,
+        },
+      })
+      expect(jobResponse.status()).toBe(201)
+      const job = await jobResponse.json()
+
+      const candidateResponse = await ownerApi.post('/api/candidates', {
+        data: {
+          firstName: 'Robin',
+          lastName: 'Rolecheck',
+          email: `robin-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`,
+          phone: '+1 555 0177',
+        },
+      })
+      expect(candidateResponse.status()).toBe(201)
+      const candidate = await candidateResponse.json()
+
+      const applicationResponse = await ownerApi.post('/api/applications', {
+        data: {
+          candidateId: candidate.id,
+          jobId: job.id,
+          notes: 'RBAC browser fixture',
+        },
+      })
+      expect(applicationResponse.status()).toBe(201)
+      const application = await applicationResponse.json()
+
+      await member.page.goto('/dashboard/settings/members')
+      await expect(member.page.getByRole('heading', { name: 'Members', exact: true })).toBeVisible()
+      await expect(member.page.getByRole('button', { name: 'Invite team member' })).toHaveCount(0)
+      await expect(member.page.getByRole('button', { name: 'New Job' })).toHaveCount(0)
+
+      await member.page.goto('/dashboard/jobs/new')
+      await expect(member.page.getByText("You don't have permission to create jobs.")).toBeVisible()
+      await expect(member.page.getByRole('button', { name: 'Save Draft' })).toHaveCount(0)
+
+      const forbiddenJobResponse = await memberApi.post('/api/jobs', {
+        data: {
+          title: 'Member should not create jobs',
+          description: 'RBAC denial fixture',
+          location: 'Remote',
+          type: 'full_time',
+        },
+      })
+      expect(forbiddenJobResponse.status()).toBe(403)
+
+      const forbiddenInviteResponse = await memberApi.post('/api/invite-links', {
+        data: { role: 'member', expiresInHours: 24, maxUses: 1 },
+      })
+      expect(forbiddenInviteResponse.status()).toBe(403)
+
+      const memberApplicationsResponse = await memberApi.get('/api/applications')
+      expect(memberApplicationsResponse.status()).toBe(200)
+      expect(JSON.stringify(await memberApplicationsResponse.json())).toContain(application.id)
+
+      await member.page.goto('/dashboard/applications')
+      await expect(member.page.getByRole('heading', { name: 'Applications' })).toBeVisible()
+      await expect(member.page.getByText('Robin Rolecheck')).toBeVisible()
+
+      const crossOrgResponse = await memberApi.post('/api/auth/organization/set-active', {
+        headers: { origin },
+        data: { organizationId: member.organizationId },
+      })
+      expect(crossOrgResponse.status()).toBe(200)
+      const hiddenApplicationResponse = await memberApi.get(`/api/applications/${application.id}`)
+      expect(hiddenApplicationResponse.status()).toBe(404)
+    }
+    finally {
+      await member.close()
+    }
+  })
+})

--- a/e2e/critical-flows/recruiter-application-lifecycle.spec.ts
+++ b/e2e/critical-flows/recruiter-application-lifecycle.spec.ts
@@ -1,0 +1,131 @@
+import type { Page } from '@playwright/test'
+import { test, expect, selectFactorySelectOption } from '../fixtures'
+
+const JOB_TITLE = 'Recruiter Lifecycle Test Job'
+
+async function advanceToSubmitButton(page: Page) {
+  const submitButton = page.getByRole('button', { name: /submit/i })
+
+  for (let step = 0; step < 3; step += 1) {
+    if (await submitButton.isVisible()) {
+      return submitButton
+    }
+
+    const continueButton = page.getByRole('button', { name: 'Continue' }).first()
+    await expect(continueButton).toBeVisible({ timeout: 10_000 })
+    await expect(continueButton).toBeEnabled()
+    await continueButton.click()
+  }
+
+  await expect(submitButton).toBeVisible({ timeout: 10_000 })
+  return submitButton
+}
+
+test.describe('Recruiter application lifecycle', () => {
+  test('recruiter sees a submitted application and persists a status transition', async ({ authenticatedPage, browser }, testInfo) => {
+    const recruiterPage = authenticatedPage
+    const jobTitle = `${JOB_TITLE} ${Date.now()} r${testInfo.retry}`
+    const applicant = {
+      firstName: 'Lifecycle',
+      lastName: 'Candidate',
+      email: `lifecycle.candidate.${Date.now()}.r${testInfo.retry}@example.com`,
+    }
+    const applicantName = `${applicant.firstName} ${applicant.lastName}`
+
+    await recruiterPage.goto('/dashboard/jobs/new')
+    await recruiterPage.waitForLoadState('networkidle')
+    await recruiterPage.getByLabel('Job title').waitFor({ state: 'visible', timeout: 15_000 })
+    await recruiterPage.getByLabel('Job title').fill(jobTitle)
+
+    await recruiterPage.locator('form').getByRole('button', { name: 'Save & continue' }).first().waitFor({ state: 'attached', timeout: 10_000 })
+    await expect(recruiterPage.locator('form').getByRole('button', { name: 'Save & continue' }).first()).toBeEnabled({ timeout: 10_000 })
+    await recruiterPage.locator('form').getByRole('button', { name: 'Save & continue' }).first().click()
+
+    const resumeRadioGroup = recruiterPage.getByRole('radiogroup', { name: /Resume requirement/i })
+    await resumeRadioGroup.waitFor({ state: 'visible', timeout: 10_000 })
+    await resumeRadioGroup.getByRole('radio', { name: 'Off' }).click()
+
+    await recruiterPage.locator('form').getByRole('button', { name: 'Save & continue' }).first().click()
+    await recruiterPage.locator('form').getByRole('button', { name: 'Save & continue' }).first().waitFor({ state: 'visible', timeout: 10_000 })
+    await recruiterPage.locator('form').getByRole('button', { name: 'Save & continue' }).first().click()
+
+    await expect(recruiterPage.getByRole('heading', { name: /Ready to go\?/i })).toBeVisible({ timeout: 10_000 })
+    const publishButton = recruiterPage.locator('form').getByRole('button', { name: /Publish & copy link/i })
+    await publishButton.waitFor({ state: 'visible', timeout: 10_000 })
+
+    const [publishResponse] = await Promise.all([
+      recruiterPage.waitForResponse(
+        resp => resp.url().includes('/api/jobs') && ['POST', 'PATCH'].includes(resp.request().method()),
+        { timeout: 30_000 },
+      ),
+      publishButton.click(),
+    ])
+    expect([200, 201], `Publish API returned ${publishResponse.status()}`).toContain(publishResponse.status())
+    const publishedJob = await publishResponse.json() as { id: string; slug: string }
+    expect(publishedJob.id, 'published job id must be present').toBeTruthy()
+    expect(publishedJob.slug, 'published job slug must be present').toBeTruthy()
+    await expect(recruiterPage.getByRole('heading', { name: 'Your job is live!' })).toBeVisible({ timeout: 30_000 })
+
+    const candidateContext = await browser.newContext()
+    const candidatePage = await candidateContext.newPage()
+    await candidatePage.goto(`/jobs/${publishedJob.slug}/apply`)
+    await candidatePage.waitForLoadState('networkidle')
+    await candidatePage.getByLabel('First name').fill(applicant.firstName)
+    await candidatePage.getByLabel('Last name').fill(applicant.lastName)
+    await candidatePage.getByLabel('Email').fill(applicant.email)
+    await selectFactorySelectOption(candidatePage, /Country/, 'United States')
+    await selectFactorySelectOption(candidatePage, /State/, 'California')
+
+    const submitButton = await advanceToSubmitButton(candidatePage)
+    const [applyResponse] = await Promise.all([
+      candidatePage.waitForResponse(
+        resp => resp.url().includes(`/api/public/jobs/${publishedJob.slug}/apply`) && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      submitButton.click(),
+    ])
+    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
+    await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}/confirmation`, { waitUntil: 'commit', timeout: 15_000 })
+    await expect(candidatePage.getByRole('heading', { name: 'Application submitted' })).toBeVisible()
+    await candidateContext.close()
+
+    await recruiterPage.goto(`/dashboard/jobs/${publishedJob.id}/candidates`)
+    await recruiterPage.waitForLoadState('networkidle')
+
+    const candidateRow = recruiterPage.getByRole('row').filter({ hasText: applicant.email })
+    await expect(candidateRow).toBeVisible({ timeout: 15_000 })
+    await expect(candidateRow).toContainText(applicantName)
+    await expect(candidateRow).toContainText('New')
+    await candidateRow.getByText(applicantName, { exact: true }).click()
+
+    const drawer = recruiterPage.locator('aside.ui-drawer-panel')
+    await expect(drawer.getByRole('heading', { name: applicantName })).toBeVisible({ timeout: 10_000 })
+    await expect(drawer).toContainText(applicant.email)
+
+    const [statusResponse] = await Promise.all([
+      recruiterPage.waitForResponse(
+        resp => /\/api\/applications\/[^/]+$/.test(new URL(resp.url()).pathname) && resp.request().method() === 'PATCH',
+        { timeout: 30_000 },
+      ),
+      drawer.getByRole('button', { name: 'Screening' }).click(),
+    ])
+    expect(statusResponse.status(), `Status PATCH returned ${statusResponse.status()}`).toBe(200)
+    const updatedApplication = await statusResponse.json() as { id: string; status: string }
+    expect(updatedApplication.status).toBe('screening')
+
+    const applicationListResponse = await recruiterPage.request.get(`/api/applications?jobId=${publishedJob.id}`)
+    expect(applicationListResponse.status(), `Applications API returned ${applicationListResponse.status()}`).toBe(200)
+    const applicationList = await applicationListResponse.json() as { data: Array<{ id: string; status: string; candidateEmail: string }> }
+    expect(applicationList.data).toContainEqual(expect.objectContaining({
+      id: updatedApplication.id,
+      status: 'screening',
+      candidateEmail: applicant.email,
+    }))
+
+    await recruiterPage.reload()
+    await recruiterPage.waitForLoadState('networkidle')
+    const reloadedRow = recruiterPage.getByRole('row').filter({ hasText: applicant.email })
+    await expect(reloadedRow).toBeVisible({ timeout: 15_000 })
+    await expect(reloadedRow).toContainText('Screening')
+  })
+})

--- a/e2e/critical-flows/resume-upload.spec.ts
+++ b/e2e/critical-flows/resume-upload.spec.ts
@@ -1,5 +1,5 @@
-import { type Browser } from '@playwright/test'
-import { test, expect } from '../fixtures'
+import { type Browser, type Page } from '@playwright/test'
+import { test, expect, selectFactorySelectOption } from '../fixtures'
 import {
   VALID_FILE_CONFIGS,
   INVALID_FILE_CONFIGS,
@@ -36,7 +36,27 @@ function applicant(index: number) {
   }
 }
 
+async function advanceToSubmitButton(page: Page) {
+  const submitButton = page.getByRole('button', { name: /submit/i })
+
+  for (let step = 0; step < 3; step += 1) {
+    if (await submitButton.isVisible()) {
+      return submitButton
+    }
+
+    const continueButton = page.getByRole('button', { name: 'Continue' }).first()
+    await expect(continueButton).toBeVisible({ timeout: 10_000 })
+    await expect(continueButton).toBeEnabled()
+    await continueButton.click()
+  }
+
+  await expect(submitButton).toBeVisible({ timeout: 10_000 })
+  return submitButton
+}
+
 test.describe('Resume Upload — Browser Smoke', () => {
+  test.describe.configure({ mode: 'serial' })
+
   // ─────────────────────────────────────────────────────────────────────────
   // One-time setup: create & publish the job
   // ─────────────────────────────────────────────────────────────────────────
@@ -179,19 +199,20 @@ async function assertUploadResult(
   await page.goto(applicationLink)
   await page.waitForLoadState('networkidle')
   await expect(page.getByRole('heading', { name: JOB_TITLE })).toBeVisible({ timeout: 15_000 })
-  await page.getByRole('button', { name: /submit/i }).waitFor({ state: 'visible', timeout: 15_000 })
 
   // ── Fill basic applicant info ──────────────────────────────────────────
-  await page.getByLabel('First name').fill(candidate.firstName)
-  await page.getByLabel('Last name').fill(candidate.lastName)
-  await page.getByLabel('Email').fill(candidate.email)
-  await page.getByLabel('Phone').fill(candidate.phone)
-  await page.getByLabel(/Country/).selectOption({ label: 'United States' })
-  await page.getByLabel(/State/).selectOption({ label: 'California' })
+  await page.getByLabel(/First Name/i).fill(candidate.firstName)
+  await page.getByLabel(/Last Name/i).fill(candidate.lastName)
+  await page.getByLabel(/Email/i).fill(candidate.email)
+  await page.getByLabel(/Phone/i).fill(candidate.phone)
+  await selectFactorySelectOption(page, /Country/, 'United States')
+  await selectFactorySelectOption(page, /State/, 'California')
+  await page.getByRole('button', { name: 'Continue' }).click()
 
   // ── Upload resume (built-in required field) ────────────────────────────
   // Built-in resume: <input id="resume" type="file" ...>
   const resumeInput = page.locator('input#resume[type="file"]')
+  await resumeInput.waitFor({ state: 'attached', timeout: 10_000 })
 
   // Upload the test file directly to the built-in resume input.
   await resumeInput.setInputFiles({
@@ -200,6 +221,7 @@ async function assertUploadResult(
     buffer: fileConfig.buffer,
   })
   await expect(page.getByText(fileConfig.filename)).toBeVisible({ timeout: 5_000 })
+  const submitButton = await advanceToSubmitButton(page)
 
   // ── Submit ─────────────────────────────────────────────────────────────
   const [response] = await Promise.all([
@@ -209,7 +231,7 @@ async function assertUploadResult(
         && resp.request().method() === 'POST',
       { timeout: 30_000 },
     ),
-    page.getByRole('button', { name: /submit/i }).click(),
+    submitButton.click(),
   ])
 
   const status = response.status()

--- a/e2e/critical-flows/sso-domain-provisioning.spec.ts
+++ b/e2e/critical-flows/sso-domain-provisioning.spec.ts
@@ -1,0 +1,160 @@
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { test, expect } from '../fixtures'
+
+type MockOidcIssuer = {
+  issuer: string
+  close: () => Promise<void>
+}
+
+async function startMockOidcIssuer(): Promise<MockOidcIssuer> {
+  let server: Server
+  const port = 3999
+
+  server = createServer((req, res) => {
+    const address = server.address() as AddressInfo
+    const issuer = `http://127.0.0.1:${address.port}`
+
+    if (req.url === '/.well-known/openid-configuration') {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({
+        issuer,
+        authorization_endpoint: `${issuer}/authorize`,
+        token_endpoint: `${issuer}/token`,
+        userinfo_endpoint: `${issuer}/userinfo`,
+        jwks_uri: `${issuer}/jwks`,
+        response_types_supported: ['code'],
+        subject_types_supported: ['public'],
+        id_token_signing_alg_values_supported: ['RS256'],
+      }))
+      return
+    }
+
+    if (req.url?.startsWith('/authorize')) {
+      res.writeHead(200, { 'content-type': 'text/html' })
+      res.end('<main><h1>Mock IdP sign-in</h1></main>')
+      return
+    }
+
+    if (req.url === '/jwks') {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ keys: [] }))
+      return
+    }
+
+    res.writeHead(404)
+    res.end('not found')
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(port, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  const address = server.address() as AddressInfo
+
+  return {
+    issuer: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve())
+    }),
+  }
+}
+
+test.describe('SSO domain provisioning', () => {
+  test('routes configured work domains to local SSO only and rejects unconfigured domains', async ({ authenticatedPage, browser }, testInfo) => {
+    const id = `${Date.now()}-${testInfo.workerIndex}-${Math.random().toString(36).slice(2)}`
+    const providerId = `sso-${id}`
+    const domain = `sso-${id}.example.com`
+    const mockIssuer = await startMockOidcIssuer()
+
+    try {
+      await authenticatedPage.goto('/dashboard/settings/sso')
+      await expect(authenticatedPage.getByRole('heading', { name: 'Single Sign-On' })).toBeVisible()
+      await authenticatedPage.getByRole('button', { name: /Add SSO Provider|Add another provider/ }).click()
+      await authenticatedPage.getByLabel('Email domain').fill(domain)
+      await authenticatedPage.getByLabel('Issuer URL').fill(mockIssuer.issuer)
+      await authenticatedPage.getByLabel('Provider ID').fill(providerId)
+      await authenticatedPage.getByLabel('Client ID').fill(`client-${id}`)
+      await authenticatedPage.getByLabel('Client Secret').fill(`secret-${id}`)
+
+      const [registrationResponse] = await Promise.all([
+        authenticatedPage.waitForResponse(
+          resp => resp.url().includes('/api/sso/providers') && resp.request().method() === 'POST',
+          { timeout: 30_000 },
+        ),
+        authenticatedPage.getByRole('button', { name: 'Register SSO Provider' }).click(),
+      ])
+      expect(
+        registrationResponse.status(),
+        await registrationResponse.text(),
+      ).toBe(201)
+
+      await expect(authenticatedPage.getByRole('heading', { name: providerId })).toBeVisible()
+      await expect(authenticatedPage.getByText(domain, { exact: true })).toBeVisible()
+
+      const callbackUrl = authenticatedPage.getByText(new RegExp(`/api/auth/sso/callback/${providerId}$`))
+      await expect(callbackUrl).toBeVisible()
+      await expect(callbackUrl).toContainText('http://127.0.0.1:3333')
+      await expect(callbackUrl).not.toContainText('thefactoryhq.com')
+
+      const api = authenticatedPage.context().request
+      const localCallback = '/dashboard'
+      const localErrorCallback = '/auth/sign-in'
+      const unconfiguredResponse = await api.post('/api/auth/sign-in/sso', {
+        headers: { origin: 'http://127.0.0.1:3333' },
+        data: {
+          email: `intruder@unconfigured-${id}.example.com`,
+          callbackURL: localCallback,
+          errorCallbackURL: localErrorCallback,
+          providerType: 'oidc',
+        },
+      })
+      expect(unconfiguredResponse.status()).toBe(404)
+
+      const configuredEmail = `owner@${domain}`
+      const configuredResponse = await api.post('/api/auth/sign-in/sso', {
+        headers: { origin: 'http://127.0.0.1:3333' },
+        data: {
+          email: configuredEmail,
+          callbackURL: localCallback,
+          errorCallbackURL: localErrorCallback,
+          providerType: 'oidc',
+        },
+      })
+      expect(configuredResponse.status()).toBe(200)
+      const ssoPayload = await configuredResponse.json()
+      const redirectUrl = new URL(String(ssoPayload.url))
+      expect(redirectUrl.origin).toBe(mockIssuer.issuer)
+      expect(redirectUrl.pathname).toBe('/authorize')
+      expect(redirectUrl.searchParams.get('login_hint')).toBe(configuredEmail)
+      expect(redirectUrl.searchParams.get('redirect_uri')).toBe(`http://127.0.0.1:3333/api/auth/sso/callback/${providerId}`)
+      expect(ssoPayload.url).not.toContain('thefactoryhq.com')
+
+      const signInContext = await browser.newContext({ storageState: { cookies: [], origins: [] } })
+      const signInPage = await signInContext.newPage()
+      await signInPage.goto('/auth/sign-in')
+      await signInPage.waitForLoadState('networkidle')
+      await expect(signInPage).toHaveURL(/\/auth\/sign-in/)
+      await signInPage.getByLabel('Work email').fill(configuredEmail)
+
+      const ssoResponsePromise = signInPage.waitForResponse(
+        resp => resp.url().includes('/api/auth/sign-in/sso') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      )
+
+      await signInPage.getByRole('button', { name: 'Continue with SSO' }).click()
+      const ssoResponse = await ssoResponsePromise
+      expect(ssoResponse.status()).toBe(200)
+
+      await expect(signInPage.getByRole('heading', { name: 'Mock IdP sign-in' })).toBeVisible()
+      await signInContext.close()
+    }
+    finally {
+      await mockIssuer.close()
+    }
+  })
+})

--- a/e2e/critical-flows/tracking-analytics.spec.ts
+++ b/e2e/critical-flows/tracking-analytics.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, selectFactorySelectOption } from '../fixtures'
+
+const JOB_TITLE = 'Tracking Analytics Test Job'
+const LINK_NAME = 'LinkedIn Analytics Campaign'
+const UTM_CAMPAIGN = 'tracking-analytics-e2e'
+
+test.describe('Tracking analytics', () => {
+  test('creates a tracking link and reflects tracked applications in recruiter analytics UI', async ({ authenticatedPage, browser }, testInfo) => {
+    const page = authenticatedPage
+    const unique = `${Date.now()}-r${testInfo.retry}`
+    const jobTitle = `${JOB_TITLE} ${unique}`
+    const linkName = `${LINK_NAME} ${unique}`
+    const applicant = {
+      firstName: 'Tracked',
+      lastName: 'Applicant',
+      email: `tracked.applicant.${unique}@example.com`,
+    }
+    const applicantName = `${applicant.firstName} ${applicant.lastName}`
+
+    await page.addInitScript(() => {
+      const copiedUrls: string[] = []
+      Object.defineProperty(window, '__copiedTrackingUrls', {
+        value: copiedUrls,
+        configurable: true,
+      })
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {
+          writeText: async (text: string) => {
+            copiedUrls.push(text)
+          },
+        },
+        configurable: true,
+      })
+    })
+
+    const createJobResponse = await page.request.post('/api/jobs', {
+      data: {
+        title: jobTitle,
+        description: 'A fast E2E job for tracking-link analytics.',
+        location: 'Remote',
+        requireResume: false,
+        requireCoverLetter: false,
+        applicationComplianceEnabled: false,
+        autoScoreOnApply: false,
+      },
+    })
+    expect(createJobResponse.status(), `Create job API returned ${createJobResponse.status()}`).toBe(201)
+    const createdJob = await createJobResponse.json() as { id: string; slug: string }
+    expect(createdJob.id, 'created job id must be present').toBeTruthy()
+    expect(createdJob.slug, 'created job slug must be present').toBeTruthy()
+
+    const publishJobResponse = await page.request.patch(`/api/jobs/${createdJob.id}`, {
+      data: { status: 'open' },
+    })
+    expect(publishJobResponse.status(), `Publish job API returned ${publishJobResponse.status()}`).toBe(200)
+    const publishedJob = await publishJobResponse.json() as { id: string; slug: string; status: string }
+    expect(publishedJob.status).toBe('open')
+
+    await page.goto('/dashboard/source-tracking?tab=links')
+    await expect(page.getByRole('heading', { name: 'Tracking', exact: true })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('button', { name: /New Link|Create Tracking Link/ }).first().click()
+    await expect(page.getByRole('heading', { name: 'Create Tracking Link' })).toBeVisible()
+    await page.getByLabel('Link Name').fill(linkName)
+    await selectFactorySelectOption(page, /Source Channel/, 'LinkedIn')
+    await page.getByText('UTM Parameters (optional)').click()
+    await page.getByLabel('utm_source').fill('linkedin')
+    await page.getByLabel('utm_medium').fill('social')
+    await page.getByLabel('utm_campaign').fill(UTM_CAMPAIGN)
+
+    const [createLinkResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/tracking-links') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.locator('form').getByRole('button', { name: 'Create Link' }).click(),
+    ])
+    expect(createLinkResponse.status(), `Create link API returned ${createLinkResponse.status()}`).toBe(201)
+    const trackingLink = await createLinkResponse.json() as { id: string; code: string }
+    expect(trackingLink.id, 'tracking link id must be present').toBeTruthy()
+    expect(trackingLink.code, 'tracking link code must be present').toBeTruthy()
+    await expect(page.getByRole('heading', { name: 'Create Tracking Link' })).toBeHidden({ timeout: 10_000 })
+
+    await page.getByRole('button', { name: 'Tracking Links' }).click()
+    const linkRow = page.getByRole('row').filter({ hasText: linkName })
+    await expect(linkRow).toBeVisible({ timeout: 15_000 })
+    await expect(linkRow).toContainText('?ref=')
+
+    await linkRow.getByRole('button', { name: 'Copy tracking URL' }).click()
+    const copiedUrls = await page.evaluate(() => (window as any).__copiedTrackingUrls as string[])
+    expect(copiedUrls.at(-1)).toContain(`/api/public/track/${encodeURIComponent(trackingLink.code)}`)
+
+    const candidateContext = await browser.newContext()
+    const candidatePage = await candidateContext.newPage()
+    await candidatePage.goto(`/api/public/track/${trackingLink.code}`)
+    await candidatePage.waitForURL('**/jobs?ref=*', { waitUntil: 'commit', timeout: 15_000 })
+    expect(new URL(candidatePage.url()).searchParams.get('ref')).toBe(trackingLink.code)
+
+    await candidatePage.getByRole('link', { name: jobTitle }).first().click()
+    await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}**`, { waitUntil: 'commit', timeout: 15_000 })
+    await candidatePage.getByRole('link', { name: 'Apply Now' }).first().click()
+    await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}/apply**`, { waitUntil: 'commit', timeout: 15_000 })
+    expect(new URL(candidatePage.url()).searchParams.get('ref')).toBe(trackingLink.code)
+
+    const applyResponse = await candidatePage.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
+      data: {
+        firstName: applicant.firstName,
+        lastName: applicant.lastName,
+        email: applicant.email,
+        country: 'United States',
+        state: 'CA',
+        ref: trackingLink.code,
+        utmSource: 'linkedin',
+        utmMedium: 'social',
+        utmCampaign: UTM_CAMPAIGN,
+        responses: [],
+      },
+    })
+    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
+
+    await expect.poll(async () => {
+      const response = await page.request.get(`/api/tracking-links/${trackingLink.id}`)
+      expect(response.status(), `Tracking link API returned ${response.status()}`).toBe(200)
+      const current = await response.json() as { clickCount: number; applicationCount: number }
+      return current
+    }, {
+      message: 'tracking link counters should include the click and submitted application',
+      timeout: 10_000,
+    }).toEqual(expect.objectContaining({ clickCount: 1, applicationCount: 1 }))
+
+    await page.goto('/dashboard/source-tracking?tab=links')
+    const updatedLinkRow = page.getByRole('row').filter({ hasText: linkName })
+    await expect(updatedLinkRow).toBeVisible({ timeout: 15_000 })
+    await expect(updatedLinkRow.locator('td').nth(3)).toHaveText('1')
+    await expect(updatedLinkRow.locator('td').nth(4)).toHaveText('1')
+    await expect(updatedLinkRow.locator('td').nth(5)).toHaveText('100%')
+
+    await page.getByRole('button', { name: 'Attribution Log' }).click()
+    const attributionRow = page.getByRole('row').filter({ hasText: applicantName })
+    await expect(attributionRow).toBeVisible({ timeout: 15_000 })
+    await expect(attributionRow).toContainText(jobTitle)
+    await expect(attributionRow).toContainText('LinkedIn')
+    await expect(attributionRow).toContainText(`via ${linkName}`)
+
+    await candidateContext.close()
+  })
+})

--- a/e2e/critical-flows/tracking-analytics.spec.ts
+++ b/e2e/critical-flows/tracking-analytics.spec.ts
@@ -127,6 +127,30 @@ test.describe('Tracking analytics', () => {
       timeout: 10_000,
     }).toEqual(expect.objectContaining({ clickCount: 1, applicationCount: 1 }))
 
+    await expect.poll(async () => {
+      const response = await page.request.get('/api/source-tracking/stats')
+      expect(response.status(), `Source stats API returned ${response.status()}`).toBe(200)
+      const stats = await response.json() as {
+        recentAttributed: {
+          candidateFirstName: string
+          candidateLastName: string
+          candidateEmail: string
+          jobTitle: string
+          trackingLinkName: string | null
+        }[]
+      }
+      return stats.recentAttributed.some(row =>
+        row.candidateFirstName === applicant.firstName
+        && row.candidateLastName === applicant.lastName
+        && row.candidateEmail === applicant.email
+        && row.jobTitle === jobTitle
+        && row.trackingLinkName === linkName
+      )
+    }, {
+      message: 'source tracking stats should expose the attributed application before the UI assertion',
+      timeout: 15_000,
+    }).toBe(true)
+
     await page.goto('/dashboard/source-tracking?tab=links')
     const updatedLinkRow = page.getByRole('row').filter({ hasText: linkName })
     await expect(updatedLinkRow).toBeVisible({ timeout: 15_000 })

--- a/e2e/critical-flows/tracking-analytics.spec.ts
+++ b/e2e/critical-flows/tracking-analytics.spec.ts
@@ -134,7 +134,7 @@ test.describe('Tracking analytics', () => {
     await expect(updatedLinkRow.locator('td').nth(4)).toHaveText('1')
     await expect(updatedLinkRow.locator('td').nth(5)).toHaveText('100%')
 
-    await page.getByRole('button', { name: 'Attribution Log' }).click()
+    await page.goto('/dashboard/source-tracking?tab=table')
     const attributionRow = page.getByRole('row').filter({ hasText: applicantName })
     await expect(attributionRow).toBeVisible({ timeout: 15_000 })
     await expect(attributionRow).toContainText(jobTitle)

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts",
     "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",
     "test:e2e:rbac": "playwright test e2e/critical-flows/rbac-role-permissions.spec.ts",
+    "test:e2e:sso": "playwright test e2e/critical-flows/sso-domain-provisioning.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts",
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
-    "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts",
+    "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts --workers=1",
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts",
     "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:e2e:smoke": "playwright test e2e/critical-flows/job-creation.spec.ts e2e/critical-flows/source-tracking.spec.ts",
     "test:e2e:uploads": "playwright test e2e/critical-flows/resume-upload.spec.ts",
     "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
+    "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts",
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts",
+    "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts",
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
     "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts",
+    "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
     "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts",
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
+    "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",
     "test:e2e:rbac": "playwright test e2e/critical-flows/rbac-role-permissions.spec.ts",
     "test:e2e:sso": "playwright test e2e/critical-flows/sso-domain-provisioning.spec.ts",
+    "test:e2e:ai-review": "playwright test e2e/critical-flows/ai-candidate-review.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts",
     "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",
+    "test:e2e:rbac": "playwright test e2e/critical-flows/rbac-role-permissions.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
     "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts e2e/critical-flows/auth-recovery-fake-mail.spec.ts --workers=1",
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
-    "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts",
+    "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts e2e/critical-flows/interview-invitation-response.spec.ts --workers=1",
     "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",
     "test:e2e:rbac": "playwright test e2e/critical-flows/rbac-role-permissions.spec.ts",
     "test:e2e:sso": "playwright test e2e/critical-flows/sso-domain-provisioning.spec.ts",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts",
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
-    "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts --workers=1",
+    "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts e2e/critical-flows/auth-recovery-fake-mail.spec.ts --workers=1",
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts",
     "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:e2e": "npx playwright test",
     "test:e2e:smoke": "playwright test e2e/critical-flows/job-creation.spec.ts e2e/critical-flows/source-tracking.spec.ts",
     "test:e2e:uploads": "playwright test e2e/critical-flows/resume-upload.spec.ts",
+    "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:e2e:uploads": "playwright test e2e/critical-flows/resume-upload.spec.ts",
     "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts",
+    "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts",
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
+    "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,20 @@
 import { defineConfig, devices } from '@playwright/test'
 
+function shellEnv(name: string, value: string | undefined) {
+  return value ? `${name}=${JSON.stringify(value)}` : ''
+}
+
+const webServerEnv = [
+  'BETTER_AUTH_URL=http://127.0.0.1:3333',
+  'NUXT_PUBLIC_SITE_URL=http://127.0.0.1:3333',
+  'FACTORY_DISABLE_PUBLIC_SIGNUP=false',
+  'FACTORY_DISABLE_PUBLIC_ORG_CREATION=false',
+  'FEATURE_FLAG_CHATBOT_EXPERIENCE=true',
+  shellEnv('FACTORY_EMAIL_TEST_MODE', process.env.FACTORY_EMAIL_TEST_MODE),
+  shellEnv('FACTORY_EMAIL_CAPTURE_PATH', process.env.FACTORY_EMAIL_CAPTURE_PATH),
+  shellEnv('FACTORY_CAREERS_HIRING_INBOX', process.env.FACTORY_CAREERS_HIRING_INBOX),
+].filter(Boolean).join(' ')
+
 /**
  * Playwright E2E configuration for Reqcore.
  *
@@ -46,7 +61,7 @@ export default defineConfig({
     ? {}
     : {
         webServer: {
-          command: 'BETTER_AUTH_URL=http://127.0.0.1:3333 NUXT_PUBLIC_SITE_URL=http://127.0.0.1:3333 FACTORY_DISABLE_PUBLIC_SIGNUP=false FACTORY_DISABLE_PUBLIC_ORG_CREATION=false FEATURE_FLAG_CHATBOT_EXPERIENCE=true npm run db:migrate && BETTER_AUTH_URL=http://127.0.0.1:3333 NUXT_PUBLIC_SITE_URL=http://127.0.0.1:3333 FACTORY_DISABLE_PUBLIC_SIGNUP=false FACTORY_DISABLE_PUBLIC_ORG_CREATION=false FEATURE_FLAG_CHATBOT_EXPERIENCE=true npx nuxt dev --port 3333 --host 127.0.0.1',
+          command: `${webServerEnv} npm run db:migrate && ${webServerEnv} npx nuxt dev --port 3333 --host 127.0.0.1`,
           url: 'http://127.0.0.1:3333',
           reuseExistingServer: true,
           timeout: process.env.CI ? 120_000 : 60_000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,7 @@ function shellEnv(name: string, value: string | undefined) {
 
 const webServerEnv = [
   'BETTER_AUTH_URL=http://127.0.0.1:3333',
+  'BETTER_AUTH_TRUSTED_ORIGINS=http://127.0.0.1:3333,http://127.0.0.1:3999',
   'NUXT_PUBLIC_SITE_URL=http://127.0.0.1:3333',
   'FACTORY_DISABLE_PUBLIC_SIGNUP=false',
   'FACTORY_DISABLE_PUBLIC_ORG_CREATION=false',

--- a/scripts/validate-production-env.mjs
+++ b/scripts/validate-production-env.mjs
@@ -465,6 +465,16 @@ function checkRateLimitOverrides(env, errors, warnings) {
   }
 }
 
+function checkTestModes(env, errors) {
+  if (trimValue(env.FACTORY_EMAIL_TEST_MODE) === 'capture') {
+    errors.push(issue('FACTORY_EMAIL_TEST_MODE', 'capture mode is not allowed in production'))
+  }
+
+  if (trimValue(env.FACTORY_AI_TEST_MODE) === 'mock') {
+    errors.push(issue('FACTORY_AI_TEST_MODE', 'mock mode is not allowed in production'))
+  }
+}
+
 export function validateProductionEnv(input) {
   const env = Object.fromEntries(
     Object.entries(input ?? {}).map(([key, value]) => [key, trimValue(value)]),
@@ -481,6 +491,7 @@ export function validateProductionEnv(input) {
   checkEmail(env, errors, warnings)
   checkTelemetry(env, errors, warnings)
   checkRateLimitOverrides(env, errors, warnings)
+  checkTestModes(env, errors)
 
   return {
     ok: errors.length === 0,

--- a/server/api/public/jobs/[slug]/apply.post.ts
+++ b/server/api/public/jobs/[slug]/apply.post.ts
@@ -705,7 +705,7 @@ export default defineEventHandler(async (event) => {
     const candidateName = `${firstName} ${lastName}`.trim()
     const applicationUrl = `${resolveFactoryCareersBaseUrl()}/dashboard/applications/${newApplication.id}`
 
-    void sendApplicationReceiptEmail({
+    const receiptEmail = sendApplicationReceiptEmail({
       candidateEmail: email.toLowerCase(),
       candidateName,
       jobTitle: existingJob.title,
@@ -718,7 +718,7 @@ export default defineEventHandler(async (event) => {
       })
     })
 
-    void sendApplicationTeamAlertEmail({
+    const teamAlertEmail = sendApplicationTeamAlertEmail({
       candidateEmail: email.toLowerCase(),
       candidateName,
       jobTitle: existingJob.title,
@@ -731,6 +731,10 @@ export default defineEventHandler(async (event) => {
         error_message: err instanceof Error ? err.message : String(err),
       })
     })
+
+    if (env.FACTORY_EMAIL_TEST_MODE === 'capture') {
+      await Promise.all([receiptEmail, teamAlertEmail])
+    }
   }
 
   // ─────────────────────────────────────────────

--- a/server/lib/email/client.ts
+++ b/server/lib/email/client.ts
@@ -1,15 +1,155 @@
 import { createEmailClient } from "@caffeinebounce/email";
+import { render } from "@react-email/render";
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { ReactNode } from "react";
 
 import { env } from "../../utils/env";
+
+type EmailClient = ReturnType<typeof createEmailClient>;
+type EmailSendPayload = Parameters<EmailClient["send"]>[0] & {
+  html?: string;
+  text?: string;
+  react?: ReactNode;
+};
+
+function normalizeRecipients(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map(String);
+  }
+
+  if (typeof value === "string") {
+    return [value];
+  }
+
+  return [];
+}
+
+function serializeReactPayload(value: unknown): string {
+  const seen = new WeakSet<object>();
+
+  return JSON.stringify(value, (key, nestedValue) => {
+    if (key === "_owner" || key === "_store") {
+      return undefined;
+    }
+
+    if (typeof nestedValue === "function") {
+      return `[function ${nestedValue.name || "anonymous"}]`;
+    }
+
+    if (typeof nestedValue === "symbol") {
+      return nestedValue.toString();
+    }
+
+    if (typeof nestedValue === "object" && nestedValue !== null) {
+      if (seen.has(nestedValue)) {
+        return "[circular]";
+      }
+      seen.add(nestedValue);
+    }
+
+    return nestedValue;
+  });
+}
+
+async function renderEmailPayload(payload: EmailSendPayload): Promise<{
+  html: string;
+  text: string;
+  renderError?: string;
+}> {
+  if (!payload.react) {
+    return {
+      html: payload.html ?? "",
+      text: payload.text ?? payload.html ?? "",
+    };
+  }
+
+  try {
+    const html = payload.html ?? await render(payload.react);
+    const text = payload.text ?? await render(payload.react, { plainText: true });
+    return { html, text };
+  } catch (error) {
+    const fallback = serializeReactPayload(payload.react);
+
+    return {
+      html: payload.html ?? fallback,
+      text: payload.text ?? fallback,
+      renderError: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+const FALLBACK_FROM = "Factory <hello@interviews.thefactoryhq.com>";
+
+function resolveDefaultFrom(): string {
+  return env.EMAIL_FROM || env.RESEND_FROM_EMAIL || FALLBACK_FROM;
+}
+
+function createCaptureEmailClient(defaultFrom: string): EmailClient {
+  const capturePath = env.FACTORY_EMAIL_CAPTURE_PATH;
+  if (!capturePath) {
+    throw new Error("FACTORY_EMAIL_CAPTURE_PATH is required when FACTORY_EMAIL_TEST_MODE=capture");
+  }
+
+  return {
+    resend: null,
+    defaultFrom,
+    send: (async (payload: EmailSendPayload) => {
+      const { html, text, renderError } = await renderEmailPayload(payload);
+      const captured = {
+        id: `capture_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+        createdAt: new Date().toISOString(),
+        from: payload.from ?? defaultFrom,
+        to: normalizeRecipients(payload.to),
+        subject: payload.subject ?? "",
+        html,
+        text,
+        renderError,
+        attachments: Array.isArray(payload.attachments)
+          ? payload.attachments.map((attachment) => ({
+              filename: typeof attachment === "object" && attachment !== null && "filename" in attachment
+                ? String(attachment.filename)
+                : undefined,
+              contentType: typeof attachment === "object" && attachment !== null && "contentType" in attachment
+                ? String(attachment.contentType)
+                : undefined,
+            }))
+          : [],
+      };
+
+      await mkdir(dirname(capturePath), { recursive: true });
+      await appendFile(capturePath, `${JSON.stringify(captured)}\n`, "utf8");
+
+      return {
+        data: { id: captured.id },
+        error: null,
+        headers: null,
+      };
+    }) as EmailClient["send"],
+  };
+}
 
 /**
  * Shared Resend-backed email client (same infrastructure as thefactoryhq.com main site).
  * Initialized once; falls back gracefully when RESEND_API_KEY is absent (dev / console mode).
  */
-export const emailClient = createEmailClient({
+const resendEmailClient = createEmailClient({
   apiKey: env.RESEND_API_KEY,
-  defaultFrom:
-    env.EMAIL_FROM ||
-    env.RESEND_FROM_EMAIL ||
-    "Factory <hello@interviews.thefactoryhq.com>",
+  defaultFrom: resolveDefaultFrom(),
 });
+
+export const emailClient: EmailClient = {
+  get resend() {
+    return resendEmailClient.resend;
+  },
+  get defaultFrom() {
+    return resolveDefaultFrom();
+  },
+  send: (async (...args: Parameters<EmailClient["send"]>) => {
+    if (env.FACTORY_EMAIL_TEST_MODE === "capture") {
+      return createCaptureEmailClient(resolveDefaultFrom()).send(...args);
+    }
+
+    return resendEmailClient.send(...args);
+  }) as EmailClient["send"],
+};

--- a/server/lib/email/templates.tsx
+++ b/server/lib/email/templates.tsx
@@ -16,6 +16,8 @@ import {
 import type { ReactNode } from "react";
 import { careersEmailConfig, careersEmailStyles as styles } from "./theme";
 
+const h = React.createElement;
+
 type EmailCta = {
   href: string;
   text: string;

--- a/server/utils/ai/provider.ts
+++ b/server/utils/ai/provider.ts
@@ -5,6 +5,7 @@
  * Credentials are decrypted per-request from the organization's AI config.
  * Never logs or stores raw API keys — only encrypted values in the database.
  */
+import { appendFile } from 'node:fs/promises'
 import { createOpenAI } from '@ai-sdk/openai'
 import { createAnthropic } from '@ai-sdk/anthropic'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
@@ -221,6 +222,45 @@ export async function generateStructuredOutput<T>(
     schemaDescription?: string
   },
 ): Promise<{ object: T; usage: { promptTokens: number; completionTokens: number } }> {
+  if (env.FACTORY_AI_TEST_MODE === 'mock') {
+    if (env.FACTORY_AI_CAPTURE_PATH) {
+      await appendFile(
+        env.FACTORY_AI_CAPTURE_PATH,
+        `${JSON.stringify({
+          provider: config.provider,
+          model: config.model,
+          schemaName: options.schemaName,
+          system: options.system,
+          prompt: options.prompt,
+        })}\n`,
+        'utf8',
+      )
+    }
+
+    if (options.schemaName === 'CandidateScoring') {
+      return {
+        object: {
+          evaluations: [{
+            criterionKey: 'domain_relevance',
+            maxScore: 10,
+            applicantScore: 9,
+            confidence: 96,
+            evidence: 'The resume cites work with athletes, entertainers, founders, media, and investments.',
+            strengths: ['Direct Factory-domain client experience is present.'],
+            gaps: ['No material gaps were identified in the provided E2E fixture.'],
+          }],
+          summary: 'Deterministic E2E review: strong Factory-domain alignment for this candidate.',
+        } as T,
+        usage: { promptTokens: 101, completionTokens: 29 },
+      }
+    }
+
+    throw createError({
+      statusCode: 422,
+      statusMessage: `No deterministic AI mock response configured for schema: ${options.schemaName}`,
+    })
+  }
+
   if (config.baseUrl) {
     await assertSafeServerSideUrl(config.baseUrl)
   }

--- a/server/utils/env.ts
+++ b/server/utils/env.ts
@@ -163,6 +163,15 @@ export const envSchema = z
     /** JSONL path used by FACTORY_EMAIL_TEST_MODE=capture. */
     FACTORY_EMAIL_CAPTURE_PATH: emptyToUndefined.pipe(z.string().min(1)).optional(),
     /**
+     * Test-only AI provider mode for E2E. When set to "mock", structured AI
+     * requests return deterministic local objects and never contact a provider.
+     */
+    FACTORY_AI_TEST_MODE: z
+      .preprocess((val) => (typeof val === "string" && val.trim() === "" ? undefined : val), z.enum(["mock"]))
+      .optional(),
+    /** JSONL path used by FACTORY_AI_TEST_MODE=mock to inspect prompt context. */
+    FACTORY_AI_CAPTURE_PATH: emptyToUndefined.pipe(z.string().min(1)).optional(),
+    /**
      * Secret used to sign unsubscribe links in marketing emails (via @caffeinebounce/email).
      * Required in production for the email system.
      */
@@ -336,6 +345,24 @@ export const envSchema = z
       }
     }
 
+    if (data.FACTORY_AI_TEST_MODE === "mock") {
+      if (process.env.NODE_ENV === "production") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["FACTORY_AI_TEST_MODE"],
+          message: "FACTORY_AI_TEST_MODE=mock is not allowed in production.",
+        });
+      }
+
+      if (!data.FACTORY_AI_CAPTURE_PATH) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["FACTORY_AI_CAPTURE_PATH"],
+          message: "FACTORY_AI_CAPTURE_PATH is required when FACTORY_AI_TEST_MODE=mock.",
+        });
+      }
+    }
+
     // OIDC SSO requires all three vars or none — partial config is a misconfiguration.
     const oidcVars = [
       ["OIDC_CLIENT_ID", data.OIDC_CLIENT_ID],
@@ -438,7 +465,7 @@ export const env = new Proxy({} as z.infer<typeof envSchema>, {
             `Ensure these variables are set in the Render web service environment.\n` +
             `Required: DATABASE_URL, BETTER_AUTH_SECRET, S3_ENDPOINT, S3_ACCESS_KEY, S3_SECRET_KEY, S3_BUCKET\n` +
             `Required on Render: BETTER_AUTH_URL=https://careers.thefactoryhq.com\n` +
-            `Optional: BETTER_AUTH_TRUSTED_ORIGINS, S3_REGION (default: us-east-1), S3_FORCE_PATH_STYLE (default: true), S3_SKIP_BUCKET_POLICY, S3_SKIP_BUCKET_INIT, SKIP_RUNTIME_MIGRATIONS, TRUSTED_PROXY_IP, DEMO_ORG_SLUG, RESEND_API_KEY, RESEND_FROM_EMAIL, EMAIL_FROM, FACTORY_EMAIL_TEST_MODE, FACTORY_EMAIL_CAPTURE_PATH, SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM, SMTP_SECURE, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, MICROSOFT_CALENDAR_AUTH_MODE, MICROSOFT_CALENDAR_CLIENT_ID, MICROSOFT_CALENDAR_CLIENT_SECRET, MICROSOFT_CALENDAR_TENANT_ID, FACTORY_CAREERS_CALENDAR_SYNC_SHARED, FACTORY_CAREERS_CALENDAR_USER_EMAILS, FACTORY_CAREERS_CALENDAR_SYNC_INTERVIEWERS, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL, OIDC_PROVIDER_NAME, AUTH_GOOGLE_CLIENT_ID, AUTH_GOOGLE_CLIENT_SECRET, AUTH_GITHUB_CLIENT_ID, AUTH_GITHUB_CLIENT_SECRET, AUTH_MICROSOFT_CLIENT_ID, AUTH_MICROSOFT_CLIENT_SECRET, AUTH_MICROSOFT_TENANT_ID, FACTORY_CAREERS_HIRING_INBOX, FACTORY_CAREERS_PRIVACY_INBOX, FACTORY_CAREERS_CLI_CLIENT_ID, FACTORY_ALLOWED_EMAIL_DOMAINS, FACTORY_INITIAL_OWNER_EMAILS\n`,
+            `Optional: BETTER_AUTH_TRUSTED_ORIGINS, S3_REGION (default: us-east-1), S3_FORCE_PATH_STYLE (default: true), S3_SKIP_BUCKET_POLICY, S3_SKIP_BUCKET_INIT, SKIP_RUNTIME_MIGRATIONS, TRUSTED_PROXY_IP, DEMO_ORG_SLUG, RESEND_API_KEY, RESEND_FROM_EMAIL, EMAIL_FROM, FACTORY_EMAIL_TEST_MODE, FACTORY_EMAIL_CAPTURE_PATH, FACTORY_AI_TEST_MODE, FACTORY_AI_CAPTURE_PATH, SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM, SMTP_SECURE, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, MICROSOFT_CALENDAR_AUTH_MODE, MICROSOFT_CALENDAR_CLIENT_ID, MICROSOFT_CALENDAR_CLIENT_SECRET, MICROSOFT_CALENDAR_TENANT_ID, FACTORY_CAREERS_CALENDAR_SYNC_SHARED, FACTORY_CAREERS_CALENDAR_USER_EMAILS, FACTORY_CAREERS_CALENDAR_SYNC_INTERVIEWERS, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL, OIDC_PROVIDER_NAME, AUTH_GOOGLE_CLIENT_ID, AUTH_GOOGLE_CLIENT_SECRET, AUTH_GITHUB_CLIENT_ID, AUTH_GITHUB_CLIENT_SECRET, AUTH_MICROSOFT_CLIENT_ID, AUTH_MICROSOFT_CLIENT_SECRET, AUTH_MICROSOFT_TENANT_ID, FACTORY_CAREERS_HIRING_INBOX, FACTORY_CAREERS_PRIVACY_INBOX, FACTORY_CAREERS_CLI_CLIENT_ID, FACTORY_ALLOWED_EMAIL_DOMAINS, FACTORY_INITIAL_OWNER_EMAILS\n`,
         );
         throw result.error;
       }

--- a/server/utils/env.ts
+++ b/server/utils/env.ts
@@ -154,6 +154,15 @@ export const envSchema = z
      */
     EMAIL_FROM: emptyToUndefined.pipe(z.string().min(1)).optional(),
     /**
+     * Test-only email capture mode for E2E. When set to "capture", messages are
+     * written to FACTORY_EMAIL_CAPTURE_PATH instead of contacting Resend.
+     */
+    FACTORY_EMAIL_TEST_MODE: z
+      .preprocess((val) => (typeof val === "string" && val.trim() === "" ? undefined : val), z.enum(["capture"]))
+      .optional(),
+    /** JSONL path used by FACTORY_EMAIL_TEST_MODE=capture. */
+    FACTORY_EMAIL_CAPTURE_PATH: emptyToUndefined.pipe(z.string().min(1)).optional(),
+    /**
      * Secret used to sign unsubscribe links in marketing emails (via @caffeinebounce/email).
      * Required in production for the email system.
      */
@@ -309,6 +318,24 @@ export const envSchema = z
       })
     }
 
+    if (data.FACTORY_EMAIL_TEST_MODE === "capture") {
+      if (process.env.NODE_ENV === "production") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["FACTORY_EMAIL_TEST_MODE"],
+          message: "FACTORY_EMAIL_TEST_MODE=capture is not allowed in production.",
+        });
+      }
+
+      if (!data.FACTORY_EMAIL_CAPTURE_PATH) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["FACTORY_EMAIL_CAPTURE_PATH"],
+          message: "FACTORY_EMAIL_CAPTURE_PATH is required when FACTORY_EMAIL_TEST_MODE=capture.",
+        });
+      }
+    }
+
     // OIDC SSO requires all three vars or none — partial config is a misconfiguration.
     const oidcVars = [
       ["OIDC_CLIENT_ID", data.OIDC_CLIENT_ID],
@@ -411,7 +438,7 @@ export const env = new Proxy({} as z.infer<typeof envSchema>, {
             `Ensure these variables are set in the Render web service environment.\n` +
             `Required: DATABASE_URL, BETTER_AUTH_SECRET, S3_ENDPOINT, S3_ACCESS_KEY, S3_SECRET_KEY, S3_BUCKET\n` +
             `Required on Render: BETTER_AUTH_URL=https://careers.thefactoryhq.com\n` +
-            `Optional: BETTER_AUTH_TRUSTED_ORIGINS, S3_REGION (default: us-east-1), S3_FORCE_PATH_STYLE (default: true), S3_SKIP_BUCKET_POLICY, S3_SKIP_BUCKET_INIT, SKIP_RUNTIME_MIGRATIONS, TRUSTED_PROXY_IP, DEMO_ORG_SLUG, RESEND_API_KEY, RESEND_FROM_EMAIL, SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM, SMTP_SECURE, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, MICROSOFT_CALENDAR_AUTH_MODE, MICROSOFT_CALENDAR_CLIENT_ID, MICROSOFT_CALENDAR_CLIENT_SECRET, MICROSOFT_CALENDAR_TENANT_ID, FACTORY_CAREERS_CALENDAR_SYNC_SHARED, FACTORY_CAREERS_CALENDAR_USER_EMAILS, FACTORY_CAREERS_CALENDAR_SYNC_INTERVIEWERS, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL, OIDC_PROVIDER_NAME, AUTH_GOOGLE_CLIENT_ID, AUTH_GOOGLE_CLIENT_SECRET, AUTH_GITHUB_CLIENT_ID, AUTH_GITHUB_CLIENT_SECRET, AUTH_MICROSOFT_CLIENT_ID, AUTH_MICROSOFT_CLIENT_SECRET, AUTH_MICROSOFT_TENANT_ID, FACTORY_CAREERS_HIRING_INBOX, FACTORY_CAREERS_PRIVACY_INBOX, FACTORY_CAREERS_CLI_CLIENT_ID, FACTORY_ALLOWED_EMAIL_DOMAINS, FACTORY_INITIAL_OWNER_EMAILS\n`,
+            `Optional: BETTER_AUTH_TRUSTED_ORIGINS, S3_REGION (default: us-east-1), S3_FORCE_PATH_STYLE (default: true), S3_SKIP_BUCKET_POLICY, S3_SKIP_BUCKET_INIT, SKIP_RUNTIME_MIGRATIONS, TRUSTED_PROXY_IP, DEMO_ORG_SLUG, RESEND_API_KEY, RESEND_FROM_EMAIL, EMAIL_FROM, FACTORY_EMAIL_TEST_MODE, FACTORY_EMAIL_CAPTURE_PATH, SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM, SMTP_SECURE, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, MICROSOFT_CALENDAR_AUTH_MODE, MICROSOFT_CALENDAR_CLIENT_ID, MICROSOFT_CALENDAR_CLIENT_SECRET, MICROSOFT_CALENDAR_TENANT_ID, FACTORY_CAREERS_CALENDAR_SYNC_SHARED, FACTORY_CAREERS_CALENDAR_USER_EMAILS, FACTORY_CAREERS_CALENDAR_SYNC_INTERVIEWERS, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL, OIDC_PROVIDER_NAME, AUTH_GOOGLE_CLIENT_ID, AUTH_GOOGLE_CLIENT_SECRET, AUTH_GITHUB_CLIENT_ID, AUTH_GITHUB_CLIENT_SECRET, AUTH_MICROSOFT_CLIENT_ID, AUTH_MICROSOFT_CLIENT_SECRET, AUTH_MICROSOFT_TENANT_ID, FACTORY_CAREERS_HIRING_INBOX, FACTORY_CAREERS_PRIVACY_INBOX, FACTORY_CAREERS_CLI_CLIENT_ID, FACTORY_ALLOWED_EMAIL_DOMAINS, FACTORY_INITIAL_OWNER_EMAILS\n`,
         );
         throw result.error;
       }

--- a/tests/unit/ai-test-mode-env.test.ts
+++ b/tests/unit/ai-test-mode-env.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { envSchema } from '../../server/utils/env'
+
+const baseEnv = {
+  DATABASE_URL: 'postgresql://user:pass@localhost:5432/test',
+  BETTER_AUTH_SECRET: 'a'.repeat(32),
+  BETTER_AUTH_URL: 'https://app.example.com',
+  S3_ENDPOINT: 'https://s3.example.com',
+  S3_ACCESS_KEY: 'test-key',
+  S3_SECRET_KEY: 'test-secret',
+  S3_BUCKET: 'test-bucket',
+}
+
+describe('AI E2E test-mode environment safety', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('accepts deterministic mock mode when a capture path is configured outside production', () => {
+    vi.stubEnv('NODE_ENV', 'test')
+
+    const result = envSchema.safeParse({
+      ...baseEnv,
+      FACTORY_AI_TEST_MODE: 'mock',
+      FACTORY_AI_CAPTURE_PATH: '/tmp/factory-careers-e2e-ai.jsonl',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('requires a capture path for deterministic mock mode', () => {
+    vi.stubEnv('NODE_ENV', 'test')
+
+    const result = envSchema.safeParse({
+      ...baseEnv,
+      FACTORY_AI_TEST_MODE: 'mock',
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues.map(issue => issue.message)).toContain(
+        'FACTORY_AI_CAPTURE_PATH is required when FACTORY_AI_TEST_MODE=mock.',
+      )
+    }
+  })
+
+  it('rejects deterministic mock mode in production', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+
+    const result = envSchema.safeParse({
+      ...baseEnv,
+      FACTORY_AI_TEST_MODE: 'mock',
+      FACTORY_AI_CAPTURE_PATH: '/tmp/factory-careers-e2e-ai.jsonl',
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues.map(issue => issue.message)).toContain(
+        'FACTORY_AI_TEST_MODE=mock is not allowed in production.',
+      )
+    }
+  })
+})

--- a/tests/unit/cli-public-commands.test.ts
+++ b/tests/unit/cli-public-commands.test.ts
@@ -78,6 +78,7 @@ describe('CLI public commands', () => {
         email: 'ada@example.com',
         responses: [],
       })
+      expect(JSON.parse(String(init?.body))).not.toHaveProperty('emailTestMode')
       return Response.json({ success: true, applicationId: 'app_1' }, { status: 201 })
     })
     const stdout: string[] = []

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -102,7 +102,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -114,13 +114,24 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
   })
 
+  it('runs extended security checks in a separate CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+
+    expect(workflow).toContain('name: Playwright security extended')
+    expect(workflow).toContain('FEATURE_FLAG_CHATBOT_EXPERIENCE: "true"')
+    expect(workflow).toContain('npm run test:e2e:security:extended')
+    expect(workflow).toContain('factory-careers-security-extended-minio')
+    expect(workflow).toContain('needs.security-extended.result')
+  })
+
   it('keeps the branch-protection E2E status as an aggregate of the split jobs', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
+    expect(workflow).toContain('needs.security-extended.result')
     expect(workflow).toContain('needs.uploads.result')
     expect(workflow).toContain('needs.ui.result')
     expect(workflow).toContain('needs.candidate.result')

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -119,6 +119,24 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.job_lifecycle.result')
   })
 
+  it('runs email-triggering browser coverage against a fake mail sink', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:email']).toBe(
+      'playwright test e2e/critical-flows/fake-mail.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright email')
+    expect(workflow).toContain('npm run test:e2e:email')
+    expect(workflow).toContain('FACTORY_EMAIL_TEST_MODE: capture')
+    expect(workflow).toContain('FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-email.jsonl')
+    expect(workflow).toContain('FACTORY_CAREERS_HIRING_INBOX: hiring-e2e@example.com')
+    expect(workflow).not.toContain('RESEND_API_KEY: ${{ secrets')
+    expect(workflow).toContain('needs.email.result')
+  })
+
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
     const packageJson = JSON.parse(read('package.json')) as {
@@ -132,7 +150,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -158,7 +176,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')
@@ -167,6 +185,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.candidate.result')
     expect(workflow).toContain('needs.recruiter.result')
     expect(workflow).toContain('needs.job_lifecycle.result')
+    expect(workflow).toContain('needs.email.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -150,7 +150,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:tracking-analytics')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.tracking_analytics.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
   })
 
   it('runs interview scheduling lifecycle browser coverage in a dedicated CI lane', () => {
@@ -166,7 +166,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:interviews')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.interviews.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
   })
 
   it('runs auth and organization edge-flow browser coverage in a dedicated CI lane', () => {
@@ -182,7 +182,23 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:auth-org')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.auth_org.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+  })
+
+  it('runs role-permission browser coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:rbac']).toBe(
+      'playwright test e2e/critical-flows/rbac-role-permissions.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright RBAC')
+    expect(workflow).toContain('npm run test:e2e:rbac')
+    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).toContain('needs.rbac.result')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
   })
 
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
@@ -198,7 +214,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -224,7 +240,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')
@@ -237,6 +253,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.tracking_analytics.result')
     expect(workflow).toContain('needs.interviews.result')
     expect(workflow).toContain('needs.auth_org.result')
+    expect(workflow).toContain('needs.rbac.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -9,6 +9,16 @@ function read(path: string): string {
   return readFileSync(join(root, path), 'utf8')
 }
 
+function workflowJobBlock(workflow: string, jobId: string): string {
+  const start = workflow.indexOf(`\n  ${jobId}:\n`)
+  expect(start, `${jobId} job should be present`).toBeGreaterThanOrEqual(0)
+
+  const nextJob = workflow.slice(start + 1).search(/\n  [a-zA-Z0-9_-]+:\n/)
+  return nextJob === -1
+    ? workflow.slice(start)
+    : workflow.slice(start, start + 1 + nextJob)
+}
+
 function walk(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const fullPath = join(dir, entry.name)
@@ -159,6 +169,7 @@ describe('Playwright E2E harness contract', () => {
 
   it('runs interview scheduling lifecycle browser coverage in a dedicated CI lane', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
+    const interviewsJob = workflowJobBlock(workflow, 'interviews')
     const packageJson = JSON.parse(read('package.json')) as {
       scripts?: Record<string, string>
     }
@@ -166,11 +177,11 @@ describe('Playwright E2E harness contract', () => {
     expect(packageJson.scripts?.['test:e2e:interviews']).toBe(
       'playwright test e2e/critical-flows/interview-lifecycle.spec.ts e2e/critical-flows/interview-invitation-response.spec.ts --workers=1',
     )
-    expect(workflow).toContain('name: Playwright interviews')
-    expect(workflow).toContain('npm run test:e2e:interviews')
-    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
-    expect(workflow).toContain('FACTORY_EMAIL_TEST_MODE: capture')
-    expect(workflow).toContain('FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-interview-email.jsonl')
+    expect(interviewsJob).toContain('name: Playwright interviews')
+    expect(interviewsJob).toContain('npm run test:e2e:interviews')
+    expect(interviewsJob).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(interviewsJob).toContain('FACTORY_EMAIL_TEST_MODE: capture')
+    expect(interviewsJob).toContain('FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-interview-email.jsonl')
     expect(read('e2e/critical-flows/interview-invitation-response.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
     expect(workflow).toContain('needs.interviews.result')
     expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]')

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -150,7 +150,23 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:tracking-analytics')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.tracking_analytics.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
+  })
+
+  it('runs interview scheduling lifecycle browser coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:interviews']).toBe(
+      'playwright test e2e/critical-flows/interview-lifecycle.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright interviews')
+    expect(workflow).toContain('npm run test:e2e:interviews')
+    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).toContain('needs.interviews.result')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
   })
 
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
@@ -166,7 +182,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -192,7 +208,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')
@@ -202,6 +218,8 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.recruiter.result')
     expect(workflow).toContain('needs.job_lifecycle.result')
     expect(workflow).toContain('needs.email.result')
+    expect(workflow).toContain('needs.tracking_analytics.result')
+    expect(workflow).toContain('needs.interviews.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -65,6 +65,22 @@ describe('Playwright E2E harness contract', () => {
     )
   })
 
+  it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:uploads']).toBe(
+      'playwright test e2e/critical-flows/resume-upload.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright uploads')
+    expect(workflow).toContain('npm run test:e2e:uploads')
+    expect(workflow).toContain('factory-careers-uploads-minio')
+    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads]')
+  })
+
   it('runs core tenant/document/RBAC security checks in CI', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
@@ -78,9 +94,10 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core]')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
+    expect(workflow).toContain('needs.uploads.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -137,6 +137,22 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.email.result')
   })
 
+  it('runs tracking-link creation and analytics browser coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:tracking-analytics']).toBe(
+      'playwright test e2e/critical-flows/tracking-analytics.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright tracking analytics')
+    expect(workflow).toContain('npm run test:e2e:tracking-analytics')
+    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).toContain('needs.tracking_analytics.result')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
+  })
+
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
     const packageJson = JSON.parse(read('package.json')) as {
@@ -150,7 +166,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -176,7 +192,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -104,6 +104,21 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.recruiter.result')
   })
 
+  it('runs post-publish job lifecycle browser coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:job-lifecycle']).toBe(
+      'playwright test e2e/critical-flows/job-lifecycle.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright job lifecycle')
+    expect(workflow).toContain('npm run test:e2e:job-lifecycle')
+    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).toContain('needs.job_lifecycle.result')
+  })
+
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
     const packageJson = JSON.parse(read('package.json')) as {
@@ -117,7 +132,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -143,7 +158,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')
@@ -151,6 +166,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.ui.result')
     expect(workflow).toContain('needs.candidate.result')
     expect(workflow).toContain('needs.recruiter.result')
+    expect(workflow).toContain('needs.job_lifecycle.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,8 +70,23 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui]')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
     expect(workflow).toContain('needs.ui.result')
+  })
+
+  it('runs candidate application browser coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:candidate']).toBe(
+      'playwright test e2e/critical-flows/candidate-application.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright candidate')
+    expect(workflow).toContain('npm run test:e2e:candidate')
+    expect(workflow).toContain('factory-careers-candidate-minio')
+    expect(workflow).toContain('needs.candidate.result')
   })
 
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
@@ -87,7 +102,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui]')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -103,11 +118,12 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui]')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui, candidate]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.uploads.result')
     expect(workflow).toContain('needs.ui.result')
+    expect(workflow).toContain('needs.candidate.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -126,14 +126,16 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:email']).toBe(
-      'playwright test e2e/critical-flows/fake-mail.spec.ts',
+      'playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts --workers=1',
     )
     expect(workflow).toContain('name: Playwright email')
     expect(workflow).toContain('npm run test:e2e:email')
     expect(workflow).toContain('FACTORY_EMAIL_TEST_MODE: capture')
     expect(workflow).toContain('FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-email.jsonl')
     expect(workflow).toContain('FACTORY_CAREERS_HIRING_INBOX: hiring-e2e@example.com')
+    expect(workflow).toContain('FACTORY_CAREERS_PRIVACY_INBOX: privacy-e2e@example.com')
     expect(workflow).not.toContain('RESEND_API_KEY: ${{ secrets')
+    expect(read('e2e/critical-flows/privacy-request-fake-mail.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
     expect(workflow).toContain('needs.email.result')
   })
 

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -152,7 +152,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:tracking-analytics')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.tracking_analytics.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]')
   })
 
   it('runs interview scheduling lifecycle browser coverage in a dedicated CI lane', () => {
@@ -168,7 +168,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:interviews')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.interviews.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]')
   })
 
   it('runs auth and organization edge-flow browser coverage in a dedicated CI lane', () => {
@@ -184,7 +184,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:auth-org')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.auth_org.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]')
   })
 
   it('runs role-permission browser coverage in a dedicated CI lane', () => {
@@ -200,7 +200,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:rbac')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.rbac.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]')
   })
 
   it('runs SSO domain provisioning browser coverage against local-only IdP origins', () => {
@@ -217,7 +217,26 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333,http://127.0.0.1:3999')
     expect(workflow).not.toContain('OIDC_CLIENT_SECRET: ${{ secrets')
     expect(workflow).toContain('needs.sso.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]')
+  })
+
+  it('runs AI candidate-review browser coverage against a deterministic mock provider', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:ai-review']).toBe(
+      'playwright test e2e/critical-flows/ai-candidate-review.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright AI review')
+    expect(workflow).toContain('npm run test:e2e:ai-review')
+    expect(workflow).toContain('FACTORY_AI_TEST_MODE: mock')
+    expect(workflow).toContain('FACTORY_AI_CAPTURE_PATH: /tmp/factory-careers-e2e-ai.jsonl')
+    expect(workflow).not.toContain('OPENAI_API_KEY: ${{ secrets')
+    expect(read('e2e/critical-flows/ai-candidate-review.spec.ts')).toContain('FACTORY_AI_TEST_MODE')
+    expect(workflow).toContain('needs.ai_review.result')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]')
   })
 
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
@@ -233,7 +252,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -259,7 +278,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -150,7 +150,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:tracking-analytics')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.tracking_analytics.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
   })
 
   it('runs interview scheduling lifecycle browser coverage in a dedicated CI lane', () => {
@@ -166,7 +166,23 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:interviews')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.interviews.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
+  })
+
+  it('runs auth and organization edge-flow browser coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:auth-org']).toBe(
+      'playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright auth and org')
+    expect(workflow).toContain('npm run test:e2e:auth-org')
+    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).toContain('needs.auth_org.result')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
   })
 
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
@@ -182,7 +198,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -208,7 +224,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')
@@ -220,6 +236,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.email.result')
     expect(workflow).toContain('needs.tracking_analytics.result')
     expect(workflow).toContain('needs.interviews.result')
+    expect(workflow).toContain('needs.auth_org.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -164,11 +164,14 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:interviews']).toBe(
-      'playwright test e2e/critical-flows/interview-lifecycle.spec.ts',
+      'playwright test e2e/critical-flows/interview-lifecycle.spec.ts e2e/critical-flows/interview-invitation-response.spec.ts --workers=1',
     )
     expect(workflow).toContain('name: Playwright interviews')
     expect(workflow).toContain('npm run test:e2e:interviews')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).toContain('FACTORY_EMAIL_TEST_MODE: capture')
+    expect(workflow).toContain('FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-interview-email.jsonl')
+    expect(read('e2e/critical-flows/interview-invitation-response.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
     expect(workflow).toContain('needs.interviews.result')
     expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]')
   })

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -89,6 +89,21 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.candidate.result')
   })
 
+  it('runs recruiter application lifecycle browser coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:recruiter']).toBe(
+      'playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright recruiter')
+    expect(workflow).toContain('npm run test:e2e:recruiter')
+    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).toContain('needs.recruiter.result')
+  })
+
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
     const packageJson = JSON.parse(read('package.json')) as {
@@ -102,7 +117,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -128,13 +143,14 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')
     expect(workflow).toContain('needs.uploads.result')
     expect(workflow).toContain('needs.ui.result')
     expect(workflow).toContain('needs.candidate.result')
+    expect(workflow).toContain('needs.recruiter.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -65,6 +65,15 @@ describe('Playwright E2E harness contract', () => {
     )
   })
 
+  it('runs invitation management browser coverage in a dedicated UI CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+
+    expect(workflow).toContain('name: Playwright UI')
+    expect(workflow).toContain('npm run test:e2e:ui')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui]')
+    expect(workflow).toContain('needs.ui.result')
+  })
+
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
     const packageJson = JSON.parse(read('package.json')) as {
@@ -78,7 +87,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads]')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -94,10 +103,11 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, uploads]')
+    expect(workflow).toContain('needs: [smoke, security-core, uploads, ui]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.uploads.result')
+    expect(workflow).toContain('needs.ui.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -126,16 +126,18 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:email']).toBe(
-      'playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts --workers=1',
+      'playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts e2e/critical-flows/auth-recovery-fake-mail.spec.ts --workers=1',
     )
     expect(workflow).toContain('name: Playwright email')
     expect(workflow).toContain('npm run test:e2e:email')
+    expect(workflow).toContain('FACTORY_ADMIN_SSO_ONLY: "false"')
     expect(workflow).toContain('FACTORY_EMAIL_TEST_MODE: capture')
     expect(workflow).toContain('FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-email.jsonl')
     expect(workflow).toContain('FACTORY_CAREERS_HIRING_INBOX: hiring-e2e@example.com')
     expect(workflow).toContain('FACTORY_CAREERS_PRIVACY_INBOX: privacy-e2e@example.com')
     expect(workflow).not.toContain('RESEND_API_KEY: ${{ secrets')
     expect(read('e2e/critical-flows/privacy-request-fake-mail.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
+    expect(read('e2e/critical-flows/auth-recovery-fake-mail.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
     expect(workflow).toContain('needs.email.result')
   })
 

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -70,7 +70,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -150,7 +150,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:tracking-analytics')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.tracking_analytics.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
   })
 
   it('runs interview scheduling lifecycle browser coverage in a dedicated CI lane', () => {
@@ -166,7 +166,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:interviews')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.interviews.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
   })
 
   it('runs auth and organization edge-flow browser coverage in a dedicated CI lane', () => {
@@ -182,7 +182,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:auth-org')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.auth_org.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
   })
 
   it('runs role-permission browser coverage in a dedicated CI lane', () => {
@@ -198,7 +198,24 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:rbac')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.rbac.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
+  })
+
+  it('runs SSO domain provisioning browser coverage against local-only IdP origins', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:sso']).toBe(
+      'playwright test e2e/critical-flows/sso-domain-provisioning.spec.ts',
+    )
+    expect(workflow).toContain('name: Playwright SSO')
+    expect(workflow).toContain('npm run test:e2e:sso')
+    expect(workflow).toContain('BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3333,http://127.0.0.1:3999')
+    expect(workflow).not.toContain('OIDC_CLIENT_SECRET: ${{ secrets')
+    expect(workflow).toContain('needs.sso.result')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
   })
 
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
@@ -214,7 +231,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -240,7 +257,7 @@ describe('Playwright E2E harness contract', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac]')
+    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso]')
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')
@@ -254,6 +271,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.interviews.result')
     expect(workflow).toContain('needs.auth_org.result')
     expect(workflow).toContain('needs.rbac.result')
+    expect(workflow).toContain('needs.sso.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {
@@ -263,6 +281,7 @@ describe('Playwright E2E harness contract', () => {
     expect(config).toContain('workers: process.env.CI ? 2 : undefined')
     expect(config).toContain('trace: process.env.CI ?')
     expect(config).toContain('FEATURE_FLAG_CHATBOT_EXPERIENCE=true')
+    expect(config).toContain('BETTER_AUTH_TRUSTED_ORIGINS=http://127.0.0.1:3333,http://127.0.0.1:3999')
     expect(config).not.toContain('tests share state')
   })
 

--- a/tests/unit/production-env-validation.test.ts
+++ b/tests/unit/production-env-validation.test.ts
@@ -109,6 +109,21 @@ describe('production environment preflight', () => {
     ]))
   })
 
+  it('rejects test-only capture modes in production env files', () => {
+    const result = validateProductionEnv({
+      ...validProductionEnv,
+      FACTORY_EMAIL_TEST_MODE: 'capture',
+      FACTORY_AI_TEST_MODE: 'mock',
+      FACTORY_AI_CAPTURE_PATH: '/tmp/factory-careers-e2e-ai.jsonl',
+    })
+
+    expect(result.ok).toBe(false)
+    expect(messages(result)).toEqual(expect.arrayContaining([
+      expect.stringContaining('FACTORY_EMAIL_TEST_MODE: capture mode is not allowed in production'),
+      expect.stringContaining('FACTORY_AI_TEST_MODE: mock mode is not allowed in production'),
+    ]))
+  })
+
   it('validates explicit production rate-limit overrides', () => {
     const result = validateProductionEnv({
       ...validProductionEnv,


### PR DESCRIPTION
## Summary
- add a fake-mail interview invitation response E2E covering recruiter scheduling, captured candidate invite email, signed public accept link, response persistence, and recruiter-side status display
- keep the coverage in the existing interviews lane with `--workers=1` instead of adding another CI job
- pin the interviews CI lane to fake-mail capture env and no calendar provider/secrets
- stabilize the tracking analytics E2E by navigating directly to the attribution-log route and refreshing source stats when that tab is selected

Closes #135

## Verification
- `npm run test:e2e:interviews`: 2 passed (24.8s)
- `npm run test:e2e:tracking-analytics`: 1 passed (21.2s) after one transient Nuxt dev-server 500 rerun
- `npm run test:unit -- tests/unit/e2e-harness-contract.test.ts`: 24 passed
- `npm run typecheck`: passed with known Vue package subpath warning
- `git diff --check`
- pre-push gate: full unit suite 846 passed, typecheck, CLI smoke, production env contract, build

## Notes
- Uses fake email capture only; no real email provider, calendar provider, or external notification secrets are involved.
