### PR TITLE
test: add mobile keyboard E2E smoke

### DIFF
--- a/app/components/AppTopBar.vue
+++ b/app/components/AppTopBar.vue
@@ -550,6 +550,10 @@ function handleNewJobClick() {
           <!-- Mobile hamburger -->
           <button
             class="flex md:hidden items-center justify-center size-8 border border-transparent bg-transparent text-white/58 transition-all duration-200 cursor-pointer hover:bg-white/[0.04] hover:text-white"
+            type="button"
+            :aria-label="showMobileMenu ? 'Close navigation menu' : 'Open navigation menu'"
+            :aria-expanded="showMobileMenu"
+            aria-controls="dashboard-mobile-navigation"
             @click="showMobileMenu = !showMobileMenu"
           >
             <X v-if="showMobileMenu" class="size-4" />
@@ -655,6 +659,7 @@ function handleNewJobClick() {
       leave-to-class="opacity-0 -translate-y-2"
     >
       <div
+        id="dashboard-mobile-navigation"
         v-if="showMobileMenu"
         class="relative z-10 md:hidden border-b border-white/10 bg-black/95 backdrop-blur-xl"
       >

--- a/app/pages/jobs/index.vue
+++ b/app/pages/jobs/index.vue
@@ -168,6 +168,8 @@ function formatPostedDate(activeFrom?: string | null, createdAt?: string | null)
           :aria-expanded="typeDropdownOpen"
           aria-haspopup="listbox"
           @click="typeDropdownOpen = !typeDropdownOpen"
+          @keydown.enter.prevent="typeDropdownOpen = !typeDropdownOpen"
+          @keydown.space.prevent="typeDropdownOpen = !typeDropdownOpen"
           @keydown.escape="typeDropdownOpen = false"
         >
           <span>{{ selectedTypeLabel }}</span>

--- a/e2e/critical-flows/mobile-keyboard-smoke.spec.ts
+++ b/e2e/critical-flows/mobile-keyboard-smoke.spec.ts
@@ -1,0 +1,99 @@
+import type { Page } from '@playwright/test'
+import { test, expect } from '../fixtures'
+
+type JobFixture = {
+  id: string
+  slug: string
+  status: string
+  title: string
+}
+
+async function createPublishedJob(page: Page, title: string): Promise<JobFixture> {
+  const createResponse = await page.request.post('/api/jobs', {
+    data: {
+      title,
+      description: `Mobile keyboard smoke fixture for ${title}`,
+      location: 'Remote',
+      type: 'full_time',
+      requireResume: false,
+      requireCoverLetter: false,
+      applicationComplianceEnabled: false,
+      autoScoreOnApply: false,
+    },
+  })
+
+  expect(createResponse.status(), `Create job API returned ${createResponse.status()}`).toBe(201)
+  const created = await createResponse.json() as JobFixture
+
+  const publishResponse = await page.request.patch(`/api/jobs/${created.id}`, {
+    data: { status: 'open' },
+  })
+
+  expect(publishResponse.status(), `Publish job API returned ${publishResponse.status()}`).toBe(200)
+  const published = await publishResponse.json() as JobFixture
+  expect(published.status).toBe('open')
+
+  return published
+}
+
+test.describe('Mobile navigation and keyboard smoke', () => {
+  test('keeps public apply entry and dashboard navigation usable on mobile', async ({ authenticatedPage, browser }, testInfo) => {
+    const adminPage = authenticatedPage
+    const jobTitle = `Mobile Keyboard ${Date.now()} r${testInfo.retry}`
+    const publishedJob = await createPublishedJob(adminPage, jobTitle)
+
+    const mobileContext = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      isMobile: true,
+      hasTouch: true,
+    })
+
+    try {
+      const publicPage = await mobileContext.newPage()
+      await publicPage.goto('/jobs')
+      await publicPage.waitForLoadState('networkidle')
+
+      await expect(publicPage.getByRole('heading', { name: 'Open Positions' })).toBeVisible()
+
+      const searchInput = publicPage.getByLabel('Search jobs')
+      const searchButton = publicPage.getByRole('button', { name: 'Open search' })
+      const typeFilter = publicPage.getByRole('button', { name: 'All types' })
+
+      await searchInput.focus()
+      await expect(searchInput).toBeFocused()
+      await publicPage.keyboard.press('Tab')
+      await expect(searchButton).toBeFocused()
+      await publicPage.keyboard.press('Tab')
+      await expect(typeFilter).toBeFocused()
+      await typeFilter.click()
+      await expect(publicPage.getByRole('listbox')).toBeVisible()
+      await publicPage.keyboard.press('Escape')
+      await expect(publicPage.getByRole('listbox')).toHaveCount(0)
+      await expect(typeFilter).toBeFocused()
+
+      await expect(publicPage.getByRole('link').filter({ hasText: jobTitle })).toBeVisible()
+      await publicPage.goto(`/jobs/${publishedJob.slug}`)
+      await expect(publicPage.getByRole('heading', { name: jobTitle })).toBeVisible()
+      await publicPage.getByRole('link', { name: /Apply Now/i }).click()
+      await expect(publicPage.getByRole('heading', { name: jobTitle })).toBeVisible()
+      await expect(publicPage.getByRole('heading', { name: 'Your application' })).toBeVisible()
+    }
+    finally {
+      await mobileContext.close()
+    }
+
+    await adminPage.setViewportSize({ width: 390, height: 844 })
+    await adminPage.goto('/dashboard')
+    await adminPage.waitForLoadState('networkidle')
+    await expect(adminPage.getByRole('heading', { name: /Dashboard|Welcome/i })).toBeVisible()
+
+    const navButton = adminPage.getByRole('button', { name: 'Open navigation menu' })
+    await expect(navButton).toBeVisible()
+    await navButton.click()
+    await expect(adminPage.getByRole('button', { name: 'Close navigation menu' })).toHaveAttribute('aria-expanded', 'true')
+
+    await adminPage.getByRole('link', { name: 'Settings' }).click()
+    await expect(adminPage).toHaveURL(/\/dashboard\/settings/)
+    await expect(adminPage.getByRole('heading', { name: 'General' })).toBeVisible()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:e2e:ai-review": "playwright test e2e/critical-flows/ai-candidate-review.spec.ts",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
-    "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts",
+    "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts e2e/critical-flows/mobile-keyboard-smoke.spec.ts",
     "cli:pack": "npm pack --workspace @thefactory/careers-cli --dry-run",
     "cli:publish": "npm publish --workspace @thefactory/careers-cli",
     "ops:backup-restore-rehearsal": "bash scripts/backup-restore-rehearsal.sh",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -71,7 +71,7 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:ui']).toBe(
-      'playwright test e2e/critical-flows/invitation-management.spec.ts',
+      'playwright test e2e/critical-flows/invitation-management.spec.ts e2e/critical-flows/mobile-keyboard-smoke.spec.ts',
     )
   })
 


### PR DESCRIPTION
## Summary
- Add a small mobile/keyboard Playwright smoke covering public job browsing, apply entry, and mobile dashboard Settings navigation.
- Add accessible state/name wiring for the dashboard mobile navigation button.
- Wire the new spec into the existing UI E2E lane instead of adding another CI job.

Closes #169.

## Validation run
- npm run test:unit -- tests/unit/e2e-harness-contract.test.ts tests/unit/e2e-safety.test.ts
- ./node_modules/.bin/tsc --noEmit
- PLAYWRIGHT_SKIP_WEB_SERVER=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3334 DATABASE_URL=postgresql://factory_e2e@127.0.0.1:55436/factory_careers_e2e FACTORY_EMAIL_TEST_MODE=capture FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-mobile-email.jsonl ./node_modules/.bin/playwright test e2e/critical-flows/mobile-keyboard-smoke.spec.ts --workers=1
- PLAYWRIGHT_SKIP_WEB_SERVER=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3334 DATABASE_URL=postgresql://factory_e2e@127.0.0.1:55436/factory_careers_e2e FACTORY_EMAIL_TEST_MODE=capture FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-mobile-email.jsonl npm run test:e2e:ui -- --workers=1
- git push pre-push: npm run preflight:pr

## Known risks or skipped checks
- Local browser validation used a disposable localhost Postgres database and explicit localhost PLAYWRIGHT_BASE_URL.
- Email delivery was capture-only via FACTORY_EMAIL_TEST_MODE=capture; the UI lane wrote two local fake invitation email entries, with no SMTP/provider delivery.
- The new spec creates and publishes only local test jobs inside the disposable database.

## Release/version notes
- No changeset needed; test coverage and small accessibility wiring only.