### PR TITLE
fix: prevent e2e production job leakage

### DIFF
--- a/e2e/safety.ts
+++ b/e2e/safety.ts
@@ -1,0 +1,120 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+type EnvMap = Record<string, string | undefined>
+
+export interface E2ESafetyOptions {
+  cwd?: string
+  env?: EnvMap
+  includeProcessEnv?: boolean
+  readDotenv?: boolean
+}
+
+const DEFAULT_BASE_URL = 'http://localhost:3333'
+const LOCAL_DATABASE_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'postgres', 'db', 'database'])
+const PRODUCTION_APP_HOSTS = new Set(['careers.thefactoryhq.com'])
+
+function parseDotenv(contents: string): EnvMap {
+  const values: EnvMap = {}
+
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+
+    const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/.exec(line)
+    if (!match) continue
+
+    const [, key, rawValue] = match
+    let value = rawValue.trim()
+    if (
+      (value.startsWith('"') && value.endsWith('"'))
+      || (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+    values[key] = value
+  }
+
+  return values
+}
+
+export function loadE2EEnvironment(options: E2ESafetyOptions = {}): EnvMap {
+  const cwd = options.cwd ?? process.cwd()
+  const shouldReadDotenv = options.readDotenv ?? true
+  const dotenvValues: EnvMap = {}
+
+  if (shouldReadDotenv) {
+    for (const file of ['.env', '.env.local']) {
+      const path = join(cwd, file)
+      if (existsSync(path)) {
+        Object.assign(dotenvValues, parseDotenv(readFileSync(path, 'utf8')))
+      }
+    }
+  }
+
+  return {
+    ...dotenvValues,
+    ...(options.includeProcessEnv === false ? {} : process.env),
+    ...(options.env ?? {}),
+  }
+}
+
+function parseUrl(value: string, label: string): URL {
+  try {
+    return new URL(value)
+  }
+  catch {
+    throw new Error(`${label} must be a valid URL for mutating Playwright E2E safety checks.`)
+  }
+}
+
+function isLocalDatabaseHost(hostname: string): boolean {
+  const host = hostname.toLowerCase()
+  return LOCAL_DATABASE_HOSTS.has(host)
+}
+
+function isLocalHttpHost(hostname: string): boolean {
+  const host = hostname.toLowerCase()
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1'
+}
+
+function isSupabaseHost(hostname: string): boolean {
+  const host = hostname.toLowerCase()
+  return host === 'supabase.com' || host.endsWith('.supabase.com')
+}
+
+export function assertMutatingE2ESafety(options: E2ESafetyOptions = {}) {
+  const env = loadE2EEnvironment(options)
+  const errors: string[] = []
+
+  const baseUrl = env.PLAYWRIGHT_BASE_URL || DEFAULT_BASE_URL
+  const parsedBaseUrl = parseUrl(baseUrl, 'PLAYWRIGHT_BASE_URL')
+  const baseHost = parsedBaseUrl.hostname.toLowerCase()
+
+  if (PRODUCTION_APP_HOSTS.has(baseHost)) {
+    errors.push(`PLAYWRIGHT_BASE_URL points at the production app host (${baseHost}).`)
+  }
+  else if (!isLocalHttpHost(baseHost) && env.E2E_ALLOW_REMOTE_BASE_URL !== 'true') {
+    errors.push(`PLAYWRIGHT_BASE_URL must be local for this mutating suite unless E2E_ALLOW_REMOTE_BASE_URL=true is set (${baseHost}).`)
+  }
+
+  if (env.DATABASE_URL) {
+    const databaseUrl = parseUrl(env.DATABASE_URL, 'DATABASE_URL')
+    const databaseHost = databaseUrl.hostname.toLowerCase()
+
+    if (isSupabaseHost(databaseHost)) {
+      errors.push(`DATABASE_URL points at Supabase (${databaseHost}); use a local or disposable E2E database.`)
+    }
+    else if (!isLocalDatabaseHost(databaseHost) && env.E2E_ALLOW_REMOTE_DATABASE !== 'true') {
+      errors.push(`DATABASE_URL must be local/disposable for this mutating suite unless E2E_ALLOW_REMOTE_DATABASE=true is set (${databaseHost}).`)
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error([
+      'Refusing to run mutating Playwright E2E against an unsafe target.',
+      ...errors.map(error => `- ${error}`),
+      'Point DATABASE_URL at a local/test database before running npm run test:e2e.',
+    ].join('\n'))
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
+import { assertMutatingE2ESafety } from './e2e/safety'
+
+assertMutatingE2ESafety()
 
 function shellEnv(name: string, value: string | undefined) {
   return value ? `${name}=${JSON.stringify(value)}` : ''

--- a/server/api/public/jobs/[slug].get.ts
+++ b/server/api/public/jobs/[slug].get.ts
@@ -1,6 +1,7 @@
 import { eq, and, asc, lte } from 'drizzle-orm'
 import { job, organization, orgSettings } from '../../../database/schema'
 import { publicJobSlugSchema } from '../../../utils/schemas/publicApplication'
+import { getPublicJobScopeCondition } from '../../../utils/publicJobScope'
 import { isBuiltInLocationQuestion } from '~~/shared/built-in-application-fields'
 
 /**
@@ -11,9 +12,12 @@ import { isBuiltInLocationQuestion } from '~~/shared/built-in-application-fields
  */
 export default defineEventHandler(async (event) => {
   const { slug } = await getValidatedRouterParams(event, publicJobSlugSchema.parse)
+  const organizationScope = await getPublicJobScopeCondition()
+  const conditions = [eq(job.slug, slug), eq(job.status, 'open'), lte(job.activeFrom, new Date())]
+  if (organizationScope) conditions.push(organizationScope)
 
   const result = await db.query.job.findFirst({
-    where: and(eq(job.slug, slug), eq(job.status, 'open'), lte(job.activeFrom, new Date())),
+    where: and(...conditions),
     columns: {
       id: true,
       organizationId: true,

--- a/server/api/public/jobs/[slug]/apply.post.ts
+++ b/server/api/public/jobs/[slug]/apply.post.ts
@@ -8,6 +8,7 @@ import { parseDocument } from '../../../../utils/resume-parser'
 import { assertUploadContentLength } from '../../../../utils/uploadLimits'
 import { readPositiveIntegerEnv } from '../../../../utils/rateLimitConfig'
 import { detectAllowedDocumentMimeType } from '../../../../utils/documentMime'
+import { getPublicJobScopeCondition } from '../../../../utils/publicJobScope'
 import { isBuiltInLocationQuestion } from '~~/shared/built-in-application-fields'
 import { isRequiredCustomQuestionAnswered } from '~~/shared/custom-question-validation'
 import { resolveFactoryCareersBaseUrl } from '../../../../utils/baseUrl'
@@ -224,8 +225,12 @@ export default defineEventHandler(async (event) => {
   // 2. Fetch the job by slug and verify it's open
   // ─────────────────────────────────────────────
 
+  const organizationScope = await getPublicJobScopeCondition()
+  const jobConditions = [eq(job.slug, slug), eq(job.status, 'open'), lte(job.activeFrom, new Date())]
+  if (organizationScope) jobConditions.push(organizationScope)
+
   const existingJob = await db.query.job.findFirst({
-    where: and(eq(job.slug, slug), eq(job.status, 'open'), lte(job.activeFrom, new Date())),
+    where: and(...jobConditions),
     columns: {
       id: true,
       title: true,

--- a/server/api/public/jobs/index.get.ts
+++ b/server/api/public/jobs/index.get.ts
@@ -1,6 +1,8 @@
+import type { SQL } from 'drizzle-orm'
 import { eq, and, desc, ilike, lte, or } from 'drizzle-orm'
 import { job } from '../../../database/schema'
 import { publicJobsQuerySchema } from '../../../utils/schemas/publicApplication'
+import { getPublicJobScopeCondition } from '../../../utils/publicJobScope'
 
 type PublicJobsQuery = Awaited<ReturnType<typeof publicJobsQuerySchema.parseAsync>>
 
@@ -31,9 +33,11 @@ function isMissingActiveFromColumn(error: unknown) {
     && message.includes('active_from')
 }
 
-function buildPublicJobsWhere(query: PublicJobsQuery, includeActiveFrom: boolean) {
+function buildPublicJobsWhere(query: PublicJobsQuery, includeActiveFrom: boolean, organizationScope?: SQL) {
   // Always filter to open jobs only. Older local databases may not have active_from yet.
   const conditions = [eq(job.status, 'open')]
+
+  if (organizationScope) conditions.push(organizationScope)
 
   if (includeActiveFrom) conditions.push(lte(job.activeFrom, new Date()))
 
@@ -65,8 +69,8 @@ function buildPublicJobsWhere(query: PublicJobsQuery, includeActiveFrom: boolean
   return and(...conditions)
 }
 
-async function listPublicJobs(query: PublicJobsQuery, offset: number, includeActiveFrom: boolean) {
-  const where = buildPublicJobsWhere(query, includeActiveFrom)
+async function listPublicJobs(query: PublicJobsQuery, offset: number, includeActiveFrom: boolean, organizationScope?: SQL) {
+  const where = buildPublicJobsWhere(query, includeActiveFrom, organizationScope)
 
   const columns = includeActiveFrom
     ? {
@@ -134,17 +138,18 @@ async function listPublicJobs(query: PublicJobsQuery, offset: number, includeAct
  */
 export default defineEventHandler(async (event) => {
   const query = await getValidatedQuery(event, publicJobsQuerySchema.parse)
+  const organizationScope = await getPublicJobScopeCondition()
 
   const offset = (query.page - 1) * query.limit
 
   try {
-    const result = await listPublicJobs(query, offset, true)
+    const result = await listPublicJobs(query, offset, true, organizationScope)
     return { ...result, page: query.page, limit: query.limit }
   }
   catch (error) {
     if (!isMissingActiveFromColumn(error)) throw error
 
-    const result = await listPublicJobs(query, offset, false)
+    const result = await listPublicJobs(query, offset, false, organizationScope)
     return { ...result, page: query.page, limit: query.limit }
   }
 })

--- a/server/utils/publicJobScope.ts
+++ b/server/utils/publicJobScope.ts
@@ -1,0 +1,21 @@
+import type { SQL } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
+import { job, organization } from '../database/schema'
+
+export async function getPublicJobScopeCondition(): Promise<SQL | undefined> {
+  if (!env.FACTORY_DISABLE_PUBLIC_ORG_CREATION) return undefined
+
+  const factoryOrg = await db.query.organization.findFirst({
+    where: eq(organization.slug, env.FACTORY_ORG_SLUG),
+    columns: { id: true },
+  })
+
+  if (!factoryOrg) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'Factory organization is not configured.',
+    })
+  }
+
+  return eq(job.organizationId, factoryOrg.id)
+}

--- a/tests/unit/cli-public-commands.test.ts
+++ b/tests/unit/cli-public-commands.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { runCli } from '../../packages/careers-cli/src/program'
@@ -148,5 +148,15 @@ describe('CLI public commands', () => {
       status: 422,
       message: 'Missing required answers: Agree to background check',
     })
+  })
+
+  it('inherits server-side Factory org scoping through the public jobs API routes', () => {
+    const program = readFileSync(join(process.cwd(), 'packages/careers-cli/src/program.ts'), 'utf8')
+    const publicScope = readFileSync(join(process.cwd(), 'server/utils/publicJobScope.ts'), 'utf8')
+
+    expect(publicScope).toContain('FACTORY_DISABLE_PUBLIC_ORG_CREATION')
+    expect(program).toContain('`${profile.baseUrl}/api/public/jobs`')
+    expect(program).toContain('`${profile.baseUrl}/api/public/jobs/${encodeURIComponent(slug)}`')
+    expect(program).toContain('`${profile.baseUrl}/api/public/jobs/${encodeURIComponent(slug)}/apply`')
   })
 })

--- a/tests/unit/e2e-safety.test.ts
+++ b/tests/unit/e2e-safety.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  assertMutatingE2ESafety,
+  loadE2EEnvironment,
+} from '../../e2e/safety'
+
+function withTempEnv(files: Record<string, string>, run: (cwd: string) => void) {
+  const cwd = mkdtempSync(join(tmpdir(), 'factory-careers-e2e-safety-'))
+  try {
+    for (const [name, contents] of Object.entries(files)) {
+      writeFileSync(join(cwd, name), contents)
+    }
+    run(cwd)
+  }
+  finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+}
+
+describe('mutating Playwright E2E safety', () => {
+  it('blocks local E2E when Nuxt would load a Supabase database from dotenv', () => {
+    withTempEnv({
+      '.env.local': 'DATABASE_URL=postgresql://factory_app:secret@aws-1-us-west-1.pooler.supabase.com:5432/postgres\n',
+    }, (cwd) => {
+      expect(() => assertMutatingE2ESafety({
+        cwd,
+        env: { PLAYWRIGHT_BASE_URL: 'http://localhost:3333' },
+        includeProcessEnv: false,
+      })).toThrow(/DATABASE_URL.*supabase/i)
+    })
+  })
+
+  it('blocks known production app hostnames even when no database is configured', () => {
+    expect(() => assertMutatingE2ESafety({
+      env: { PLAYWRIGHT_BASE_URL: 'https://careers.thefactoryhq.com' },
+      includeProcessEnv: false,
+      readDotenv: false,
+    })).toThrow(/PLAYWRIGHT_BASE_URL.*production/i)
+  })
+
+  it('does not classify lookalike database hostnames as Supabase hosts', () => {
+    expect(() => assertMutatingE2ESafety({
+      env: {
+        PLAYWRIGHT_BASE_URL: 'http://127.0.0.1:3333',
+        DATABASE_URL: 'postgresql://factory:factory@not-supabase.com:5432/factory_careers_e2e',
+        E2E_ALLOW_REMOTE_DATABASE: 'true',
+      },
+      includeProcessEnv: false,
+      readDotenv: false,
+    })).not.toThrow()
+  })
+
+  it('allows local app and local database targets', () => {
+    expect(() => assertMutatingE2ESafety({
+      env: {
+        PLAYWRIGHT_BASE_URL: 'http://127.0.0.1:3333',
+        DATABASE_URL: 'postgresql://factory:factory@localhost:5432/factory_careers_e2e',
+      },
+      includeProcessEnv: false,
+      readDotenv: false,
+    })).not.toThrow()
+  })
+
+  it('loads .env.local after .env so the effective E2E database matches Nuxt', () => {
+    withTempEnv({
+      '.env': 'DATABASE_URL=postgresql://factory:factory@localhost:5432/factory_careers_e2e\n',
+      '.env.local': 'DATABASE_URL=postgresql://factory_app:secret@aws-1-us-west-1.pooler.supabase.com:5432/postgres\n',
+    }, (cwd) => {
+      expect(loadE2EEnvironment({ cwd, env: {}, includeProcessEnv: false }).DATABASE_URL).toContain('supabase.com')
+    })
+  })
+})

--- a/tests/unit/job-auto-score-default.test.ts
+++ b/tests/unit/job-auto-score-default.test.ts
@@ -16,6 +16,8 @@ describe('job auto-score default', () => {
     expect(jobSchema).toContain("autoScoreOnApply: boolean('auto_score_on_apply').notNull().default(true)")
     expect(newJobPage).toContain('const autoScoreOnApply = ref(true)')
     expect(newJobPage).toContain('autoScoreOnApply.value = true')
+    expect(aiPage).toContain('const autoScoreOnApply = ref(true)')
+    expect(aiPage).toContain('autoScoreOnApply.value = (j as any).autoScoreOnApply ?? true')
     expect(aiPage).toContain('(j as any).autoScoreOnApply ?? true')
     expect(aiPage).toContain('body: { autoScoreOnApply: autoScoreOnApply.value }')
   })

--- a/tests/unit/public-job-scope.test.ts
+++ b/tests/unit/public-job-scope.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const organizationFindFirst = vi.fn()
+
+function readProjectFile(path: string) {
+  return readFileSync(join(process.cwd(), path), 'utf8')
+}
+
+function makeError(opts: { statusCode: number, statusMessage?: string }) {
+  return Object.assign(new Error(opts.statusMessage), opts)
+}
+
+vi.stubGlobal('createError', makeError)
+vi.stubGlobal('db', {
+  query: {
+    organization: { findFirst: organizationFindFirst },
+  },
+})
+
+const { getPublicJobScopeCondition } = await import('../../server/utils/publicJobScope')
+
+describe('public job organization scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('env', {
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: true,
+      FACTORY_ORG_SLUG: 'factory',
+    })
+    organizationFindFirst.mockResolvedValue({ id: 'factory-org' })
+  })
+
+  it('scopes anonymous job board reads to the Factory org in single-org mode', async () => {
+    await expect(getPublicJobScopeCondition()).resolves.toBeTruthy()
+    expect(organizationFindFirst).toHaveBeenCalledWith(expect.objectContaining({
+      columns: { id: true },
+    }))
+  })
+
+  it('keeps upstream multi-org deployments unscoped when public org creation is enabled', async () => {
+    vi.stubGlobal('env', {
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: false,
+      FACTORY_ORG_SLUG: 'factory',
+    })
+
+    await expect(getPublicJobScopeCondition()).resolves.toBeUndefined()
+    expect(organizationFindFirst).not.toHaveBeenCalled()
+  })
+
+  it('uses the same public scope on list, detail, and apply endpoints', () => {
+    expect(readProjectFile('server/api/public/jobs/index.get.ts')).toContain('getPublicJobScopeCondition')
+    expect(readProjectFile('server/api/public/jobs/[slug].get.ts')).toContain('getPublicJobScopeCondition')
+    expect(readProjectFile('server/api/public/jobs/[slug]/apply.post.ts')).toContain('getPublicJobScopeCondition')
+  })
+})


### PR DESCRIPTION
## Summary
- Add a Playwright safety guard that refuses mutating E2E when dotenv or base URL targets production/Supabase.
- Scope anonymous public jobs list/detail/apply routes to the Factory org in single-org mode.
- Add E2E safety, public job scope, and CLI parity evidence tests.

## Validation run
- npm ci
- npm run test:unit
- npm run typecheck
- npx playwright test --list (expected fail-closed with Supabase DATABASE_URL)
- DATABASE_URL=postgresql://factory:factory@localhost:5432/factory_careers_e2e npx playwright test --list
- npm run preflight:pr (via pre-push)

## Known risks or skipped checks
- Did not run the full E2E suite because the safety guard correctly blocks this checkout while DATABASE_URL points at Supabase.
- Typecheck logs existing vue-router/volar package export warning but exits successfully.

## Release/version notes
- No changeset needed; app hotfix only.
