### PR TITLE
fix: add privacy request fake-mail e2e coverage

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -640,6 +640,7 @@ jobs:
       FACTORY_EMAIL_TEST_MODE: capture
       FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-email.jsonl
       FACTORY_CAREERS_HIRING_INBOX: hiring-e2e@example.com
+      FACTORY_CAREERS_PRIVACY_INBOX: privacy-e2e@example.com
       S3_ENDPOINT: http://127.0.0.1:9000
       S3_ACCESS_KEY: e2e-access-key
       S3_SECRET_KEY: e2e-secret-key

--- a/e2e/critical-flows/fake-mail.spec.ts
+++ b/e2e/critical-flows/fake-mail.spec.ts
@@ -1,33 +1,9 @@
-import { readFile, rm } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 import type { Page } from "@playwright/test";
 import { test, expect, selectFactorySelectOption } from "../fixtures";
+import { readCapturedEmails } from "../helpers/captured-emails";
 
 const JOB_TITLE = "Email Capture Test Job";
-
-type CapturedEmail = {
-  from: string;
-  to: string[];
-  subject: string;
-  html: string;
-  text: string;
-  renderError?: string;
-};
-
-async function readCapturedEmails(capturePath: string): Promise<CapturedEmail[]> {
-  try {
-    const contents = await readFile(capturePath, "utf8");
-    return contents
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as CapturedEmail);
-  } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      return [];
-    }
-
-    throw error;
-  }
-}
 
 async function advanceToSubmitButton(page: Page) {
   const submitButton = page.getByRole("button", { name: /submit/i });

--- a/e2e/critical-flows/privacy-request-fake-mail.spec.ts
+++ b/e2e/critical-flows/privacy-request-fake-mail.spec.ts
@@ -1,14 +1,8 @@
-import { readFile, rm } from 'node:fs/promises'
+import { rm } from 'node:fs/promises'
 import { test, expect } from '../fixtures'
 import postgres from 'postgres'
-
-type CapturedEmail = {
-  to: string[]
-  subject: string
-  html: string
-  text: string
-  renderError?: string
-}
+import type { Sql } from 'postgres'
+import { type CapturedEmail, readCapturedEmails } from '../helpers/captured-emails'
 
 type PrivacyRequestRecord = {
   id: string
@@ -21,46 +15,24 @@ type PrivacyRequestRecord = {
   verifiedAt: Date | null
 }
 
-async function readCapturedEmails(capturePath: string): Promise<CapturedEmail[]> {
-  try {
-    const contents = await readFile(capturePath, 'utf8')
-    return contents
-      .split('\n')
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as CapturedEmail)
-  }
-  catch (error) {
-    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return []
-    throw error
-  }
-}
+async function lookupPrivacyRequest(sql: Sql, requesterEmail: string) {
+  const [request] = await sql<PrivacyRequestRecord[]>`
+    select
+      id,
+      status,
+      requester_name as "requesterName",
+      requester_email as "requesterEmail",
+      state_of_residence as "stateOfResidence",
+      details,
+      verification_token_hash as "verificationTokenHash",
+      verified_at as "verifiedAt"
+    from privacy_request
+    where requester_email = ${requesterEmail}
+    order by created_at desc
+    limit 1
+  `
 
-async function lookupPrivacyRequest(requesterEmail: string) {
-  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for privacy request e2e coverage').toBeTruthy()
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-
-  try {
-    const [request] = await sql<PrivacyRequestRecord[]>`
-      select
-        id,
-        status,
-        requester_name as "requesterName",
-        requester_email as "requesterEmail",
-        state_of_residence as "stateOfResidence",
-        details,
-        verification_token_hash as "verificationTokenHash",
-        verified_at as "verifiedAt"
-      from privacy_request
-      where requester_email = ${requesterEmail}
-      order by created_at desc
-      limit 1
-    `
-
-    return request ?? null
-  }
-  finally {
-    await sql.end()
-  }
+  return request ?? null
 }
 
 function extractVerifyUrl(email: CapturedEmail) {
@@ -73,97 +45,104 @@ test.describe('Privacy request fake mail', () => {
     const capturePath = process.env.FACTORY_EMAIL_CAPTURE_PATH
     expect(capturePath, 'FACTORY_EMAIL_CAPTURE_PATH must be set for privacy request E2E').toBeTruthy()
     expect(process.env.FACTORY_EMAIL_TEST_MODE, 'E2E mail must use capture mode, not a real provider').toBe('capture')
+    expect(process.env.DATABASE_URL, 'DATABASE_URL is required for privacy request e2e coverage').toBeTruthy()
 
     await rm(capturePath!, { force: true })
+    const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
 
-    const id = `${Date.now()}-${testInfo.workerIndex}-${Math.random().toString(36).slice(2)}`
-    const requester = {
-      name: `Privacy Requester ${id}`,
-      email: `privacy.requester.${id}@example.com`,
-      state: 'California',
-      context: `Candidate role context ${id}`,
-      details: `Please review deletion for application fixture ${id}.`,
+    try {
+      const id = `${Date.now()}-${testInfo.workerIndex}-${Math.random().toString(36).slice(2)}`
+      const requester = {
+        name: `Privacy Requester ${id}`,
+        email: `privacy.requester.${id}@example.com`,
+        state: 'California',
+        context: `Candidate role context ${id}`,
+        details: `Please review deletion for application fixture ${id}.`,
+      }
+      const privacyInbox = process.env.FACTORY_CAREERS_PRIVACY_INBOX || 'legal@thefactoryhq.com'
+
+      await page.goto('/privacy/delete-request')
+      await page.waitForLoadState('networkidle')
+      await expect(page.getByRole('heading', { name: 'Request deletion of applicant information' })).toBeVisible()
+      await page.getByLabel('Name').fill(requester.name)
+      await page.getByLabel('Email').fill(requester.email)
+      await page.getByLabel('State of residence').selectOption(requester.state)
+      await page.getByLabel('Role or application context').fill(requester.context)
+      await page.getByLabel('Details').fill(requester.details)
+
+      const [submitResponse] = await Promise.all([
+        page.waitForResponse(
+          resp => resp.url().includes('/api/privacy-requests') && resp.request().method() === 'POST',
+          { timeout: 30_000 },
+        ),
+        page.getByRole('button', { name: 'Submit deletion request' }).click(),
+      ])
+      expect(submitResponse.status()).toBe(202)
+      await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible()
+
+      await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+        message: 'privacy request should capture requester verification and internal alert emails',
+        timeout: 10_000,
+      }).toBeGreaterThanOrEqual(2)
+
+      const request = await lookupPrivacyRequest(sql, requester.email)
+      expect(request, 'privacy request should be persisted').toBeTruthy()
+      expect(request).toMatchObject({
+        status: 'submitted',
+        requesterName: requester.name,
+        requesterEmail: requester.email,
+        stateOfResidence: requester.state,
+        verifiedAt: null,
+      })
+      expect(request?.details).toContain(requester.context)
+      expect(request?.details).toContain(requester.details)
+      expect(request?.verificationTokenHash).toMatch(/^[a-f0-9]{64}$/)
+
+      const capturedEmails = await readCapturedEmails(capturePath!)
+      const verificationEmail = capturedEmails.find((email) => email.subject === 'Verify your deletion request — Factory Careers')
+      expect(verificationEmail, 'requester verification email should be captured').toBeTruthy()
+      expect(verificationEmail?.renderError, 'requester verification email should render successfully').toBeUndefined()
+      expect(verificationEmail?.to).toContain(requester.email)
+      expect(verificationEmail?.text).toContain(requester.name)
+      expect(verificationEmail?.text).toContain('Verify your deletion request')
+
+      const verifyUrl = extractVerifyUrl(verificationEmail!)
+      expect(verifyUrl, 'verification email should contain a local verification URL').toContain('/api/privacy-requests/verify?token=')
+      expect(verifyUrl).not.toContain(request.verificationTokenHash)
+      expect(verifyUrl).not.toContain('thefactoryhq.com')
+
+      const internalAlert = capturedEmails.find((email) => email.subject === `Privacy deletion request: ${requester.email}`)
+      expect(internalAlert, 'privacy-team alert email should be captured').toBeTruthy()
+      expect(internalAlert?.renderError, 'privacy-team alert email should render successfully').toBeUndefined()
+      expect(internalAlert?.to).toContain(privacyInbox)
+      expect(internalAlert?.text).toContain(requester.name)
+      expect(internalAlert?.text).toContain(requester.email)
+      expect(internalAlert?.text).toContain(requester.state)
+
+      const verifyResponse = await page.request.get(verifyUrl)
+      expect(verifyResponse.status()).toBe(200)
+      await expect.poll(async () => (await lookupPrivacyRequest(sql, requester.email))?.status, {
+        message: 'privacy request should move to verified after opening the verification URL',
+        timeout: 10_000,
+      }).toBe('verified')
+
+      const verifiedRequest = await lookupPrivacyRequest(sql, requester.email)
+      expect(verifiedRequest?.verifiedAt).toBeTruthy()
+
+      await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+        message: 'privacy verification should capture confirmation email',
+        timeout: 10_000,
+      }).toBeGreaterThanOrEqual(3)
+
+      const confirmationEmail = (await readCapturedEmails(capturePath!))
+        .find((email) => email.subject === 'Deletion request verified — Factory Careers')
+      expect(confirmationEmail, 'requester confirmation email should be captured').toBeTruthy()
+      expect(confirmationEmail?.renderError, 'requester confirmation email should render successfully').toBeUndefined()
+      expect(confirmationEmail?.to).toContain(requester.email)
+      expect(confirmationEmail?.text).toContain('Request verified')
     }
-    const privacyInbox = process.env.FACTORY_CAREERS_PRIVACY_INBOX || 'legal@thefactoryhq.com'
-
-    await page.goto('/privacy/delete-request')
-    await page.waitForLoadState('networkidle')
-    await expect(page.getByRole('heading', { name: 'Request deletion of applicant information' })).toBeVisible()
-    await page.getByLabel('Name').fill(requester.name)
-    await page.getByLabel('Email').fill(requester.email)
-    await page.getByLabel('State of residence').selectOption(requester.state)
-    await page.getByLabel('Role or application context').fill(requester.context)
-    await page.getByLabel('Details').fill(requester.details)
-
-    const [submitResponse] = await Promise.all([
-      page.waitForResponse(
-        resp => resp.url().includes('/api/privacy-requests') && resp.request().method() === 'POST',
-        { timeout: 30_000 },
-      ),
-      page.getByRole('button', { name: 'Submit deletion request' }).click(),
-    ])
-    expect(submitResponse.status()).toBe(202)
-    await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible()
-
-    await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
-      message: 'privacy request should capture requester verification and internal alert emails',
-      timeout: 10_000,
-    }).toBeGreaterThanOrEqual(2)
-
-    const request = await lookupPrivacyRequest(requester.email)
-    expect(request, 'privacy request should be persisted').toBeTruthy()
-    expect(request).toMatchObject({
-      status: 'submitted',
-      requesterName: requester.name,
-      requesterEmail: requester.email,
-      stateOfResidence: requester.state,
-      verifiedAt: null,
-    })
-    expect(request?.details).toContain(requester.context)
-    expect(request?.details).toContain(requester.details)
-    expect(request?.verificationTokenHash).toMatch(/^[a-f0-9]{64}$/)
-
-    const capturedEmails = await readCapturedEmails(capturePath!)
-    const verificationEmail = capturedEmails.find((email) => email.subject === 'Verify your deletion request — Factory Careers')
-    expect(verificationEmail, 'requester verification email should be captured').toBeTruthy()
-    expect(verificationEmail?.renderError, 'requester verification email should render successfully').toBeUndefined()
-    expect(verificationEmail?.to).toContain(requester.email)
-    expect(verificationEmail?.text).toContain(requester.name)
-    expect(verificationEmail?.text).toContain('Verify your deletion request')
-
-    const verifyUrl = extractVerifyUrl(verificationEmail!)
-    expect(verifyUrl, 'verification email should contain a local verification URL').toContain('/api/privacy-requests/verify?token=')
-    expect(verifyUrl).not.toContain(request.verificationTokenHash)
-    expect(verifyUrl).not.toContain('thefactoryhq.com')
-
-    const internalAlert = capturedEmails.find((email) => email.subject === `Privacy deletion request: ${requester.email}`)
-    expect(internalAlert, 'privacy-team alert email should be captured').toBeTruthy()
-    expect(internalAlert?.renderError, 'privacy-team alert email should render successfully').toBeUndefined()
-    expect(internalAlert?.to).toContain(privacyInbox)
-    expect(internalAlert?.text).toContain(requester.name)
-    expect(internalAlert?.text).toContain(requester.email)
-    expect(internalAlert?.text).toContain(requester.state)
-
-    const verifyResponse = await page.request.get(verifyUrl)
-    expect(verifyResponse.status()).toBe(200)
-    await expect.poll(async () => (await lookupPrivacyRequest(requester.email))?.status, {
-      message: 'privacy request should move to verified after opening the verification URL',
-      timeout: 10_000,
-    }).toBe('verified')
-
-    const verifiedRequest = await lookupPrivacyRequest(requester.email)
-    expect(verifiedRequest?.verifiedAt).toBeTruthy()
-
-    await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
-      message: 'privacy verification should capture confirmation email',
-      timeout: 10_000,
-    }).toBeGreaterThanOrEqual(3)
-
-    const confirmationEmail = (await readCapturedEmails(capturePath!))
-      .find((email) => email.subject === 'Deletion request verified — Factory Careers')
-    expect(confirmationEmail, 'requester confirmation email should be captured').toBeTruthy()
-    expect(confirmationEmail?.renderError, 'requester confirmation email should render successfully').toBeUndefined()
-    expect(confirmationEmail?.to).toContain(requester.email)
-    expect(confirmationEmail?.text).toContain('Request verified')
+    finally {
+      await sql.end()
+    }
   })
 })

--- a/e2e/critical-flows/privacy-request-fake-mail.spec.ts
+++ b/e2e/critical-flows/privacy-request-fake-mail.spec.ts
@@ -1,5 +1,5 @@
 import { rm } from 'node:fs/promises'
-import { test, expect } from '../fixtures'
+import { test, expect, selectFactorySelectOption } from '../fixtures'
 import postgres from 'postgres'
 import type { Sql } from 'postgres'
 import { type CapturedEmail, readCapturedEmails } from '../helpers/captured-emails'
@@ -66,7 +66,7 @@ test.describe('Privacy request fake mail', () => {
       await expect(page.getByRole('heading', { name: 'Request deletion of applicant information' })).toBeVisible()
       await page.getByLabel('Name').fill(requester.name)
       await page.getByLabel('Email').fill(requester.email)
-      await page.getByLabel('State of residence').selectOption(requester.state)
+      await selectFactorySelectOption(page, /State of residence/, requester.state)
       await page.getByLabel('Role or application context').fill(requester.context)
       await page.getByLabel('Details').fill(requester.details)
 

--- a/e2e/critical-flows/privacy-request-fake-mail.spec.ts
+++ b/e2e/critical-flows/privacy-request-fake-mail.spec.ts
@@ -37,7 +37,10 @@ async function lookupPrivacyRequest(sql: Sql, requesterEmail: string) {
 
 function extractVerifyUrl(email: CapturedEmail) {
   const content = `${email.text}\n${email.html}`
-  return content.match(/http:\/\/127\.0\.0\.1:3333\/api\/privacy-requests\/verify\?token=[^\s"'<>]+/)?.[0] ?? ''
+  const path = content.match(/\/api\/privacy-requests\/verify\?token=[^\s"'<>]+/)?.[0]
+  if (!path) return ''
+
+  return new URL(path, process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3333').toString()
 }
 
 test.describe('Privacy request fake mail', () => {

--- a/e2e/critical-flows/privacy-request-fake-mail.spec.ts
+++ b/e2e/critical-flows/privacy-request-fake-mail.spec.ts
@@ -1,0 +1,169 @@
+import { readFile, rm } from 'node:fs/promises'
+import { test, expect } from '../fixtures'
+import postgres from 'postgres'
+
+type CapturedEmail = {
+  to: string[]
+  subject: string
+  html: string
+  text: string
+  renderError?: string
+}
+
+type PrivacyRequestRecord = {
+  id: string
+  status: string
+  requesterName: string
+  requesterEmail: string
+  stateOfResidence: string
+  details: string | null
+  verificationTokenHash: string
+  verifiedAt: Date | null
+}
+
+async function readCapturedEmails(capturePath: string): Promise<CapturedEmail[]> {
+  try {
+    const contents = await readFile(capturePath, 'utf8')
+    return contents
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as CapturedEmail)
+  }
+  catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return []
+    throw error
+  }
+}
+
+async function lookupPrivacyRequest(requesterEmail: string) {
+  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for privacy request e2e coverage').toBeTruthy()
+  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+
+  try {
+    const [request] = await sql<PrivacyRequestRecord[]>`
+      select
+        id,
+        status,
+        requester_name as "requesterName",
+        requester_email as "requesterEmail",
+        state_of_residence as "stateOfResidence",
+        details,
+        verification_token_hash as "verificationTokenHash",
+        verified_at as "verifiedAt"
+      from privacy_request
+      where requester_email = ${requesterEmail}
+      order by created_at desc
+      limit 1
+    `
+
+    return request ?? null
+  }
+  finally {
+    await sql.end()
+  }
+}
+
+function extractVerifyUrl(email: CapturedEmail) {
+  const content = `${email.text}\n${email.html}`
+  return content.match(/http:\/\/127\.0\.0\.1:3333\/api\/privacy-requests\/verify\?token=[^\s"'<>]+/)?.[0] ?? ''
+}
+
+test.describe('Privacy request fake mail', () => {
+  test('verifies deletion request persistence, fake-mail verification, and confirmation', async ({ page }, testInfo) => {
+    const capturePath = process.env.FACTORY_EMAIL_CAPTURE_PATH
+    expect(capturePath, 'FACTORY_EMAIL_CAPTURE_PATH must be set for privacy request E2E').toBeTruthy()
+    expect(process.env.FACTORY_EMAIL_TEST_MODE, 'E2E mail must use capture mode, not a real provider').toBe('capture')
+
+    await rm(capturePath!, { force: true })
+
+    const id = `${Date.now()}-${testInfo.workerIndex}-${Math.random().toString(36).slice(2)}`
+    const requester = {
+      name: `Privacy Requester ${id}`,
+      email: `privacy.requester.${id}@example.com`,
+      state: 'California',
+      context: `Candidate role context ${id}`,
+      details: `Please review deletion for application fixture ${id}.`,
+    }
+    const privacyInbox = process.env.FACTORY_CAREERS_PRIVACY_INBOX || 'legal@thefactoryhq.com'
+
+    await page.goto('/privacy/delete-request')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('heading', { name: 'Request deletion of applicant information' })).toBeVisible()
+    await page.getByLabel('Name').fill(requester.name)
+    await page.getByLabel('Email').fill(requester.email)
+    await page.getByLabel('State of residence').selectOption(requester.state)
+    await page.getByLabel('Role or application context').fill(requester.context)
+    await page.getByLabel('Details').fill(requester.details)
+
+    const [submitResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/privacy-requests') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Submit deletion request' }).click(),
+    ])
+    expect(submitResponse.status()).toBe(202)
+    await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible()
+
+    await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+      message: 'privacy request should capture requester verification and internal alert emails',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(2)
+
+    const request = await lookupPrivacyRequest(requester.email)
+    expect(request, 'privacy request should be persisted').toBeTruthy()
+    expect(request).toMatchObject({
+      status: 'submitted',
+      requesterName: requester.name,
+      requesterEmail: requester.email,
+      stateOfResidence: requester.state,
+      verifiedAt: null,
+    })
+    expect(request?.details).toContain(requester.context)
+    expect(request?.details).toContain(requester.details)
+    expect(request?.verificationTokenHash).toMatch(/^[a-f0-9]{64}$/)
+
+    const capturedEmails = await readCapturedEmails(capturePath!)
+    const verificationEmail = capturedEmails.find((email) => email.subject === 'Verify your deletion request — Factory Careers')
+    expect(verificationEmail, 'requester verification email should be captured').toBeTruthy()
+    expect(verificationEmail?.renderError, 'requester verification email should render successfully').toBeUndefined()
+    expect(verificationEmail?.to).toContain(requester.email)
+    expect(verificationEmail?.text).toContain(requester.name)
+    expect(verificationEmail?.text).toContain('Verify your deletion request')
+
+    const verifyUrl = extractVerifyUrl(verificationEmail!)
+    expect(verifyUrl, 'verification email should contain a local verification URL').toContain('/api/privacy-requests/verify?token=')
+    expect(verifyUrl).not.toContain(request.verificationTokenHash)
+    expect(verifyUrl).not.toContain('thefactoryhq.com')
+
+    const internalAlert = capturedEmails.find((email) => email.subject === `Privacy deletion request: ${requester.email}`)
+    expect(internalAlert, 'privacy-team alert email should be captured').toBeTruthy()
+    expect(internalAlert?.renderError, 'privacy-team alert email should render successfully').toBeUndefined()
+    expect(internalAlert?.to).toContain(privacyInbox)
+    expect(internalAlert?.text).toContain(requester.name)
+    expect(internalAlert?.text).toContain(requester.email)
+    expect(internalAlert?.text).toContain(requester.state)
+
+    const verifyResponse = await page.request.get(verifyUrl)
+    expect(verifyResponse.status()).toBe(200)
+    await expect.poll(async () => (await lookupPrivacyRequest(requester.email))?.status, {
+      message: 'privacy request should move to verified after opening the verification URL',
+      timeout: 10_000,
+    }).toBe('verified')
+
+    const verifiedRequest = await lookupPrivacyRequest(requester.email)
+    expect(verifiedRequest?.verifiedAt).toBeTruthy()
+
+    await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+      message: 'privacy verification should capture confirmation email',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(3)
+
+    const confirmationEmail = (await readCapturedEmails(capturePath!))
+      .find((email) => email.subject === 'Deletion request verified — Factory Careers')
+    expect(confirmationEmail, 'requester confirmation email should be captured').toBeTruthy()
+    expect(confirmationEmail?.renderError, 'requester confirmation email should render successfully').toBeUndefined()
+    expect(confirmationEmail?.to).toContain(requester.email)
+    expect(confirmationEmail?.text).toContain('Request verified')
+  })
+})

--- a/e2e/helpers/captured-emails.ts
+++ b/e2e/helpers/captured-emails.ts
@@ -1,0 +1,26 @@
+import { readFile } from "node:fs/promises";
+
+export type CapturedEmail = {
+  from?: string;
+  to: string[];
+  subject: string;
+  html: string;
+  text: string;
+  renderError?: string;
+};
+
+export async function readCapturedEmails(capturePath: string): Promise<CapturedEmail[]> {
+  try {
+    const contents = await readFile(capturePath, "utf8");
+    return contents
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as CapturedEmail);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+
+    throw error;
+  }
+}

--- a/e2e/helpers/captured-emails.ts
+++ b/e2e/helpers/captured-emails.ts
@@ -12,10 +12,21 @@ export type CapturedEmail = {
 export async function readCapturedEmails(capturePath: string): Promise<CapturedEmail[]> {
   try {
     const contents = await readFile(capturePath, "utf8");
-    return contents
+    const lines = contents
       .split("\n")
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as CapturedEmail);
+      .filter(Boolean);
+
+    return lines.flatMap((line, index) => {
+      try {
+        return [JSON.parse(line) as CapturedEmail];
+      } catch {
+        if (index === lines.length - 1) {
+          return [];
+        }
+
+        throw error;
+      }
+    });
   } catch (error) {
     if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return [];

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts",
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
-    "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts",
+    "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts --workers=1",
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts",
     "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -126,14 +126,16 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:email']).toBe(
-      'playwright test e2e/critical-flows/fake-mail.spec.ts',
+      'playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts --workers=1',
     )
     expect(workflow).toContain('name: Playwright email')
     expect(workflow).toContain('npm run test:e2e:email')
     expect(workflow).toContain('FACTORY_EMAIL_TEST_MODE: capture')
     expect(workflow).toContain('FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-email.jsonl')
     expect(workflow).toContain('FACTORY_CAREERS_HIRING_INBOX: hiring-e2e@example.com')
+    expect(workflow).toContain('FACTORY_CAREERS_PRIVACY_INBOX: privacy-e2e@example.com')
     expect(workflow).not.toContain('RESEND_API_KEY: ${{ secrets')
+    expect(read('e2e/critical-flows/privacy-request-fake-mail.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
     expect(workflow).toContain('needs.email.result')
   })
 


### PR DESCRIPTION
## Summary
- add browser-level privacy deletion request coverage to the fake-mail E2E lane
- assert DB persistence plus verification/internal/confirmation captured emails without contacting real providers
- share captured-email JSONL parsing and reuse a single DB client inside the privacy test

## Verification
- npm run test:unit -- tests/unit/e2e-harness-contract.test.ts
- ./node_modules/.bin/tsc --noEmit
- npx playwright test --list e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts
- pre-push preflight: unit, typecheck, CLI smoke, production env validation, build