### PR TITLE
fix: add interview invitation response e2e coverage

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,6 +44,8 @@ jobs:
       PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
       FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
       FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      FACTORY_EMAIL_TEST_MODE: capture
+      FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-interview-email.jsonl
       S3_ENDPOINT: http://127.0.0.1:9000
       S3_ACCESS_KEY: e2e-access-key
       S3_SECRET_KEY: e2e-secret-key

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,8 +44,6 @@ jobs:
       PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
       FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
       FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
-      FACTORY_EMAIL_TEST_MODE: capture
-      FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-interview-email.jsonl
       S3_ENDPOINT: http://127.0.0.1:9000
       S3_ACCESS_KEY: e2e-access-key
       S3_SECRET_KEY: e2e-secret-key
@@ -784,6 +782,8 @@ jobs:
       PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
       FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
       FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      FACTORY_EMAIL_TEST_MODE: capture
+      FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-interview-email.jsonl
       S3_ENDPOINT: http://127.0.0.1:9000
       S3_ACCESS_KEY: e2e-access-key
       S3_SECRET_KEY: e2e-secret-key

--- a/app/pages/dashboard/interviews/[id].vue
+++ b/app/pages/dashboard/interviews/[id].vue
@@ -12,6 +12,8 @@ import {
   getInterviewStatusLabel,
   getInterviewTransitionButtonClass,
   getInterviewTransitionLabel,
+  getCandidateResponseIconClass,
+  getCandidateResponseLabel,
 } from '~/utils/status-display'
 import { formatPhoneNumber } from '~/utils/phone-format'
 
@@ -404,6 +406,23 @@ const localePath = useLocalePath()
         >
           <CheckCheck class="size-3.5" />
           Invitation sent <TimelineDateLink :date="interview.invitationSentAt" class="text-success-600 dark:text-success-400">{{ formatDate(interview.invitationSentAt) }}</TimelineDateLink>
+        </div>
+        <!-- Candidate response status -->
+        <div
+          v-if="interview.candidateResponse !== 'pending'"
+          class="mt-2 flex flex-wrap items-center gap-1.5 text-xs"
+          :class="getCandidateResponseIconClass(interview.candidateResponse)"
+        >
+          <Check class="size-3.5" />
+          <span>Candidate response</span>
+          <span class="font-semibold">{{ getCandidateResponseLabel(interview.candidateResponse) }}</span>
+          <TimelineDateLink
+            v-if="interview.candidateRespondedAt"
+            :date="interview.candidateRespondedAt"
+            class="opacity-80"
+          >
+            {{ formatDate(interview.candidateRespondedAt) }}
+          </TimelineDateLink>
         </div>
         <!-- Calendar sync status -->
         <div

--- a/e2e/critical-flows/interview-invitation-response.spec.ts
+++ b/e2e/critical-flows/interview-invitation-response.spec.ts
@@ -1,34 +1,18 @@
-import { readFile, rm } from 'node:fs/promises'
+import { rm } from 'node:fs/promises'
 import { test, expect } from '../fixtures'
+import { type CapturedEmail, readCapturedEmails } from '../helpers/captured-emails'
 
 const JOB_TITLE = 'Interview Invitation Response Test Job'
 const INTERVIEW_TITLE = 'Candidate response screen'
 
-type CapturedEmail = {
-  to: string[]
-  subject: string
-  html: string
-  text: string
-  renderError?: string
-}
-
-async function readCapturedEmails(capturePath: string): Promise<CapturedEmail[]> {
-  try {
-    const contents = await readFile(capturePath, 'utf8')
-    return contents
-      .split('\n')
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as CapturedEmail)
-  }
-  catch (error) {
-    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return []
-    throw error
-  }
-}
-
 function extractAcceptUrl(email: CapturedEmail) {
-  const content = `${email.text}\n${email.html}`
-  return content.match(/http:\/\/127\.0\.0\.1:3333\/interview\/respond\?token=[A-Za-z0-9._%-]+/)?.[0] ?? ''
+  const acceptHref = email.html.match(/href="([^"]+)"[\s\S]{0,1000}(?:✓|&#x2713;|&#10003;)\s*Accept/i)?.[1]
+  if (!acceptHref) return ''
+
+  return new URL(
+    acceptHref.replaceAll('&amp;', '&'),
+    process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3333',
+  ).toString()
 }
 
 test.describe('Interview invitation response', () => {

--- a/e2e/critical-flows/interview-invitation-response.spec.ts
+++ b/e2e/critical-flows/interview-invitation-response.spec.ts
@@ -1,0 +1,172 @@
+import { readFile, rm } from 'node:fs/promises'
+import { test, expect } from '../fixtures'
+
+const JOB_TITLE = 'Interview Invitation Response Test Job'
+const INTERVIEW_TITLE = 'Candidate response screen'
+
+type CapturedEmail = {
+  to: string[]
+  subject: string
+  html: string
+  text: string
+  renderError?: string
+}
+
+async function readCapturedEmails(capturePath: string): Promise<CapturedEmail[]> {
+  try {
+    const contents = await readFile(capturePath, 'utf8')
+    return contents
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as CapturedEmail)
+  }
+  catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return []
+    throw error
+  }
+}
+
+function extractAcceptUrl(email: CapturedEmail) {
+  const content = `${email.text}\n${email.html}`
+  return content.match(/http:\/\/127\.0\.0\.1:3333\/interview\/respond\?token=[A-Za-z0-9._%-]+/)?.[0] ?? ''
+}
+
+test.describe('Interview invitation response', () => {
+  test('captures the invitation email and records the candidate response', async ({ authenticatedPage, browser }, testInfo) => {
+    const capturePath = process.env.FACTORY_EMAIL_CAPTURE_PATH
+    expect(capturePath, 'FACTORY_EMAIL_CAPTURE_PATH must be set for interview invitation E2E').toBeTruthy()
+    expect(process.env.FACTORY_EMAIL_TEST_MODE, 'Interview invitation E2E must use capture mode').toBe('capture')
+
+    await rm(capturePath!, { force: true })
+
+    const page = authenticatedPage
+    const unique = `${Date.now()}-r${testInfo.retry}`
+    const jobTitle = `${JOB_TITLE} ${unique}`
+    const applicant = {
+      firstName: 'Response',
+      lastName: 'Candidate',
+      email: `interview.response.${unique}@example.com`,
+    }
+    const applicantName = `${applicant.firstName} ${applicant.lastName}`
+
+    const createJobResponse = await page.request.post('/api/jobs', {
+      data: {
+        title: jobTitle,
+        description: 'A fast E2E job for interview invitation responses.',
+        location: 'Remote',
+        requireResume: false,
+        requireCoverLetter: false,
+        applicationComplianceEnabled: false,
+        autoScoreOnApply: false,
+      },
+    })
+    expect(createJobResponse.status(), `Create job API returned ${createJobResponse.status()}`).toBe(201)
+    const createdJob = await createJobResponse.json() as { id: string; slug: string }
+
+    const publishJobResponse = await page.request.patch(`/api/jobs/${createdJob.id}`, {
+      data: { status: 'open' },
+    })
+    expect(publishJobResponse.status(), `Publish job API returned ${publishJobResponse.status()}`).toBe(200)
+    const publishedJob = await publishJobResponse.json() as { slug: string }
+
+    const applyResponse = await page.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
+      data: {
+        firstName: applicant.firstName,
+        lastName: applicant.lastName,
+        email: applicant.email,
+        country: 'United States',
+        state: 'CA',
+        responses: [],
+      },
+    })
+    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
+
+    const applicationsResponse = await page.request.get(`/api/applications?jobId=${createdJob.id}&limit=10`)
+    expect(applicationsResponse.status(), `Applications API returned ${applicationsResponse.status()}`).toBe(200)
+    const applications = await applicationsResponse.json() as {
+      data: Array<{ id: string; candidateEmail: string }>
+    }
+    const application = applications.data.find(item => item.candidateEmail === applicant.email)
+    expect(application?.id, 'application id must be discoverable after public apply').toBeTruthy()
+
+    await page.goto(`/dashboard/applications/${application!.id}`, { waitUntil: 'networkidle' })
+    await expect(page.getByRole('heading', { name: new RegExp(applicantName) })).toBeVisible({ timeout: 15_000 })
+    const quickActions = page.locator('.ui-panel').filter({ hasText: 'Quick actions' })
+    await quickActions.getByRole('button', { name: 'Schedule Interview' }).click()
+    await expect(page.getByRole('heading', { name: 'Schedule Interview' })).toBeVisible({ timeout: 15_000 })
+
+    const emailCheckbox = page.getByRole('checkbox', { name: /Standard email/i })
+    await expect(emailCheckbox).toBeChecked()
+    const calendarCheckbox = page.getByRole('checkbox', { name: /Calendar|Microsoft|Google/i }).first()
+    await expect(calendarCheckbox, 'calendar sync should be disabled when no provider is configured').not.toBeChecked()
+
+    await page.getByLabel('Title').fill(`${INTERVIEW_TITLE} ${unique}`)
+    await page.getByRole('button', { name: '30m' }).click()
+
+    const [scheduleResponse, invitationResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/interviews') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.waitForResponse(
+        resp => resp.url().includes('/send-invitation') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Schedule Interview' }).last().click(),
+    ])
+    expect(scheduleResponse.status(), `Schedule interview API returned ${scheduleResponse.status()}`).toBe(201)
+    expect(invitationResponse.status(), `Send invitation API returned ${invitationResponse.status()}`).toBe(200)
+    const createdInterview = await scheduleResponse.json() as { id: string; calendarEventProvider?: string | null; googleCalendarEventId?: string | null }
+    expect(createdInterview.id, 'created interview id must be present').toBeTruthy()
+    expect(createdInterview.calendarEventProvider ?? null).toBeNull()
+    expect(createdInterview.googleCalendarEventId ?? null).toBeNull()
+
+    await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+      message: 'interview scheduling should capture the candidate invitation email',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(1)
+
+    const invitation = (await readCapturedEmails(capturePath!))
+      .find(email =>
+        email.subject.startsWith(`Interview Invitation: ${jobTitle} at `)
+        && email.to.includes(applicant.email),
+      )
+    expect(invitation, 'candidate interview invitation email should be captured').toBeTruthy()
+    expect(invitation?.renderError, 'candidate interview invitation email should render successfully').toBeUndefined()
+    expect(invitation?.to).toContain(applicant.email)
+    expect(invitation?.text).toContain(applicantName)
+    expect(invitation?.text).toContain(jobTitle)
+
+    const acceptUrl = extractAcceptUrl(invitation!)
+    expect(acceptUrl, 'invitation email should contain a local accept URL').toContain('/interview/respond?token=')
+    expect(acceptUrl).not.toContain('thefactoryhq.com')
+
+    const candidateContext = await browser.newContext()
+    const candidatePage = await candidateContext.newPage()
+    await candidatePage.goto(acceptUrl, { waitUntil: 'networkidle' })
+    await expect(candidatePage.getByRole('heading', { name: 'Interview Invitation' })).toBeVisible({ timeout: 15_000 })
+    await expect(candidatePage.getByText(`${INTERVIEW_TITLE} ${unique}`)).toBeVisible()
+    await expect(candidatePage.getByText(jobTitle)).toBeVisible()
+
+    const [candidateResponse] = await Promise.all([
+      candidatePage.waitForResponse(
+        resp => resp.url().includes('/api/public/interviews/respond') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      candidatePage.getByRole('button', { name: 'Accept Interview' }).click(),
+    ])
+    expect(candidateResponse.status(), `Candidate response API returned ${candidateResponse.status()}`).toBe(200)
+    await expect(candidatePage.getByRole('heading', { name: 'Response Recorded' })).toBeVisible({ timeout: 15_000 })
+    await candidateContext.close()
+
+    const interviewResponse = await page.request.get(`/api/interviews/${createdInterview.id}`)
+    expect(interviewResponse.status(), `Interview detail API returned ${interviewResponse.status()}`).toBe(200)
+    const updatedInterview = await interviewResponse.json() as { candidateResponse: string; candidateRespondedAt: string | null }
+    expect(updatedInterview.candidateResponse).toBe('accepted')
+    expect(updatedInterview.candidateRespondedAt).toBeTruthy()
+
+    await page.goto(`/dashboard/interviews/${createdInterview.id}`, { waitUntil: 'networkidle' })
+    await expect(page.getByText('Candidate response', { exact: true })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Accepted', { exact: true })).toBeVisible()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
     "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts e2e/critical-flows/auth-recovery-fake-mail.spec.ts --workers=1",
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
-    "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts",
+    "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts e2e/critical-flows/interview-invitation-response.spec.ts --workers=1",
     "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",
     "test:e2e:rbac": "playwright test e2e/critical-flows/rbac-role-permissions.spec.ts",
     "test:e2e:sso": "playwright test e2e/critical-flows/sso-domain-provisioning.spec.ts",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -9,6 +9,16 @@ function read(path: string): string {
   return readFileSync(join(root, path), 'utf8')
 }
 
+function workflowJobBlock(workflow: string, jobId: string): string {
+  const start = workflow.indexOf(`\n  ${jobId}:\n`)
+  expect(start, `${jobId} job should be present`).toBeGreaterThanOrEqual(0)
+
+  const nextJob = workflow.slice(start + 1).search(/\n  [a-zA-Z0-9_-]+:\n/)
+  return nextJob === -1
+    ? workflow.slice(start)
+    : workflow.slice(start, start + 1 + nextJob)
+}
+
 function walk(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const fullPath = join(dir, entry.name)
@@ -159,6 +169,7 @@ describe('Playwright E2E harness contract', () => {
 
   it('runs interview scheduling lifecycle browser coverage in a dedicated CI lane', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
+    const interviewsJob = workflowJobBlock(workflow, 'interviews')
     const packageJson = JSON.parse(read('package.json')) as {
       scripts?: Record<string, string>
     }
@@ -166,11 +177,11 @@ describe('Playwright E2E harness contract', () => {
     expect(packageJson.scripts?.['test:e2e:interviews']).toBe(
       'playwright test e2e/critical-flows/interview-lifecycle.spec.ts e2e/critical-flows/interview-invitation-response.spec.ts --workers=1',
     )
-    expect(workflow).toContain('name: Playwright interviews')
-    expect(workflow).toContain('npm run test:e2e:interviews')
-    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
-    expect(workflow).toContain('FACTORY_EMAIL_TEST_MODE: capture')
-    expect(workflow).toContain('FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-interview-email.jsonl')
+    expect(interviewsJob).toContain('name: Playwright interviews')
+    expect(interviewsJob).toContain('npm run test:e2e:interviews')
+    expect(interviewsJob).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(interviewsJob).toContain('FACTORY_EMAIL_TEST_MODE: capture')
+    expect(interviewsJob).toContain('FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-interview-email.jsonl')
     expect(read('e2e/critical-flows/interview-invitation-response.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
     expect(workflow).toContain('needs.interviews.result')
     expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]')

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -164,11 +164,14 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:interviews']).toBe(
-      'playwright test e2e/critical-flows/interview-lifecycle.spec.ts',
+      'playwright test e2e/critical-flows/interview-lifecycle.spec.ts e2e/critical-flows/interview-invitation-response.spec.ts --workers=1',
     )
     expect(workflow).toContain('name: Playwright interviews')
     expect(workflow).toContain('npm run test:e2e:interviews')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).toContain('FACTORY_EMAIL_TEST_MODE: capture')
+    expect(workflow).toContain('FACTORY_EMAIL_CAPTURE_PATH: /tmp/factory-careers-e2e-interview-email.jsonl')
+    expect(read('e2e/critical-flows/interview-invitation-response.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
     expect(workflow).toContain('needs.interviews.result')
     expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, auth_org, rbac, sso, ai_review]')
   })


### PR DESCRIPTION
Replaces #151 after its stacked base branch was removed during the E2E reintegration merge sequence.

## Summary
- adds fake-mail-backed interview invitation response E2E coverage
- pins the interviews CI lane to capture-mode email settings
- asserts the candidate accept response is persisted and visible in interview details

## Verification
- npm run test:unit -- tests/unit/e2e-harness-contract.test.ts
- ./node_modules/.bin/tsc --noEmit
- npx playwright test --list e2e/critical-flows/interview-invitation-response.spec.ts