### PR TITLE
fix: enforce custom question validation in E2E

### DIFF
--- a/app/pages/jobs/[slug]/apply.vue
+++ b/app/pages/jobs/[slug]/apply.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { MapPin, Briefcase, Building2 } from 'lucide-vue-next'
 import { COUNTRY_OPTIONS, US_STATE_OPTIONS } from '~~/shared/location-options'
+import { isRequiredCustomQuestionAnswered } from '~~/shared/custom-question-validation'
 
 definePageMeta({
   layout: 'public',
@@ -264,19 +265,14 @@ function validateResumeAndQuestionsFields(): boolean {
   if (job.value?.questions) {
     for (const q of job.value.questions) {
       if (q.required) {
-        if (q.type === 'file_upload') {
-          // For file uploads, check if a File was selected
-          if (!fileUploads.value[q.id]) {
-            errors.value[`q-${q.id}`] = 'This field is required'
-          }
-        } else {
-          const val = responses.value[q.id]
-          const isEmpty = val === undefined || val === null || val === '' ||
-            (Array.isArray(val) && val.length === 0)
+        const answered = isRequiredCustomQuestionAnswered(
+          q.type,
+          responses.value[q.id],
+          !!fileUploads.value[q.id],
+        )
 
-          if (isEmpty) {
-            errors.value[`q-${q.id}`] = 'This field is required'
-          }
+        if (!answered) {
+          errors.value[`q-${q.id}`] = 'This field is required'
         }
       }
     }

--- a/e2e/critical-flows/candidate-application.spec.ts
+++ b/e2e/critical-flows/candidate-application.spec.ts
@@ -249,6 +249,30 @@ test.describe('Candidate Application Flow — All Custom Question Field Types', 
     await selectFactorySelectOption(candidatePage, /Country/, 'United States')
     await selectFactorySelectOption(candidatePage, /State/, 'California')
     await candidatePage.getByRole('button', { name: 'Continue' }).click()
+    await expect(candidatePage.getByText('Additional questions')).toBeVisible({ timeout: 10_000 })
+
+    // Required custom questions must block the candidate before any submission
+    // request can be sent. This catches schema/UI drift where recruiter-authored
+    // required fields render but are not enforced on the public form.
+    const customQuestionContainer = (label: string) => candidatePage
+      .locator('label')
+      .filter({ hasText: label })
+      .first()
+      .locator('xpath=..')
+
+    await candidatePage.getByRole('button', { name: 'Continue' }).click()
+    await expect(
+      customQuestionContainer('Years of experience').getByText('This field is required'),
+    ).toBeVisible()
+    await expect(
+      customQuestionContainer('Preferred work style').getByText('This field is required'),
+    ).toBeVisible()
+    await expect(
+      customQuestionContainer('Agree to background check').getByText('This field is required'),
+    ).toBeVisible()
+    await expect(candidatePage.getByText('Voluntary self-identification')).toBeHidden()
+    await expect(candidatePage.getByRole('button', { name: 'Submit Application' })).toBeHidden()
+    expect(candidatePage.url()).not.toContain('/confirmation')
 
     // ── Fill each custom question field type ──────────────────────────────────
 

--- a/server/api/public/jobs/[slug]/apply.post.ts
+++ b/server/api/public/jobs/[slug]/apply.post.ts
@@ -9,6 +9,7 @@ import { assertUploadContentLength } from '../../../../utils/uploadLimits'
 import { readPositiveIntegerEnv } from '../../../../utils/rateLimitConfig'
 import { detectAllowedDocumentMimeType } from '../../../../utils/documentMime'
 import { isBuiltInLocationQuestion } from '~~/shared/built-in-application-fields'
+import { isRequiredCustomQuestionAnswered } from '~~/shared/custom-question-validation'
 import {
   MAX_FILE_SIZE,
   MAX_DOCUMENTS_PER_CANDIDATE,
@@ -294,23 +295,16 @@ export default defineEventHandler(async (event) => {
   })
   const questions = rawQuestions.filter((q) => !isBuiltInLocationQuestion(q))
 
-  const requiredQuestionIds = questions
+  const responseValuesByQuestionId = new Map(responseArray.map((r) => [r.questionId, r.value]))
+
+  const unanswered = questions
     .filter((q) => q.required)
+    .filter((q) => !isRequiredCustomQuestionAnswered(
+      q.type,
+      responseValuesByQuestionId.get(q.id),
+      uploadedFiles.has(q.id),
+    ))
     .map((q) => q.id)
-
-  // Check required non-file questions are answered
-  const answeredIds = new Set(responseArray.map((r) => r.questionId))
-
-  // For file_upload questions, check if files were provided
-  const fileQuestions = questions.filter((q) => q.type === 'file_upload')
-  const fileQuestionIds = new Set(fileQuestions.map((q) => q.id))
-
-  const unanswered = requiredQuestionIds.filter((id) => {
-    if (fileQuestionIds.has(id)) {
-      return !uploadedFiles.has(id)
-    }
-    return !answeredIds.has(id)
-  })
 
   if (unanswered.length > 0) {
     const unansweredLabels = questions
@@ -325,6 +319,7 @@ export default defineEventHandler(async (event) => {
 
   // Filter out responses for questions that don't belong to this job
   const validQuestionIds = new Set(questions.map((q) => q.id))
+  const fileQuestionIds = new Set(questions.filter((q) => q.type === 'file_upload').map((q) => q.id))
   const validResponses = responseArray.filter((r) => validQuestionIds.has(r.questionId))
 
   // ─────────────────────────────────────────────

--- a/shared/custom-question-validation.ts
+++ b/shared/custom-question-validation.ts
@@ -1,0 +1,14 @@
+export type CustomQuestionResponseValue = string | string[] | number | boolean | null | undefined
+
+export function isRequiredCustomQuestionAnswered(
+  questionType: string,
+  value: CustomQuestionResponseValue,
+  hasUploadedFile = false,
+): boolean {
+  if (questionType === 'file_upload') return hasUploadedFile
+  if (questionType === 'checkbox') return value === true
+  if (Array.isArray(value)) return value.length > 0
+  if (typeof value === 'string') return value.trim().length > 0
+
+  return value !== undefined && value !== null
+}

--- a/tests/unit/cli-public-commands.test.ts
+++ b/tests/unit/cli-public-commands.test.ts
@@ -101,4 +101,52 @@ describe('CLI public commands', () => {
     expect(exitCode).toBe(0)
     expect(JSON.parse(stdout[0])).toEqual({ success: true, applicationId: 'app_1' })
   })
+
+  it('preserves custom question response values for server-side required validation', async () => {
+    const dir = tempDir()
+    const configPath = join(dir, 'config.json')
+    writeConfig(configPath)
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(JSON.parse(String(init?.body))).toEqual({
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        email: 'ada@example.com',
+        country: 'United States',
+        state: 'CA',
+        responses: [
+          { questionId: 'q-required-checkbox', value: false },
+        ],
+      })
+      return Response.json({
+        statusCode: 422,
+        statusMessage: 'Missing required answers: Agree to background check',
+      }, { status: 422 })
+    })
+    const stdout: string[] = []
+
+    const exitCode = await runCli(
+      ['public', 'jobs', 'apply', 'senior-engineer', '--stdin', '--yes', '--config', configPath, '--json'],
+      {
+        stdout: (value) => stdout.push(value),
+        stderr: () => {},
+        fetch: fetchMock as typeof fetch,
+        stdin: async () => JSON.stringify({
+          firstName: 'Ada',
+          lastName: 'Lovelace',
+          email: 'ada@example.com',
+          country: 'United States',
+          state: 'CA',
+          responses: [
+            { questionId: 'q-required-checkbox', value: false },
+          ],
+        }),
+      },
+    )
+
+    expect(exitCode).toBe(1)
+    expect(JSON.parse(stdout[0])).toMatchObject({
+      status: 422,
+      message: 'Missing required answers: Agree to background check',
+    })
+  })
 })

--- a/tests/unit/custom-question-validation.test.ts
+++ b/tests/unit/custom-question-validation.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { isRequiredCustomQuestionAnswered } from '../../shared/custom-question-validation'
+
+describe('required custom question validation', () => {
+  it('requires checkbox questions to be checked', () => {
+    expect(isRequiredCustomQuestionAnswered('checkbox', true)).toBe(true)
+    expect(isRequiredCustomQuestionAnswered('checkbox', false)).toBe(false)
+    expect(isRequiredCustomQuestionAnswered('checkbox', undefined)).toBe(false)
+  })
+
+  it('treats blank text and empty multi-select answers as unanswered', () => {
+    expect(isRequiredCustomQuestionAnswered('short_text', '  ')).toBe(false)
+    expect(isRequiredCustomQuestionAnswered('short_text', '5')).toBe(true)
+    expect(isRequiredCustomQuestionAnswered('multi_select', [])).toBe(false)
+    expect(isRequiredCustomQuestionAnswered('multi_select', ['Vue'])).toBe(true)
+  })
+
+  it('validates file upload questions from the uploaded file map', () => {
+    expect(isRequiredCustomQuestionAnswered('file_upload', undefined, false)).toBe(false)
+    expect(isRequiredCustomQuestionAnswered('file_upload', undefined, true)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- replace stacked PR #158 with a clean branch from current main
- scope candidate E2E required-field assertions to each custom question wrapper
- wait for the custom-question step before validating required questions
- enforce required checkbox custom questions consistently in the public form and API
- add shared validation unit coverage plus CLI parity evidence for public application submissions

## Validation
- npm run test:unit -- tests/unit/custom-question-validation.test.ts tests/unit/e2e-harness-contract.test.ts tests/unit/cli-public-commands.test.ts
- ./node_modules/.bin/tsc --noEmit
- npm run preflight:cli-parity
- full pre-push gate: CLI parity, unit tests, typecheck, CLI smoke, production env validation, build
- local candidate E2E reached submit path; final local submit failed because MinIO is not available on this machine, while CI starts MinIO for the candidate lane

Replaces #158 and addresses Copilot threads PRRT_kwDOSi-Zzs6E4lf2, PRRT_kwDOSi-Zzs6E4lga, PRRT_kwDOSi-Zzs6E4lgp.