### PR TITLE
fix: harden e2e production safety checks

### DIFF
--- a/e2e/safety.ts
+++ b/e2e/safety.ts
@@ -12,7 +12,7 @@ export interface E2ESafetyOptions {
 
 const DEFAULT_BASE_URL = 'http://localhost:3333'
 const LOCAL_DATABASE_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'postgres', 'db', 'database'])
-const PRODUCTION_APP_HOSTS = new Set(['careers.thefactoryhq.com'])
+const PRODUCTION_APP_HOSTS = new Set(['thefactoryhq.com', 'www.thefactoryhq.com', 'careers.thefactoryhq.com'])
 
 function parseDotenv(contents: string): EnvMap {
   const values: EnvMap = {}
@@ -59,6 +59,30 @@ export function loadE2EEnvironment(options: E2ESafetyOptions = {}): EnvMap {
   }
 }
 
+function loadE2EEnvironmentSources(options: E2ESafetyOptions = {}) {
+  const cwd = options.cwd ?? process.cwd()
+  const sources: Array<{ name: string, env: EnvMap }> = []
+
+  if (options.readDotenv ?? true) {
+    for (const file of ['.env', '.env.local']) {
+      const path = join(cwd, file)
+      if (existsSync(path)) {
+        sources.push({ name: file, env: parseDotenv(readFileSync(path, 'utf8')) })
+      }
+    }
+  }
+
+  if (options.includeProcessEnv !== false) {
+    sources.push({ name: 'process environment', env: process.env })
+  }
+
+  if (options.env) {
+    sources.push({ name: 'explicit environment', env: options.env })
+  }
+
+  return sources
+}
+
 function parseUrl(value: string, label: string): URL {
   try {
     return new URL(value)
@@ -84,29 +108,57 @@ function isSupabaseHost(hostname: string): boolean {
 }
 
 export function assertMutatingE2ESafety(options: E2ESafetyOptions = {}) {
-  const env = loadE2EEnvironment(options)
   const errors: string[] = []
+  const sources = loadE2EEnvironmentSources(options)
 
-  const baseUrl = env.PLAYWRIGHT_BASE_URL || DEFAULT_BASE_URL
-  const parsedBaseUrl = parseUrl(baseUrl, 'PLAYWRIGHT_BASE_URL')
-  const baseHost = parsedBaseUrl.hostname.toLowerCase()
+  for (const { name, env } of sources) {
+    const baseUrl = env.PLAYWRIGHT_BASE_URL
+    if (baseUrl) {
+      const parsedBaseUrl = parseUrl(baseUrl, `${name} PLAYWRIGHT_BASE_URL`)
+      const baseHost = parsedBaseUrl.hostname.toLowerCase()
 
-  if (PRODUCTION_APP_HOSTS.has(baseHost)) {
-    errors.push(`PLAYWRIGHT_BASE_URL points at the production app host (${baseHost}).`)
-  }
-  else if (!isLocalHttpHost(baseHost) && env.E2E_ALLOW_REMOTE_BASE_URL !== 'true') {
-    errors.push(`PLAYWRIGHT_BASE_URL must be local for this mutating suite unless E2E_ALLOW_REMOTE_BASE_URL=true is set (${baseHost}).`)
-  }
-
-  if (env.DATABASE_URL) {
-    const databaseUrl = parseUrl(env.DATABASE_URL, 'DATABASE_URL')
-    const databaseHost = databaseUrl.hostname.toLowerCase()
-
-    if (isSupabaseHost(databaseHost)) {
-      errors.push(`DATABASE_URL points at Supabase (${databaseHost}); use a local or disposable E2E database.`)
+      if (PRODUCTION_APP_HOSTS.has(baseHost)) {
+        errors.push(`${name} PLAYWRIGHT_BASE_URL points at a production app host (${baseHost}).`)
+      }
+      else if (!isLocalHttpHost(baseHost)) {
+        errors.push(`${name} PLAYWRIGHT_BASE_URL must be local for this mutating suite (${baseHost}).`)
+      }
     }
-    else if (!isLocalDatabaseHost(databaseHost) && env.E2E_ALLOW_REMOTE_DATABASE !== 'true') {
-      errors.push(`DATABASE_URL must be local/disposable for this mutating suite unless E2E_ALLOW_REMOTE_DATABASE=true is set (${databaseHost}).`)
+
+    if (env.BETTER_AUTH_URL) {
+      const parsedAuthUrl = parseUrl(env.BETTER_AUTH_URL, `${name} BETTER_AUTH_URL`)
+      const authHost = parsedAuthUrl.hostname.toLowerCase()
+      if (PRODUCTION_APP_HOSTS.has(authHost)) {
+        errors.push(`${name} BETTER_AUTH_URL points at a production app host (${authHost}).`)
+      }
+    }
+
+    if (env.NUXT_PUBLIC_SITE_URL) {
+      const parsedSiteUrl = parseUrl(env.NUXT_PUBLIC_SITE_URL, `${name} NUXT_PUBLIC_SITE_URL`)
+      const siteHost = parsedSiteUrl.hostname.toLowerCase()
+      if (PRODUCTION_APP_HOSTS.has(siteHost)) {
+        errors.push(`${name} NUXT_PUBLIC_SITE_URL points at a production app host (${siteHost}).`)
+      }
+    }
+
+    if (env.DATABASE_URL) {
+      const databaseUrl = parseUrl(env.DATABASE_URL, `${name} DATABASE_URL`)
+      const databaseHost = databaseUrl.hostname.toLowerCase()
+
+      if (isSupabaseHost(databaseHost)) {
+        errors.push(`${name} DATABASE_URL points at Supabase (${databaseHost}); use a local or disposable E2E database.`)
+      }
+      else if (!isLocalDatabaseHost(databaseHost)) {
+        errors.push(`${name} DATABASE_URL must be local/disposable for this mutating suite (${databaseHost}).`)
+      }
+    }
+  }
+
+  const effectiveEnv = loadE2EEnvironment(options)
+  if (!effectiveEnv.PLAYWRIGHT_BASE_URL) {
+    const parsedDefaultBaseUrl = parseUrl(DEFAULT_BASE_URL, 'default PLAYWRIGHT_BASE_URL')
+    if (!isLocalHttpHost(parsedDefaultBaseUrl.hostname)) {
+      errors.push(`default PLAYWRIGHT_BASE_URL must be local for this mutating suite (${parsedDefaultBaseUrl.hostname}).`)
     }
   }
 

--- a/tests/unit/e2e-safety.test.ts
+++ b/tests/unit/e2e-safety.test.ts
@@ -34,24 +34,27 @@ describe('mutating Playwright E2E safety', () => {
     })
   })
 
-  it('blocks known production app hostnames even when no database is configured', () => {
+  it.each([
+    'https://thefactoryhq.com',
+    'https://www.thefactoryhq.com',
+    'https://careers.thefactoryhq.com',
+  ])('blocks known production app hostname %s even when no database is configured', (url) => {
     expect(() => assertMutatingE2ESafety({
-      env: { PLAYWRIGHT_BASE_URL: 'https://careers.thefactoryhq.com' },
+      env: { PLAYWRIGHT_BASE_URL: url },
       includeProcessEnv: false,
       readDotenv: false,
     })).toThrow(/PLAYWRIGHT_BASE_URL.*production/i)
   })
 
-  it('does not classify lookalike database hostnames as Supabase hosts', () => {
+  it('blocks remote database hostnames even when they are not Supabase', () => {
     expect(() => assertMutatingE2ESafety({
       env: {
         PLAYWRIGHT_BASE_URL: 'http://127.0.0.1:3333',
         DATABASE_URL: 'postgresql://factory:factory@not-supabase.com:5432/factory_careers_e2e',
-        E2E_ALLOW_REMOTE_DATABASE: 'true',
       },
       includeProcessEnv: false,
       readDotenv: false,
-    })).not.toThrow()
+    })).toThrow(/DATABASE_URL must be local\/disposable/i)
   })
 
   it('allows local app and local database targets', () => {


### PR DESCRIPTION
## Summary
- tighten the mutating Playwright E2E safety gate so production Factory hosts are always blocked
- remove the remote database/base-url escape path for mutating E2E runs
- validate each dotenv/process source independently so a production .env cannot hide behind a local shell override

## Verification
- npm run test:unit -- tests/unit/e2e-safety.test.ts
- ./node_modules/.bin/tsc --noEmit
- PLAYWRIGHT_SKIP_WEB_SERVER=1 PLAYWRIGHT_BASE_URL=https://thefactoryhq.com ./node_modules/.bin/playwright test e2e/critical-flows/source-tracking.spec.ts --workers=1 (expected safety failure before tests run)
- PLAYWRIGHT_SKIP_WEB_SERVER=1 DATABASE_URL=postgresql://user:pass@prod.example.com:5432/app ./node_modules/.bin/playwright test e2e/critical-flows/source-tracking.spec.ts --workers=1 (expected safety failure before tests run)
- git push preflight: full unit suite, typecheck, CLI smoke, production env contract, build