### PR TITLE
test: cover candidate custom properties

### DIFF
--- a/e2e/critical-flows/candidate-custom-properties.spec.ts
+++ b/e2e/critical-flows/candidate-custom-properties.spec.ts
@@ -1,0 +1,237 @@
+import type { Browser, Page } from '@playwright/test'
+import { test, expect } from '../fixtures'
+
+type CandidateFixture = {
+  id: string
+  firstName: string
+  lastName: string
+  email: string
+}
+
+type PropertyFixture = {
+  id: string
+  name: string
+}
+
+type PropertyEntry = {
+  definition: { id: string, name: string }
+  value: unknown
+}
+
+async function createCandidate(
+  page: Page,
+  candidate: Omit<CandidateFixture, 'id'>,
+): Promise<CandidateFixture> {
+  const response = await page.request.post('/api/candidates', { data: candidate })
+
+  expect(response.status(), `Create candidate API returned ${response.status()}`).toBe(201)
+  return await response.json() as CandidateFixture
+}
+
+async function setCandidatePropertyValue(
+  page: Page,
+  candidateId: string,
+  propertyId: string,
+  value: unknown,
+) {
+  const response = await page.request.put(`/api/candidates/${candidateId}/properties/${propertyId}`, {
+    data: { value },
+  })
+
+  expect(response.status(), `Set candidate property value API returned ${response.status()}`).toBe(200)
+}
+
+async function expectCandidatePropertyValue(
+  page: Page,
+  candidateId: string,
+  propertyId: string,
+  expected: unknown,
+) {
+  const response = await page.request.get(`/api/candidates/${candidateId}`)
+  expect(response.status(), `Candidate detail API returned ${response.status()}`).toBe(200)
+  const candidate = await response.json() as { properties: PropertyEntry[] }
+  const entry = candidate.properties.find(property => property.definition.id === propertyId)
+  expect(entry, `Candidate detail should include property ${propertyId}`).toBeTruthy()
+  expect(entry?.value).toEqual(expected)
+}
+
+async function createCandidateTextPropertyFromDetail(page: Page, candidateId: string, name: string) {
+  await page.goto(`/dashboard/candidates/${candidateId}`)
+  await page.waitForLoadState('networkidle')
+  await page.getByRole('button', { name: 'Add org-wide property' }).click()
+
+  const editor = page.getByRole('complementary').filter({ hasText: 'Organization candidate properties' })
+  await expect(editor).toBeVisible({ timeout: 15_000 })
+  await editor.getByRole('button', { name: 'Add property' }).click()
+  await editor.getByRole('textbox').first().fill(name)
+
+  const [createResponse] = await Promise.all([
+    page.waitForResponse(
+      resp => resp.url().includes('/api/properties') && resp.request().method() === 'POST',
+      { timeout: 30_000 },
+    ),
+    editor.getByRole('button', { name: 'Create' }).click(),
+  ])
+  expect(createResponse.status(), `Create candidate property API returned ${createResponse.status()}`).toBe(200)
+  const property = await createResponse.json() as PropertyFixture
+  expect(property.id, 'candidate property id must be present').toBeTruthy()
+  expect(property.name).toBe(name)
+
+  await expect(editor).toBeHidden({ timeout: 10_000 })
+  await expect(page.getByText(name)).toBeVisible({ timeout: 10_000 })
+
+  return property
+}
+
+async function showPropertyColumn(page: Page, propertyName: string) {
+  await page.getByRole('button', { name: /Columns/ }).click()
+  const menu = page.getByText('Toggle columns', { exact: true }).locator('..')
+  const toggle = menu.getByRole('button', { name: propertyName, exact: true })
+  await expect(toggle).toBeVisible()
+  await toggle.click()
+  await expect(page.getByRole('columnheader', { name: propertyName })).toBeVisible()
+  await page.getByRole('heading', { name: 'Candidates' }).click()
+}
+
+async function setCandidatePropertyFromTable(page: Page, candidateEmail: string, nextValue: string) {
+  const row = page.getByRole('row').filter({ hasText: candidateEmail })
+  await expect(row).toBeVisible({ timeout: 15_000 })
+  await row.getByRole('button', { name: 'Empty' }).click()
+  const input = row.locator('input.ui-field')
+  await expect(input).toBeVisible()
+
+  const [saveResponse] = await Promise.all([
+    page.waitForResponse(
+      resp => resp.url().includes('/api/candidates/') && resp.url().includes('/properties/') && resp.request().method() === 'PUT',
+      { timeout: 30_000 },
+    ),
+    input.fill(nextValue).then(() => input.press('Enter')),
+  ])
+  expect(saveResponse.status(), `Candidate property save API returned ${saveResponse.status()}`).toBe(200)
+  await expect(row).toContainText(nextValue)
+}
+
+async function signUpWithOrganization(browser: Browser, baseURL: string, account: {
+  name: string
+  email: string
+  password: string
+  orgName: string
+}) {
+  const context = await browser.newContext({ baseURL })
+  const page = await context.newPage()
+
+  await page.goto('/auth/sign-up')
+  await page.waitForLoadState('networkidle')
+  await page.getByLabel('Name').fill(account.name)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password', { exact: true }).fill(account.password)
+  await page.getByLabel('Confirm password').fill(account.password)
+
+  await Promise.all([
+    page.waitForResponse(
+      resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200,
+      { timeout: 30_000 },
+    ),
+    page.getByRole('button', { name: 'Sign up' }).click(),
+  ])
+
+  await page.waitForURL(
+    url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'),
+    { waitUntil: 'commit', timeout: 30_000 },
+  )
+
+  if (page.url().includes('/auth/sign-in')) {
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Email').fill(account.email)
+    await page.getByLabel('Password').fill(account.password)
+    await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200,
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Sign in' }).click(),
+    ])
+    await page.waitForURL('**/onboarding/**', { waitUntil: 'commit', timeout: 30_000 })
+  }
+
+  await page.getByLabel('Organization name').waitFor({ state: 'visible', timeout: 30_000 })
+  await page.getByLabel('Organization name').fill(account.orgName)
+  await page.getByRole('button', { name: 'Create organization' }).click()
+  await page.waitForURL('**/dashboard**', { waitUntil: 'commit', timeout: 30_000 })
+
+  return { context, page }
+}
+
+test.describe('Candidate custom properties', () => {
+  test('creates, persists, renders, filters, and scopes candidate property values', async ({ authenticatedPage, browser }, testInfo) => {
+    const page = authenticatedPage
+    const runId = `${Date.now()}-r${testInfo.retry}`
+    const matchedCandidate = await createCandidate(page, {
+      firstName: 'Casey',
+      lastName: `Candidate Property ${runId}`,
+      email: `casey.candidate.property.${runId}@example.com`,
+    })
+    const otherCandidate = await createCandidate(page, {
+      firstName: 'Morgan',
+      lastName: `Candidate Property ${runId}`,
+      email: `morgan.candidate.property.${runId}@example.com`,
+    })
+
+    const property = await createCandidateTextPropertyFromDetail(
+      page,
+      matchedCandidate.id,
+      `Candidate signal ${runId}`,
+    )
+
+    await page.goto('/dashboard/candidates')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('heading', { name: 'Candidates' })).toBeVisible()
+    await showPropertyColumn(page, property.name)
+    await setCandidatePropertyFromTable(page, matchedCandidate.email, 'Portfolio reviewed')
+    await setCandidatePropertyValue(page, otherCandidate.id, property.id, 'Needs discovery')
+
+    await expectCandidatePropertyValue(page, matchedCandidate.id, property.id, 'Portfolio reviewed')
+    await expectCandidatePropertyValue(page, otherCandidate.id, property.id, 'Needs discovery')
+
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    const reloadedRow = page.getByRole('row').filter({ hasText: matchedCandidate.email })
+    await expect(reloadedRow).toBeVisible()
+    await expect(reloadedRow).toContainText('Portfolio reviewed')
+
+    await page.goto(`/dashboard/candidates/${matchedCandidate.id}`)
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('heading', { name: `${matchedCandidate.firstName} ${matchedCandidate.lastName}` })).toBeVisible()
+    const propertiesPanel = page.locator('.ui-panel').filter({ hasText: 'Properties' })
+    await expect(propertiesPanel).toContainText(property.name)
+    await expect(propertiesPanel).toContainText('Portfolio reviewed')
+
+    await page.goto('/dashboard/candidates')
+    await page.waitForLoadState('networkidle')
+    await page.getByRole('button', { name: /Filters/ }).click()
+    await page.getByRole('button', { name: 'Filter', exact: true }).click()
+    await page.getByRole('button', { name: new RegExp(property.name) }).click()
+    await page.getByRole('button', { name: new RegExp(`Edit filter: ${property.name} contains`) }).click()
+    await page.getByPlaceholder('Value').fill('Portfolio')
+    await page.getByRole('heading', { name: 'Filter candidates' }).click()
+    await expect(page.getByRole('row').filter({ hasText: matchedCandidate.email })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('row').filter({ hasText: otherCandidate.email })).toHaveCount(0)
+
+    const baseURL = testInfo.project.use.baseURL as string
+    const isolated = await signUpWithOrganization(browser, baseURL, {
+      name: `Property Scope ${runId}`,
+      email: `property.scope.${runId}@test.local`,
+      password: process.env.E2E_TEST_PASSWORD || 'TestPassword123!',
+      orgName: `Property Scope Org ${runId}`,
+    })
+    try {
+      const propertiesResponse = await isolated.page.request.get('/api/properties?entityType=candidate')
+      expect(propertiesResponse.status(), `Other-org properties API returned ${propertiesResponse.status()}`).toBe(200)
+      const properties = await propertiesResponse.json() as PropertyFixture[]
+      expect(properties.map(item => item.name)).not.toContain(property.name)
+    }
+    finally {
+      await isolated.context.close()
+    }
+  })
+})

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:e2e:smoke": "playwright test e2e/critical-flows/dropdown-styling.spec.ts e2e/critical-flows/job-creation.spec.ts e2e/critical-flows/source-tracking.spec.ts",
     "test:e2e:uploads": "playwright test e2e/critical-flows/resume-upload.spec.ts",
     "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
-    "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts e2e/critical-flows/application-saved-views.spec.ts e2e/critical-flows/application-custom-properties.spec.ts",
+    "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts e2e/critical-flows/application-saved-views.spec.ts e2e/critical-flows/application-custom-properties.spec.ts e2e/critical-flows/candidate-custom-properties.spec.ts",
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts e2e/critical-flows/application-form-builder.spec.ts",
     "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts e2e/critical-flows/auth-recovery-fake-mail.spec.ts --workers=1",
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -106,7 +106,7 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:recruiter']).toBe(
-      'playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts e2e/critical-flows/application-saved-views.spec.ts e2e/critical-flows/application-custom-properties.spec.ts',
+      'playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts e2e/critical-flows/application-saved-views.spec.ts e2e/critical-flows/application-custom-properties.spec.ts e2e/critical-flows/candidate-custom-properties.spec.ts',
     )
     expect(workflow).toContain('name: Playwright recruiter')
     expect(workflow).toContain('npm run test:e2e:recruiter')


### PR DESCRIPTION
## Summary
- Add a focused Playwright spec for candidate custom-property coverage: create schema from the candidate detail UI, set a value from the candidate table, verify API/detail/table persistence, filter by the property, and assert another org cannot see the property definition.
- Fold the spec into the existing recruiter E2E lane so coverage grows without adding another CI job.
- Closes #143.

## Validation run
- Confirmed no worktree .env or .env.local was present before local E2E validation.
- Used an explicit localhost app URL and disposable local Postgres database only: PLAYWRIGHT_BASE_URL=http://127.0.0.1:3337 and DATABASE_URL=postgresql://douglasebanks@127.0.0.1:55441/factory_careers_e2e.
- Used FACTORY_EMAIL_TEST_MODE=capture with FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-candidate-props-email.jsonl; captured output remained local test sink output only.
- ./node_modules/.bin/playwright test e2e/critical-flows/candidate-custom-properties.spec.ts --workers=1: 1 passed (7.2s).
- npm run test:e2e:recruiter -- --workers=1: 4 passed (18.8s).
- npm run test:unit -- tests/unit/e2e-harness-contract.test.ts tests/unit/e2e-safety.test.ts: 32 passed.
- ./node_modules/.bin/tsc --noEmit: passed.
- Pre-push npm run preflight:pr: passed, including unit suite, typecheck, CLI smoke, production env contract, and build.

## Known risks or skipped checks
- Test-only change; no production or remote-backed E2E run was used.
- Existing Nuxt i18n, Vue route-block, and Tailwind sourcemap warnings still appear during typecheck/build.

## Release/version notes
- Test-only coverage change; no changeset needed.