### PR TITLE
test: cover application form builder lifecycle

### DIFF
--- a/e2e/critical-flows/application-form-builder.spec.ts
+++ b/e2e/critical-flows/application-form-builder.spec.ts
@@ -1,0 +1,222 @@
+import type { Page } from '@playwright/test'
+import { test, expect, selectFactorySelectOption } from '../fixtures'
+
+type JobFixture = {
+  id: string
+  slug: string
+  title: string
+}
+
+type QuestionFixture = {
+  id: string
+  label: string
+  type: string
+  required: boolean
+  options: string[] | null
+  displayOrder: number
+}
+
+async function createJob(page: Page, title: string): Promise<JobFixture> {
+  const response = await page.request.post('/api/jobs', {
+    data: {
+      title,
+      description: `E2E fixture for ${title}`,
+      location: 'Remote',
+      type: 'full_time',
+      requireResume: false,
+      requireCoverLetter: false,
+      applicationComplianceEnabled: false,
+      autoScoreOnApply: false,
+    },
+  })
+
+  expect(response.status(), `Create job API returned ${response.status()}`).toBe(201)
+  return await response.json() as JobFixture
+}
+
+async function createQuestion(
+  page: Page,
+  jobId: string,
+  question: {
+    label: string
+    type: string
+    required: boolean
+    options?: string[]
+    displayOrder: number
+  },
+): Promise<QuestionFixture> {
+  const response = await page.request.post(`/api/jobs/${jobId}/questions`, { data: question })
+
+  expect(response.status(), `Create question API returned ${response.status()}`).toBe(201)
+  return await response.json() as QuestionFixture
+}
+
+async function listQuestions(page: Page, jobId: string): Promise<QuestionFixture[]> {
+  const response = await page.request.get(`/api/jobs/${jobId}/questions`)
+  expect(response.status(), `List questions API returned ${response.status()}`).toBe(200)
+  return await response.json() as QuestionFixture[]
+}
+
+async function publishJob(page: Page, jobId: string): Promise<JobFixture> {
+  const response = await page.request.patch(`/api/jobs/${jobId}`, {
+    data: { status: 'open' },
+  })
+
+  expect(response.status(), `Publish job API returned ${response.status()}`).toBe(200)
+  return await response.json() as JobFixture
+}
+
+function questionRow(page: Page, label: string) {
+  return page.locator('.ui-list-row').filter({ hasText: label })
+}
+
+async function editQuestion(
+  page: Page,
+  currentLabel: string,
+  next: {
+    label: string
+    type: string
+    options?: string[]
+    required?: boolean
+  },
+) {
+  const row = questionRow(page, currentLabel)
+  await expect(row).toBeVisible()
+  await row.getByTitle('Edit').click()
+
+  await page.locator('#q-label').fill(next.label)
+  await page.locator('#q-type').click()
+  await page.getByRole('option', { name: next.type, exact: true }).click()
+
+  if (next.options) {
+    await page.getByPlaceholder('Option 1').fill(next.options[0] ?? '')
+    for (let index = 1; index < next.options.length; index += 1) {
+      await page.getByRole('button', { name: 'Add option' }).click()
+      await page.getByPlaceholder(`Option ${index + 1}`).fill(next.options[index] ?? '')
+    }
+  }
+
+  if (next.required) {
+    await page.getByRole('checkbox', { name: 'Required' }).check()
+  }
+
+  const [updateResponse] = await Promise.all([
+    page.waitForResponse(
+      response => response.url().includes('/questions/') && response.request().method() === 'PATCH',
+      { timeout: 30_000 },
+    ),
+    page.getByRole('button', { name: 'Update' }).click(),
+  ])
+  expect(updateResponse.status(), `Update question API returned ${updateResponse.status()}`).toBe(200)
+  await page.locator('#q-label').waitFor({ state: 'hidden', timeout: 10_000 })
+}
+
+async function moveQuestionUp(page: Page, label: string) {
+  const row = questionRow(page, label)
+  await expect(row).toBeVisible()
+  const [reorderResponse] = await Promise.all([
+    page.waitForResponse(
+      response => response.url().includes('/questions/reorder') && response.request().method() === 'PUT',
+      { timeout: 30_000 },
+    ),
+    row.getByTitle('Move up').click(),
+  ])
+  expect(reorderResponse.status(), `Reorder question API returned ${reorderResponse.status()}`).toBe(200)
+}
+
+async function deleteQuestion(page: Page, label: string) {
+  const row = questionRow(page, label)
+  await expect(row).toBeVisible()
+  const [deleteResponse] = await Promise.all([
+    page.waitForResponse(
+      response => response.url().includes('/questions/') && response.request().method() === 'DELETE',
+      { timeout: 30_000 },
+    ),
+    row.getByTitle('Delete').click(),
+  ])
+  expect(deleteResponse.status(), `Delete question API returned ${deleteResponse.status()}`).toBe(204)
+  await expect(questionRow(page, label)).toHaveCount(0)
+}
+
+test.describe('Application form builder lifecycle', () => {
+  test('persists edit, reorder, and delete changes before publishing to the public form', async ({ authenticatedPage }, testInfo) => {
+    const page = authenticatedPage
+    const runId = `${Date.now()}-r${testInfo.retry}`
+    const job = await createJob(page, `Application Form Builder ${runId}`)
+
+    await createQuestion(page, job.id, {
+      label: `Portfolio link ${runId}`,
+      type: 'url',
+      required: false,
+      displayOrder: 0,
+    })
+    await createQuestion(page, job.id, {
+      label: `Availability ${runId}`,
+      type: 'short_text',
+      required: false,
+      displayOrder: 1,
+    })
+    await createQuestion(page, job.id, {
+      label: `Deprecated question ${runId}`,
+      type: 'long_text',
+      required: false,
+      displayOrder: 2,
+    })
+
+    await page.goto(`/dashboard/jobs/${job.id}/application-form`)
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('heading', { name: 'Application Form' })).toBeVisible()
+    await expect(questionRow(page, `Portfolio link ${runId}`)).toBeVisible()
+    await expect(questionRow(page, `Availability ${runId}`)).toBeVisible()
+    await expect(questionRow(page, `Deprecated question ${runId}`)).toBeVisible()
+
+    await editQuestion(page, `Availability ${runId}`, {
+      label: `Candidate availability ${runId}`,
+      type: 'Single Select',
+      options: ['Immediately', 'Two weeks', 'One month'],
+      required: true,
+    })
+    await moveQuestionUp(page, `Candidate availability ${runId}`)
+    await deleteQuestion(page, `Deprecated question ${runId}`)
+
+    const updatedQuestions = await listQuestions(page, job.id)
+    expect(updatedQuestions.map(question => question.label)).toEqual([
+      `Candidate availability ${runId}`,
+      `Portfolio link ${runId}`,
+    ])
+    expect(updatedQuestions[0]).toEqual(expect.objectContaining({
+      type: 'single_select',
+      required: true,
+      options: ['Immediately', 'Two weeks', 'One month'],
+    }))
+
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await expect(questionRow(page, `Candidate availability ${runId}`)).toBeVisible()
+    await expect(questionRow(page, `Portfolio link ${runId}`)).toBeVisible()
+    await expect(questionRow(page, `Deprecated question ${runId}`)).toHaveCount(0)
+
+    const published = await publishJob(page, job.id)
+    await page.goto(`/jobs/${published.slug}/apply`)
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('heading', { name: job.title })).toBeVisible()
+    await page.getByLabel('First name').fill('Builder')
+    await page.getByLabel('Last name').fill('Applicant')
+    await page.getByLabel('Email').fill(`builder.applicant.${runId}@example.com`)
+    await selectFactorySelectOption(page, /Country/, 'United States')
+    await selectFactorySelectOption(page, /State/, 'California')
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await expect(page.getByText('Additional questions')).toBeVisible()
+
+    await expect(page.getByLabel(`Candidate availability ${runId}`)).toBeVisible()
+    await expect(page.getByLabel(`Portfolio link ${runId}`)).toBeVisible()
+    await expect(page.getByText(`Deprecated question ${runId}`)).toHaveCount(0)
+    await page.getByLabel(`Candidate availability ${runId}`).selectOption('Two weeks')
+    await expect(page.getByLabel(`Candidate availability ${runId}`)).toHaveValue('Two weeks')
+
+    const bodyText = await page.locator('body').innerText()
+    expect(bodyText.indexOf(`Candidate availability ${runId}`)).toBeLessThan(
+      bodyText.indexOf(`Portfolio link ${runId}`),
+    )
+  })
+})

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:e2e:uploads": "playwright test e2e/critical-flows/resume-upload.spec.ts",
     "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts e2e/critical-flows/application-saved-views.spec.ts e2e/critical-flows/application-custom-properties.spec.ts",
-    "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts",
+    "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts e2e/critical-flows/application-form-builder.spec.ts",
     "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts e2e/critical-flows/auth-recovery-fake-mail.spec.ts --workers=1",
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts e2e/critical-flows/interview-invitation-response.spec.ts e2e/critical-flows/interview-template-management.spec.ts --workers=1",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -121,7 +121,7 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:job-lifecycle']).toBe(
-      'playwright test e2e/critical-flows/job-lifecycle.spec.ts',
+      'playwright test e2e/critical-flows/job-lifecycle.spec.ts e2e/critical-flows/application-form-builder.spec.ts',
     )
     expect(workflow).toContain('name: Playwright job lifecycle')
     expect(workflow).toContain('npm run test:e2e:job-lifecycle')


### PR DESCRIPTION
## Summary
- Add a focused Playwright spec for the job application form builder lifecycle: seed via API, edit/reorder/delete through the dashboard builder, reload for persistence, publish, and verify the public apply form reflects the final config.
- Fold the spec into the existing job lifecycle E2E lane so coverage grows without adding another CI job.
- Closes #168.

## Validation run
- Confirmed no worktree .env or .env.local was present before local E2E validation.
- Used an explicit localhost app URL and disposable local Postgres database only: PLAYWRIGHT_BASE_URL=http://127.0.0.1:3336 and DATABASE_URL=postgresql://factory_e2e@127.0.0.1:55439/factory_careers_e2e.
- Used FACTORY_EMAIL_TEST_MODE=capture with FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-form-builder-email.jsonl; no capture file was produced.
- ./node_modules/.bin/playwright test e2e/critical-flows/application-form-builder.spec.ts --workers=1: 1 passed (4.3s).
- npm run test:e2e:job-lifecycle -- --workers=1: 2 passed (8.7s).
- npm run test:unit -- tests/unit/e2e-harness-contract.test.ts tests/unit/e2e-safety.test.ts: 32 passed.
- ./node_modules/.bin/tsc --noEmit: passed.
- Pre-push npm run preflight:pr: passed, including unit suite, typecheck, CLI smoke, production env contract, and build.

## Known risks or skipped checks
- Test-only change; no production or remote-backed E2E run was used.
- Existing Nuxt i18n and Vue route-block warnings still appear during typecheck/build.

## Release/version notes
- Test-only coverage change; no changeset needed.