### PR TITLE
test: cover AI config lifecycle E2E

### DIFF
--- a/app/pages/dashboard/jobs/[id]/ai-analysis.vue
+++ b/app/pages/dashboard/jobs/[id]/ai-analysis.vue
@@ -13,7 +13,7 @@ const jobId = route.params.id as string
 const toast = useToast()
 const { track } = useTrack()
 
-const { job, status: jobFetchStatus, error: jobError, updateJob } = useJob(jobId)
+const { job, status: jobFetchStatus, error: jobError, updateJob, refresh: refreshJob } = useJob(jobId)
 
 useSeoMeta({
   title: computed(() =>
@@ -169,6 +169,10 @@ function loadTemplate(template: 'standard' | 'technical' | 'non_technical') {
 const isGeneratingCriteria = ref(false)
 
 async function generateAiCriteria() {
+  if (isGeneratingCriteria.value) return
+  if (!job.value?.description) {
+    await refreshJob()
+  }
   if (!job.value?.description) {
     toast.warning('Job description required', 'Add a job description first so AI can generate relevant criteria.')
     return

--- a/app/pages/dashboard/settings/ai/[id].vue
+++ b/app/pages/dashboard/settings/ai/[id].vue
@@ -64,6 +64,7 @@ const isReady = computed(() =>
 const notFound = computed(() => isReady.value && !config.value)
 
 async function onSaved() {
+  await refreshNuxtData('ai-configs')
   await navigateTo('/dashboard/settings/ai')
 }
 function onCancel() {

--- a/app/pages/dashboard/settings/ai/index.vue
+++ b/app/pages/dashboard/settings/ai/index.vue
@@ -333,6 +333,7 @@ function modelTitle(c: AiConfigRow): string {
           <div class="flex flex-wrap items-center gap-1.5 shrink-0">
             <button
               v-if="!c.isDefaultChatbot"
+              type="button"
               :disabled="!c.hasApiKey || (togglingDefaultId === c.id && togglingPurpose === 'chatbot')"
               class="ui-button ui-button-secondary px-2.5 py-1.5 text-xs disabled:opacity-50 disabled:cursor-not-allowed"
               :title="c.hasApiKey ? 'Use this model for the chatbot' : 'Add an API key first'"
@@ -345,6 +346,7 @@ function modelTitle(c: AiConfigRow): string {
 
             <button
               v-if="!c.isDefaultAnalysis"
+              type="button"
               :disabled="!c.hasApiKey || (togglingDefaultId === c.id && togglingPurpose === 'analysis')"
               class="ui-button ui-button-secondary px-2.5 py-1.5 text-xs disabled:opacity-50 disabled:cursor-not-allowed"
               :title="c.hasApiKey ? 'Use this model for candidate analysis' : 'Add an API key first'"
@@ -356,6 +358,7 @@ function modelTitle(c: AiConfigRow): string {
             </button>
 
             <button
+              type="button"
               :disabled="testingId === c.id || !c.hasApiKey"
               class="ui-button ui-button-secondary px-2.5 py-1.5 text-xs disabled:opacity-50 disabled:cursor-not-allowed"
               @click="testConnection(c)"
@@ -374,6 +377,7 @@ function modelTitle(c: AiConfigRow): string {
             </NuxtLink>
 
             <button
+              type="button"
               :disabled="deletingId === c.id"
               class="ui-button ui-button-danger-outline px-2.5 py-1.5 text-xs disabled:opacity-50 disabled:cursor-not-allowed"
               @click="deleteConfig(c)"

--- a/app/pages/dashboard/settings/ai/new.vue
+++ b/app/pages/dashboard/settings/ai/new.vue
@@ -58,6 +58,7 @@ const isReady = computed(() =>
 const isFirst = computed(() => (configsData.value ?? []).length === 0)
 
 async function onSaved() {
+  await refreshNuxtData('ai-configs')
   await navigateTo('/dashboard/settings/ai')
 }
 function onCancel() {

--- a/e2e/critical-flows/ai-config-lifecycle.spec.ts
+++ b/e2e/critical-flows/ai-config-lifecycle.spec.ts
@@ -1,0 +1,198 @@
+import { readFile, rm } from 'node:fs/promises'
+import { test, expect } from '../fixtures'
+
+type CapturedAiRequest = {
+  schemaName: string
+  system: string
+  prompt: string
+  provider: string
+  model: string
+}
+
+type AiConfigRow = {
+  id: string
+  name: string
+  model: string
+  isDefaultChatbot: boolean
+  isDefaultAnalysis: boolean
+}
+
+async function readCapturedAiRequests(capturePath: string): Promise<CapturedAiRequest[]> {
+  try {
+    const contents = await readFile(capturePath, 'utf8')
+    return contents
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as CapturedAiRequest)
+  }
+  catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return []
+    throw error
+  }
+}
+
+test.describe('AI configuration lifecycle', () => {
+  test('creates, edits, tests, defaults, and uses local AI config for generated job criteria', async ({ authenticatedPage }, testInfo) => {
+    const capturePath = process.env.FACTORY_AI_CAPTURE_PATH
+    expect(process.env.FACTORY_AI_TEST_MODE, 'AI E2E must use mock mode, not a real provider').toBe('mock')
+    expect(capturePath, 'FACTORY_AI_CAPTURE_PATH must be set for AI E2E').toBeTruthy()
+    await rm(capturePath!, { force: true })
+
+    const page = authenticatedPage
+    const runId = `${Date.now()}-${testInfo.workerIndex}-${testInfo.retry}`
+    const firstConfigName = `Local deterministic AI ${runId}`
+    const editedConfigName = `Edited deterministic AI ${runId}`
+    const analysisConfigName = `Criteria deterministic AI ${runId}`
+    const brokenConfigName = `Broken deterministic AI ${runId}`
+    const jobTitle = `AI Criteria Client Lead ${runId}`
+
+    await page.goto('/dashboard/settings/ai')
+    await expect(page.getByRole('heading', { name: 'AI Configuration' })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('link', { name: 'Add your first model' }).click()
+
+    await expect(page.getByRole('heading', { name: 'Add an AI model' })).toBeVisible({ timeout: 15_000 })
+    await page.getByPlaceholder('e.g. GPT-4o (production)').fill(firstConfigName)
+    await page.getByPlaceholder('sk-…').fill('fake-local-only-key')
+    await Promise.all([
+      page.waitForResponse(resp => resp.url().includes('/api/ai-config') && resp.request().method() === 'POST' && resp.status() === 201),
+      page.getByRole('button', { name: 'Add model' }).click(),
+    ])
+    await expect(page.getByRole('heading', { name: 'AI Configuration' })).toBeVisible({ timeout: 15_000 })
+    const firstRow = page.locator('li').filter({ hasText: firstConfigName })
+    await expect(firstRow.getByRole('heading', { name: firstConfigName })).toBeVisible()
+    await expect(firstRow.getByText('Chatbot default')).toBeVisible()
+    await expect(firstRow.getByText('Analysis default')).toBeVisible()
+
+    await firstRow.getByRole('link', { name: 'Edit' }).click()
+    await expect(page.getByRole('heading', { name: new RegExp(firstConfigName) })).toBeVisible({ timeout: 15_000 })
+    await page.getByPlaceholder('e.g. GPT-4o (production)').fill(editedConfigName)
+    await Promise.all([
+      page.waitForResponse(resp => resp.url().includes('/api/ai-config/') && resp.request().method() === 'PATCH' && resp.status() === 200),
+      page.getByRole('button', { name: 'Save changes' }).click(),
+    ])
+    await expect(page.getByText(editedConfigName)).toBeVisible({ timeout: 15_000 })
+
+    const editedRow = page.locator('li').filter({ hasText: editedConfigName })
+    await Promise.all([
+      page.waitForResponse(resp => resp.url().includes('/test-connection') && resp.request().method() === 'POST' && resp.status() === 200),
+      editedRow.getByRole('button', { name: 'Test' }).click(),
+    ])
+    await expect(editedRow.getByText('Connection verified.')).toBeVisible()
+
+    const analysisConfigResponse = await page.request.post('/api/ai-config', {
+      data: {
+        name: analysisConfigName,
+        provider: 'openai',
+        model: 'factory-e2e-generated-criteria',
+        apiKey: 'fake-local-only-key',
+        maxTokens: 2048,
+      },
+    })
+    expect(analysisConfigResponse.status(), `Analysis config API returned ${analysisConfigResponse.status()}`).toBe(201)
+
+    const brokenConfigResponse = await page.request.post('/api/ai-config', {
+      data: {
+        name: brokenConfigName,
+        provider: 'openai',
+        model: 'factory-e2e-connection-failure',
+        apiKey: 'fake-local-only-key',
+        maxTokens: 256,
+      },
+    })
+    expect(brokenConfigResponse.status(), `Broken config API returned ${brokenConfigResponse.status()}`).toBe(201)
+
+    await page.reload()
+    const analysisRow = page.locator('li').filter({ hasText: analysisConfigName })
+    await Promise.all([
+      page.waitForResponse(resp => resp.url().includes('/set-default') && resp.request().method() === 'POST' && resp.status() === 200),
+      analysisRow.getByRole('button', { name: 'Use for analysis' }).click(),
+    ])
+    await expect(analysisRow.getByText('Analysis default')).toBeVisible({ timeout: 15_000 })
+
+    const configsResponse = await page.request.get('/api/ai-config')
+    expect(configsResponse.status(), `AI config list API returned ${configsResponse.status()}`).toBe(200)
+    const configs = await configsResponse.json() as AiConfigRow[]
+    const defaultAnalysis = configs.find(config => config.isDefaultAnalysis)
+    expect(defaultAnalysis).toMatchObject({
+      name: analysisConfigName,
+      model: 'factory-e2e-generated-criteria',
+    })
+
+    const brokenRow = page.locator('li').filter({ hasText: brokenConfigName })
+    await Promise.all([
+      page.waitForResponse(resp => resp.url().includes('/test-connection') && resp.request().method() === 'POST' && resp.status() === 422),
+      brokenRow.getByRole('button', { name: 'Test' }).click(),
+    ])
+    await expect(brokenRow.getByText('Deterministic E2E connection failure.')).toBeVisible()
+
+    const createJobResponse = await page.request.post('/api/jobs', {
+      data: {
+        title: jobTitle,
+        description: 'Lead client operations for athletes, entertainers, and founders across investments, media ventures, brand services, confidentiality, and high-touch business management.',
+        location: 'New York, NY',
+        type: 'full_time',
+        requireResume: false,
+        requireCoverLetter: false,
+        autoScoreOnApply: false,
+        applicationComplianceEnabled: false,
+      },
+    })
+    expect(createJobResponse.status(), `Create job API returned ${createJobResponse.status()}`).toBe(201)
+    const job = await createJobResponse.json() as { id: string }
+
+    await page.goto(`/dashboard/jobs/${job.id}/ai-analysis`)
+    await expect(page.getByRole('heading', { name: 'AI' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('button', { name: /Generate from job description/ })).toBeVisible()
+
+    const generatedCriteriaResponse = await page.request.post('/api/ai-config/generate-criteria', {
+      data: {
+        title: jobTitle,
+        description: 'Lead client operations for athletes, entertainers, and founders across investments, media ventures, brand services, confidentiality, and high-touch business management.',
+      },
+    })
+    expect(generatedCriteriaResponse.status(), `Generate criteria API returned ${generatedCriteriaResponse.status()}`).toBe(200)
+    const generatedCriteria = await generatedCriteriaResponse.json() as {
+      criteria: Array<{ key: string, name: string, description?: string, category: string, maxScore: number, weight: number }>
+    }
+    expect(generatedCriteria.criteria).toContainEqual(expect.objectContaining({
+      key: 'domain_relevance',
+      name: 'Factory Domain Relevance',
+    }))
+
+    const saveCriteriaResponse = await page.request.post(`/api/jobs/${job.id}/criteria`, {
+      data: {
+        criteria: generatedCriteria.criteria.map((criterion, index) => ({
+          ...criterion,
+          displayOrder: index,
+        })),
+      },
+    })
+    expect(saveCriteriaResponse.status(), `Save criteria API returned ${saveCriteriaResponse.status()}`).toBe(201)
+
+    await page.reload()
+    await expect(page.getByText('Factory Domain Relevance')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Client Operations Judgment')).toBeVisible()
+
+    const criteriaResponse = await page.request.get(`/api/jobs/${job.id}/criteria`)
+    expect(criteriaResponse.status(), `Criteria API returned ${criteriaResponse.status()}`).toBe(200)
+    const criteriaPayload = await criteriaResponse.json() as { criteria: Array<{ key: string, name: string, organizationId: string, jobId: string }> }
+    expect(criteriaPayload.criteria).toContainEqual(expect.objectContaining({
+      key: 'domain_relevance',
+      name: 'Factory Domain Relevance',
+      jobId: job.id,
+    }))
+
+    await expect.poll(async () => (await readCapturedAiRequests(capturePath!)).length, {
+      message: 'AI mock provider should capture connection checks and generated criteria',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(3)
+
+    const captured = await readCapturedAiRequests(capturePath!)
+    const generatedCriteriaRequest = captured.find(request => request.schemaName === 'GeneratedCriteria')
+    expect(generatedCriteriaRequest, 'generated criteria request should be captured').toBeTruthy()
+    expect(generatedCriteriaRequest?.provider).toBe('openai')
+    expect(generatedCriteriaRequest?.model).toBe('factory-e2e-generated-criteria')
+    expect(generatedCriteriaRequest?.prompt).toContain(jobTitle)
+    expect(generatedCriteriaRequest?.prompt).toContain('athletes, entertainers, and founders')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",
     "test:e2e:rbac": "playwright test e2e/critical-flows/rbac-role-permissions.spec.ts",
     "test:e2e:sso": "playwright test e2e/critical-flows/sso-domain-provisioning.spec.ts",
-    "test:e2e:ai-review": "playwright test e2e/critical-flows/ai-candidate-review.spec.ts",
+    "test:e2e:ai-review": "playwright test e2e/critical-flows/ai-candidate-review.spec.ts e2e/critical-flows/ai-config-lifecycle.spec.ts --workers=1",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts e2e/critical-flows/mobile-keyboard-smoke.spec.ts",

--- a/server/api/ai-config/[id]/set-default.post.ts
+++ b/server/api/ai-config/[id]/set-default.post.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { aiConfig } from '../../../database/schema'
 import { setAiConfigDefaultSchema } from '../../../utils/schemas/scoring'
@@ -9,11 +9,9 @@ const paramsSchema = z.object({ id: z.string().min(1) })
  * POST /api/ai-config/:id/set-default
  *
  * Atomically claims one or more "default" slots (chatbot, analysis) for this
- * configuration. Uses a single UPDATE per purpose that sets the flag to true
- * for the chosen row and false for every other row in the same organization,
- * so the "exactly one default per purpose" invariant is preserved even under
- * concurrent requests. The partial unique indexes on `is_default_chatbot` and
- * `is_default_analysis` provide a DB-level backstop.
+ * configuration. Each purpose is cleared before setting the selected row so
+ * Postgres never sees two default rows while enforcing the partial unique
+ * indexes on `is_default_chatbot` and `is_default_analysis`.
  */
 export default defineEventHandler(async (event) => {
   const session = await requirePermission(event, { aiConfig: ['update'] })
@@ -31,18 +29,30 @@ export default defineEventHandler(async (event) => {
     if (body.purposes.includes('chatbot')) {
       await tx.update(aiConfig)
         .set({
-          isDefaultChatbot: sql`${aiConfig.id} = ${id}`,
+          isDefaultChatbot: false,
           updatedAt: new Date(),
         })
         .where(eq(aiConfig.organizationId, orgId))
+      await tx.update(aiConfig)
+        .set({
+          isDefaultChatbot: true,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(aiConfig.id, id), eq(aiConfig.organizationId, orgId)))
     }
     if (body.purposes.includes('analysis')) {
       await tx.update(aiConfig)
         .set({
-          isDefaultAnalysis: sql`${aiConfig.id} = ${id}`,
+          isDefaultAnalysis: false,
           updatedAt: new Date(),
         })
         .where(eq(aiConfig.organizationId, orgId))
+      await tx.update(aiConfig)
+        .set({
+          isDefaultAnalysis: true,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(aiConfig.id, id), eq(aiConfig.organizationId, orgId)))
     }
   })
 

--- a/server/utils/ai/provider.ts
+++ b/server/utils/ai/provider.ts
@@ -257,6 +257,47 @@ export async function generateStructuredOutput<T>(
       }
     }
 
+    if (options.schemaName === 'TestConnection') {
+      if (config.model.includes('connection-failure')) {
+        throw createError({
+          statusCode: 422,
+          statusMessage: 'Deterministic E2E connection failure.',
+        })
+      }
+
+      const object = options.schema.parse({ ok: true })
+
+      return {
+        object,
+        usage: { promptTokens: 4, completionTokens: 2 },
+      }
+    }
+
+    if (options.schemaName === 'GeneratedCriteria') {
+      const object = options.schema.parse({
+        criteria: [{
+          key: 'domain_relevance',
+          name: 'Factory Domain Relevance',
+          description: 'Measures direct experience with athletes, entertainers, founders, investments, media, and business-management workflows.',
+          category: 'experience',
+          maxScore: 10,
+          suggestedWeight: 85,
+        }, {
+          key: 'client_operations',
+          name: 'Client Operations Judgment',
+          description: 'Assesses ability to handle high-touch client operations, confidentiality, prioritization, and detail-heavy follow-through.',
+          category: 'soft_skills',
+          maxScore: 10,
+          suggestedWeight: 70,
+        }],
+      })
+
+      return {
+        object,
+        usage: { promptTokens: 74, completionTokens: 38 },
+      }
+    }
+
     throw createError({
       statusCode: 422,
       statusMessage: `No deterministic AI mock response configured for schema: ${options.schemaName}`,

--- a/tests/unit/ai-provider-mock.test.ts
+++ b/tests/unit/ai-provider-mock.test.ts
@@ -1,0 +1,106 @@
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+const baseEnv = {
+  DATABASE_URL: 'postgresql://user:pass@127.0.0.1:5432/factory_careers_test',
+  BETTER_AUTH_SECRET: 'a'.repeat(32),
+  BETTER_AUTH_URL: 'http://127.0.0.1:3333',
+  S3_ENDPOINT: 'http://127.0.0.1:9000',
+  S3_ACCESS_KEY: 'test-key',
+  S3_SECRET_KEY: 'test-secret',
+  S3_BUCKET: 'test-bucket',
+  FACTORY_AI_TEST_MODE: 'mock',
+}
+
+async function loadProviderWithMockEnv(capturePath: string) {
+  vi.resetModules()
+  ;(globalThis as Record<string, unknown>).__env = undefined
+
+  for (const [key, value] of Object.entries(baseEnv)) {
+    vi.stubEnv(key, value)
+  }
+  vi.stubEnv('NODE_ENV', 'test')
+  vi.stubEnv('FACTORY_AI_CAPTURE_PATH', capturePath)
+  vi.stubGlobal('env', {
+    FACTORY_AI_TEST_MODE: 'mock',
+    FACTORY_AI_CAPTURE_PATH: capturePath,
+  })
+  vi.stubGlobal('createError', (input: { statusMessage?: string }) => new Error(input.statusMessage ?? 'createError'))
+
+  return import('../../server/utils/ai/provider')
+}
+
+describe('deterministic AI provider mock', () => {
+  let capturePath: string
+
+  beforeEach(() => {
+    capturePath = join(tmpdir(), `factory-careers-ai-provider-mock-${Date.now()}-${Math.random()}.jsonl`)
+  })
+
+  afterEach(async () => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    ;(globalThis as Record<string, unknown>).__env = undefined
+    await rm(capturePath, { force: true })
+  })
+
+  it('returns a local success object for connection checks', async () => {
+    const { generateStructuredOutput } = await loadProviderWithMockEnv(capturePath)
+
+    await expect(generateStructuredOutput(
+      {
+        provider: 'openai',
+        model: 'factory-e2e-test-connection',
+        apiKeyEncrypted: 'encrypted-fake-key',
+        maxTokens: 20,
+      },
+      {
+        system: 'Respond with ok: true',
+        prompt: 'Test connection',
+        schemaName: 'TestConnection',
+        schema: z.object({ ok: z.boolean() }),
+      },
+    )).resolves.toMatchObject({
+      object: { ok: true },
+      usage: { promptTokens: expect.any(Number), completionTokens: expect.any(Number) },
+    })
+  })
+
+  it('returns local generated criteria for criteria generation', async () => {
+    const { generateStructuredOutput } = await loadProviderWithMockEnv(capturePath)
+
+    const result = await generateStructuredOutput(
+      {
+        provider: 'openai',
+        model: 'factory-e2e-criteria',
+        apiKeyEncrypted: 'encrypted-fake-key',
+        maxTokens: 2048,
+      },
+      {
+        system: 'Generate safe scoring criteria.',
+        prompt: 'Job Title: Client Services Lead',
+        schemaName: 'GeneratedCriteria',
+        schema: z.object({
+          criteria: z.array(z.object({
+            key: z.string(),
+            name: z.string(),
+            description: z.string(),
+            category: z.enum(['technical', 'experience', 'soft_skills', 'education', 'culture', 'custom']),
+            maxScore: z.number().int().min(1).max(10),
+            suggestedWeight: z.number().int().min(10).max(100),
+          })),
+        }),
+      },
+    )
+
+    expect(result.object.criteria).toContainEqual(expect.objectContaining({
+      key: 'domain_relevance',
+      name: 'Factory Domain Relevance',
+      category: 'experience',
+      maxScore: 10,
+    }))
+  })
+})

--- a/tests/unit/cli-ai-config-commands.test.ts
+++ b/tests/unit/cli-ai-config-commands.test.ts
@@ -148,6 +148,7 @@ describe('CLI AI config commands', () => {
     expect(JSON.parse(defaultOut[0])).toEqual({ success: true })
     expect(JSON.parse(testOut[0])).toEqual({ success: true })
     expect(JSON.parse(deleteOut[0])).toEqual({ success: true })
+    expect(fetchMock).toHaveBeenCalledTimes(5)
   })
 
   it('lists providers, refreshes providers, and generates criteria', async () => {

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -265,7 +265,7 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:ai-review']).toBe(
-      'playwright test e2e/critical-flows/ai-candidate-review.spec.ts',
+      'playwright test e2e/critical-flows/ai-candidate-review.spec.ts e2e/critical-flows/ai-config-lifecycle.spec.ts --workers=1',
     )
     expect(workflow).toContain('name: Playwright AI review')
     expect(workflow).toContain('npm run test:e2e:ai-review')
@@ -273,6 +273,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('FACTORY_AI_CAPTURE_PATH: /tmp/factory-careers-e2e-ai.jsonl')
     expect(workflow).not.toContain('OPENAI_API_KEY: ${{ secrets')
     expect(read('e2e/critical-flows/ai-candidate-review.spec.ts')).toContain('FACTORY_AI_TEST_MODE')
+    expect(read('e2e/critical-flows/ai-config-lifecycle.spec.ts')).toContain('FACTORY_AI_TEST_MODE')
     expect(workflow).toContain('needs.ai_review.result')
     expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review]')
   })


### PR DESCRIPTION
## Summary
- add deterministic AI mock responses for connection checks and generated criteria
- add a mocked AI lifecycle E2E covering dashboard AI config create/edit/test/default selection plus generated criteria persistence
- fix AI config settings cache refresh after save and make set-default avoid partial unique-index collisions

Refs #160, #144.

## Validation run
- npm run test:unit -- tests/unit/cli-ai-config-commands.test.ts tests/unit/ai-provider-mock.test.ts tests/unit/e2e-harness-contract.test.ts
- npm run typecheck
- Local-only E2E: no .env/.env.local present; disposable Postgres at 127.0.0.1:5557; Nuxt at 127.0.0.1:3337; FACTORY_AI_TEST_MODE=mock; FACTORY_AI_CAPTURE_PATH=/tmp/factory-careers-ai-config-ai.jsonl
- PLAYWRIGHT_SKIP_WEB_SERVER=1 ... ./node_modules/.bin/playwright test e2e/critical-flows/ai-config-lifecycle.spec.ts --workers=1
- PLAYWRIGHT_SKIP_WEB_SERVER=1 ... npm run test:e2e:ai-review -- --workers=1
- pre-push npm run preflight:pr completed: CLI parity evidence, full unit suite, typecheck, CLI smoke, production env contract, build

## Known risks or skipped checks
- Criteria generation is exercised through the authenticated local API and then verified on the dashboard after persistence; the generate-card click itself is not asserted in this slice after local Playwright did not emit that request reliably.
- Build/typecheck emit existing Nuxt/Volar/Tailwind warnings, but exit successfully.

## Release/version notes
- No changeset needed; test coverage and bug fixes only.