### PR TITLE
test: cover AI criteria generation UI

### DIFF
--- a/e2e/critical-flows/ai-config-lifecycle.spec.ts
+++ b/e2e/critical-flows/ai-config-lifecycle.spec.ts
@@ -142,32 +142,20 @@ test.describe('AI configuration lifecycle', () => {
 
     await page.goto(`/dashboard/jobs/${job.id}/ai-analysis`)
     await expect(page.getByRole('heading', { name: 'AI' })).toBeVisible({ timeout: 15_000 })
-    await expect(page.getByRole('button', { name: /Generate from job description/ })).toBeVisible()
+    await page.waitForLoadState('networkidle')
+    const generateButton = page.getByRole('button', { name: /Generate from job description/ })
+    await expect(generateButton).toBeVisible()
+    await Promise.all([
+      page.waitForResponse(resp => resp.url().includes('/api/ai-config/generate-criteria') && resp.request().method() === 'POST' && resp.status() === 200),
+      generateButton.click(),
+    ])
+    await expect(page.getByText('Factory Domain Relevance')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Client Operations Judgment')).toBeVisible()
 
-    const generatedCriteriaResponse = await page.request.post('/api/ai-config/generate-criteria', {
-      data: {
-        title: jobTitle,
-        description: 'Lead client operations for athletes, entertainers, and founders across investments, media ventures, brand services, confidentiality, and high-touch business management.',
-      },
-    })
-    expect(generatedCriteriaResponse.status(), `Generate criteria API returned ${generatedCriteriaResponse.status()}`).toBe(200)
-    const generatedCriteria = await generatedCriteriaResponse.json() as {
-      criteria: Array<{ key: string, name: string, description?: string, category: string, maxScore: number, weight: number }>
-    }
-    expect(generatedCriteria.criteria).toContainEqual(expect.objectContaining({
-      key: 'domain_relevance',
-      name: 'Factory Domain Relevance',
-    }))
-
-    const saveCriteriaResponse = await page.request.post(`/api/jobs/${job.id}/criteria`, {
-      data: {
-        criteria: generatedCriteria.criteria.map((criterion, index) => ({
-          ...criterion,
-          displayOrder: index,
-        })),
-      },
-    })
-    expect(saveCriteriaResponse.status(), `Save criteria API returned ${saveCriteriaResponse.status()}`).toBe(201)
+    await Promise.all([
+      page.waitForResponse(resp => resp.url().includes(`/api/jobs/${job.id}/criteria`) && resp.request().method() === 'POST' && resp.status() === 201),
+      page.getByRole('button', { name: 'Save criteria' }).click(),
+    ])
 
     await page.reload()
     await expect(page.getByText('Factory Domain Relevance')).toBeVisible({ timeout: 15_000 })


### PR DESCRIPTION
## Summary
- Replaces the AI criteria generation API shortcut in the AI config lifecycle E2E with the real dashboard generate-button flow.
- Waits for the job AI page to hydrate before clicking, then asserts the mocked AI request, rendered generated criteria, UI save, reload, and persisted job-scoped criteria.
- Finishes the remaining UI-click gap tracked in #144 after PR #186.

## Validation run
- Safe local target only: `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3337`, disposable Postgres at `127.0.0.1:5557`, `FACTORY_AI_TEST_MODE=mock`, capture path `/tmp/factory-careers-ai-ui.jsonl`.
- `./node_modules/.bin/playwright test e2e/critical-flows/ai-config-lifecycle.spec.ts --workers=1` (1 passed, 8.1s)
- `npm run test:e2e:ai-review` (2 passed, 12.0s)
- `git diff --check`
- Pre-push `npm run preflight:pr` passed: unit tests, typecheck, CLI smoke, production env contract, build.

## Known risks or skipped checks
- No production or remote app/database target was used. `.env` and `.env.local` were absent before local E2E.
- Existing typecheck warning remains: Vue/Volar cannot resolve `vue-router/volar/sfc-route-blocks` package subpath.

## Release/version notes
- Test-only change. No changeset needed.

Refs #144