### PR TITLE
test: cover privacy request fulfillment

### DIFF
--- a/e2e/critical-flows/privacy-request-fake-mail.spec.ts
+++ b/e2e/critical-flows/privacy-request-fake-mail.spec.ts
@@ -1,4 +1,5 @@
 import { rm } from 'node:fs/promises'
+import type { Page } from '@playwright/test'
 import { test, expect, selectFactorySelectOption } from '../fixtures'
 import postgres from 'postgres'
 import type { Sql } from 'postgres'
@@ -6,26 +7,40 @@ import { type CapturedEmail, readCapturedEmails } from '../helpers/captured-emai
 
 type PrivacyRequestRecord = {
   id: string
+  organizationId: string | null
   status: string
   requesterName: string
   requesterEmail: string
   stateOfResidence: string
+  applicationId: string | null
   details: string | null
   verificationTokenHash: string
   verifiedAt: Date | null
+  completedAt: Date | null
+  resolutionNotes: string | null
+}
+
+type CandidateApplicationRecord = {
+  candidateId: string
+  applicationId: string
+  organizationId: string
 }
 
 async function lookupPrivacyRequest(sql: Sql, requesterEmail: string) {
   const [request] = await sql<PrivacyRequestRecord[]>`
     select
       id,
+      organization_id as "organizationId",
       status,
       requester_name as "requesterName",
       requester_email as "requesterEmail",
       state_of_residence as "stateOfResidence",
+      application_id as "applicationId",
       details,
       verification_token_hash as "verificationTokenHash",
-      verified_at as "verifiedAt"
+      verified_at as "verifiedAt",
+      completed_at as "completedAt",
+      resolution_notes as "resolutionNotes"
     from privacy_request
     where requester_email = ${requesterEmail}
     order by created_at desc
@@ -35,12 +50,94 @@ async function lookupPrivacyRequest(sql: Sql, requesterEmail: string) {
   return request ?? null
 }
 
+async function lookupCandidateApplication(sql: Sql, requesterEmail: string) {
+  const [record] = await sql<CandidateApplicationRecord[]>`
+    select
+      c.id as "candidateId",
+      a.id as "applicationId",
+      c.organization_id as "organizationId"
+    from candidate c
+    join application a on a.candidate_id = c.id and a.organization_id = c.organization_id
+    where c.email = ${requesterEmail}
+    order by a.created_at desc
+    limit 1
+  `
+
+  return record ?? null
+}
+
+async function countCandidateRows(sql: Sql, candidateId: string) {
+  const [row] = await sql<{ count: number }[]>`
+    select count(*)::int as count
+    from candidate
+    where id = ${candidateId}
+  `
+  return row?.count ?? 0
+}
+
+async function countApplicationRows(sql: Sql, applicationId: string) {
+  const [row] = await sql<{ count: number }[]>`
+    select count(*)::int as count
+    from application
+    where id = ${applicationId}
+  `
+  return row?.count ?? 0
+}
+
+async function countPrivacyAuditRows(sql: Sql, organizationId: string, requestId: string) {
+  const [row] = await sql<{ count: number }[]>`
+    select count(*)::int as count
+    from activity_log
+    where organization_id = ${organizationId}
+      and resource_type = 'privacy_request'
+      and resource_id = ${requestId}
+      and action = 'deleted'
+  `
+  return row?.count ?? 0
+}
+
 function extractVerifyUrl(email: CapturedEmail) {
   const content = `${email.text}\n${email.html}`
   const path = content.match(/\/api\/privacy-requests\/verify\?token=[^\s"'<>]+/)?.[0]
   if (!path) return ''
 
   return new URL(path, process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3333').toString()
+}
+
+async function signUpAndCreateOrganization(page: Page, id: string) {
+  const account = {
+    name: `Privacy Other ${id}`,
+    email: `privacy.other.${id}@test.local`,
+    password: 'TestPassword123!',
+    orgName: `Privacy Other Org ${id}`,
+  }
+
+  await page.goto('/auth/sign-up')
+  await page.waitForLoadState('networkidle')
+  await page.getByLabel('Name').fill(account.name)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password', { exact: true }).fill(account.password)
+  await page.getByLabel('Confirm password').fill(account.password)
+  await Promise.all([
+    page.waitForResponse(resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200),
+    page.getByRole('button', { name: 'Sign up' }).click(),
+  ])
+  await page.waitForURL(url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'), { timeout: 30_000 })
+
+  if (page.url().includes('/auth/sign-in')) {
+    await page.getByLabel('Email').fill(account.email)
+    await page.getByLabel('Password').fill(account.password)
+    await Promise.all([
+      page.waitForResponse(resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200),
+      page.getByRole('button', { name: 'Sign in' }).click(),
+    ])
+    await page.waitForURL('**/onboarding/**', { timeout: 30_000 })
+  }
+
+  await page.getByLabel('Organization name').waitFor({ state: 'visible', timeout: 30_000 })
+  await page.getByLabel('Organization name').fill(account.orgName)
+  await page.getByRole('button', { name: 'Create organization' }).click()
+  await page.waitForURL('**/dashboard**', { waitUntil: 'commit', timeout: 30_000 })
 }
 
 test.describe('Privacy request fake mail', () => {
@@ -143,6 +240,167 @@ test.describe('Privacy request fake mail', () => {
       expect(confirmationEmail?.renderError, 'requester confirmation email should render successfully').toBeUndefined()
       expect(confirmationEmail?.to).toContain(requester.email)
       expect(confirmationEmail?.text).toContain('Request verified')
+    }
+    finally {
+      await sql.end()
+    }
+  })
+
+  test('fulfills a verified deletion request from the dashboard and removes matched applicant data', async ({ authenticatedPage, browser }, testInfo) => {
+    const capturePath = process.env.FACTORY_EMAIL_CAPTURE_PATH
+    expect(capturePath, 'FACTORY_EMAIL_CAPTURE_PATH must be set for privacy request E2E').toBeTruthy()
+    expect(process.env.FACTORY_EMAIL_TEST_MODE, 'E2E mail must use capture mode, not a real provider').toBe('capture')
+    expect(process.env.DATABASE_URL, 'DATABASE_URL is required for privacy request e2e coverage').toBeTruthy()
+
+    await rm(capturePath!, { force: true })
+    const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+    const page = authenticatedPage
+    const id = `${Date.now()}-${testInfo.workerIndex}-${Math.random().toString(36).slice(2)}`
+    const requester = {
+      firstName: 'Privacy',
+      lastName: `Applicant ${id}`,
+      name: `Privacy Applicant ${id}`,
+      email: `privacy.applicant.${id}@example.com`,
+      state: 'California',
+      applicationState: 'CA',
+    }
+
+    try {
+      const createJobResponse = await page.request.post('/api/jobs', {
+        data: {
+          title: `Privacy Fulfillment Role ${id}`,
+          description: 'Role used to verify privacy request fulfillment removes applicant data.',
+          location: 'Remote',
+          type: 'full_time',
+          requireResume: false,
+          requireCoverLetter: false,
+          autoScoreOnApply: false,
+          applicationComplianceEnabled: false,
+        },
+      })
+      expect(createJobResponse.status(), `Create job API returned ${createJobResponse.status()}`).toBe(201)
+      const createdJob = await createJobResponse.json() as { id: string, slug: string }
+
+      const publishJobResponse = await page.request.patch(`/api/jobs/${createdJob.id}`, {
+        data: { status: 'open' },
+      })
+      expect(publishJobResponse.status(), `Publish job API returned ${publishJobResponse.status()}`).toBe(200)
+
+      const applyResponse = await page.request.post(`/api/public/jobs/${createdJob.slug}/apply`, {
+        data: {
+          firstName: requester.firstName,
+          lastName: requester.lastName,
+          email: requester.email,
+          phone: '555-0100',
+          country: 'United States',
+          state: requester.applicationState,
+          coverLetterText: 'Please delete this applicant record when the privacy request is fulfilled.',
+          responses: [],
+        },
+      })
+      expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
+
+      const candidateApplication = await lookupCandidateApplication(sql, requester.email)
+      expect(candidateApplication, 'candidate/application fixture should be persisted').toBeTruthy()
+
+      const privacyResponse = await page.request.post('/api/privacy-requests', {
+        data: {
+          requesterName: requester.name,
+          requesterEmail: requester.email,
+          stateOfResidence: requester.state,
+          applicationId: candidateApplication!.applicationId,
+          requestContext: `Privacy Fulfillment Role ${id}`,
+          details: 'Please delete the application and candidate profile linked to this request.',
+        },
+      })
+      expect(privacyResponse.status(), `Privacy request API returned ${privacyResponse.status()}`).toBe(202)
+
+      await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+        message: 'privacy request should capture verification email',
+        timeout: 10_000,
+      }).toBeGreaterThanOrEqual(1)
+
+      const verificationEmail = (await readCapturedEmails(capturePath!))
+        .find((email) => email.subject === 'Verify your deletion request — Factory Careers')
+      expect(verificationEmail, 'requester verification email should be captured').toBeTruthy()
+      const verifyUrl = extractVerifyUrl(verificationEmail!)
+      expect(verifyUrl).toContain('/api/privacy-requests/verify?token=')
+      expect(verifyUrl).not.toContain('thefactoryhq.com')
+
+      const verifyResponse = await page.request.get(verifyUrl)
+      expect(verifyResponse.status()).toBe(200)
+      await expect.poll(async () => (await lookupPrivacyRequest(sql, requester.email))?.status, {
+        message: 'privacy request should move to verified before dashboard fulfillment',
+        timeout: 10_000,
+      }).toBe('verified')
+
+      const verifiedRequest = await lookupPrivacyRequest(sql, requester.email)
+      expect(verifiedRequest).toMatchObject({
+        organizationId: candidateApplication!.organizationId,
+        applicationId: candidateApplication!.applicationId,
+        requesterEmail: requester.email,
+      })
+      expect(verifiedRequest?.verifiedAt).toBeTruthy()
+
+      const otherContext = await browser.newContext()
+      const otherPage = await otherContext.newPage()
+      try {
+        await signUpAndCreateOrganization(otherPage, id)
+        const wrongTenantDetail = await otherPage.request.get(`/api/privacy-requests/${verifiedRequest!.id}`)
+        expect(wrongTenantDetail.status(), `Wrong-tenant detail API returned ${wrongTenantDetail.status()}`).toBe(404)
+        const wrongTenantFulfill = await otherPage.request.post(`/api/privacy-requests/${verifiedRequest!.id}/fulfill`, {
+          data: {
+            candidateIds: [candidateApplication!.candidateId],
+            resolutionNotes: 'Wrong tenant should not fulfill this request.',
+          },
+        })
+        expect(wrongTenantFulfill.status(), `Wrong-tenant fulfill API returned ${wrongTenantFulfill.status()}`).toBe(404)
+      }
+      finally {
+        await otherContext.close()
+      }
+
+      await page.goto('/dashboard/settings/privacy-requests')
+      await page.waitForLoadState('networkidle')
+      await expect(page.getByRole('heading', { name: 'Privacy Requests' })).toBeVisible({ timeout: 15_000 })
+      await expect(page.getByRole('button', { name: new RegExp(requester.email) })).toBeVisible()
+      await expect(page.getByText(requester.email).first()).toBeVisible()
+      await expect(page.getByText('verified').first()).toBeVisible()
+      await expect(page.getByText(requester.name).first()).toBeVisible()
+      await expect(page.getByText(requester.email).nth(1)).toBeVisible()
+
+      await page.getByRole('checkbox', { name: new RegExp(requester.email) }).check()
+      await page.getByLabel('Resolution notes').fill(`Completed deletion for ${requester.email}`)
+      await Promise.all([
+        page.waitForResponse(resp => resp.url().includes(`/api/privacy-requests/${verifiedRequest!.id}/fulfill`) && resp.request().method() === 'POST' && resp.status() === 200),
+        page.getByRole('button', { name: 'Fulfill deletion' }).click(),
+      ])
+
+      await expect(page.getByText('Deletion request fulfilled.')).toBeVisible({ timeout: 10_000 })
+      await expect(page.getByText('completed').first()).toBeVisible()
+      await expect(page.getByText('No candidates match this verified email in the active organization.')).toBeVisible()
+
+      await expect.poll(() => countCandidateRows(sql, candidateApplication!.candidateId), {
+        message: 'fulfillment should delete matched candidate personal data',
+        timeout: 10_000,
+      }).toBe(0)
+      await expect.poll(() => countApplicationRows(sql, candidateApplication!.applicationId), {
+        message: 'fulfillment should cascade-delete matched application data',
+        timeout: 10_000,
+      }).toBe(0)
+
+      const completedRequest = await lookupPrivacyRequest(sql, requester.email)
+      expect(completedRequest).toMatchObject({
+        id: verifiedRequest!.id,
+        status: 'completed',
+        organizationId: candidateApplication!.organizationId,
+      })
+      expect(completedRequest?.completedAt).toBeTruthy()
+      expect(completedRequest?.resolutionNotes).toContain(requester.email)
+      await expect.poll(() => countPrivacyAuditRows(sql, candidateApplication!.organizationId, verifiedRequest!.id), {
+        message: 'privacy fulfillment should preserve an audit trail',
+        timeout: 10_000,
+      }).toBeGreaterThanOrEqual(1)
     }
     finally {
       await sql.end()

--- a/e2e/critical-flows/privacy-request-fake-mail.spec.ts
+++ b/e2e/critical-flows/privacy-request-fake-mail.spec.ts
@@ -104,6 +104,10 @@ function extractVerifyUrl(email: CapturedEmail) {
   return new URL(path, process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3333').toString()
 }
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 async function signUpAndCreateOrganization(page: Page, id: string) {
   const account = {
     name: `Privacy Other ${id}`,
@@ -119,19 +123,19 @@ async function signUpAndCreateOrganization(page: Page, id: string) {
   await page.getByLabel('Password', { exact: true }).fill(account.password)
   await page.getByLabel('Confirm password').fill(account.password)
   await Promise.all([
-    page.waitForResponse(resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200),
+    page.waitForResponse(resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200, { timeout: 30_000 }),
     page.getByRole('button', { name: 'Sign up' }).click(),
   ])
-  await page.waitForURL(url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'), { timeout: 30_000 })
+  await page.waitForURL(url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'), { waitUntil: 'commit', timeout: 30_000 })
 
   if (page.url().includes('/auth/sign-in')) {
     await page.getByLabel('Email').fill(account.email)
     await page.getByLabel('Password').fill(account.password)
     await Promise.all([
-      page.waitForResponse(resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200),
+      page.waitForResponse(resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200, { timeout: 30_000 }),
       page.getByRole('button', { name: 'Sign in' }).click(),
     ])
-    await page.waitForURL('**/onboarding/**', { timeout: 30_000 })
+    await page.waitForURL('**/onboarding/**', { waitUntil: 'commit', timeout: 30_000 })
   }
 
   await page.getByLabel('Organization name').waitFor({ state: 'visible', timeout: 30_000 })
@@ -363,13 +367,14 @@ test.describe('Privacy request fake mail', () => {
       await page.goto('/dashboard/settings/privacy-requests')
       await page.waitForLoadState('networkidle')
       await expect(page.getByRole('heading', { name: 'Privacy Requests' })).toBeVisible({ timeout: 15_000 })
-      await expect(page.getByRole('button', { name: new RegExp(requester.email) })).toBeVisible()
+      const requesterEmailPattern = new RegExp(escapeRegExp(requester.email))
+      await expect(page.getByRole('button', { name: requesterEmailPattern })).toBeVisible()
       await expect(page.getByText(requester.email).first()).toBeVisible()
       await expect(page.getByText('verified').first()).toBeVisible()
       await expect(page.getByText(requester.name).first()).toBeVisible()
       await expect(page.getByText(requester.email).nth(1)).toBeVisible()
 
-      await page.getByRole('checkbox', { name: new RegExp(requester.email) }).check()
+      await page.getByRole('checkbox', { name: requesterEmailPattern }).check()
       await page.getByLabel('Resolution notes').fill(`Completed deletion for ${requester.email}`)
       await Promise.all([
         page.waitForResponse(resp => resp.url().includes(`/api/privacy-requests/${verifiedRequest!.id}/fulfill`) && resp.request().method() === 'POST' && resp.status() === 200),


### PR DESCRIPTION
## Summary
- Extends the privacy fake-mail E2E lane with dashboard fulfillment coverage for verified deletion requests.
- Seeds a realistic published job application, submits and verifies a linked deletion request, blocks wrong-tenant access/fulfillment, fulfills from the dashboard, and verifies applicant deletion plus completed request/audit persistence.
- Keeps the scenario in the existing fake-mail/capture E2E lane so it exercises the production path without sending real email.

## Validation run
- Safety boundary before mutating E2E: no .env/.env.local present; app target was http://127.0.0.1:3338; DB was disposable local Postgres at 127.0.0.1:5558; email mode was FACTORY_EMAIL_TEST_MODE=capture with FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-privacy-email.jsonl.
- npm run test:unit -- tests/unit/e2e-harness-contract.test.ts tests/unit/privacy-request-contracts.test.ts (32 passed)
- npm run test:e2e:email (4 passed, 11.7s)
- git diff --check
- npm run preflight:pr (unit/typecheck/CLI smoke/production env/build passed; existing Volar route-block warning only)

## Known risks or skipped checks
- No production or remote targets were used for mutating E2E; the run used a disposable local DB and captured email only.
- This is intentionally scoped to the email/privacy lane and does not broaden browser/project coverage beyond the existing lane.

## Release/version notes
- Test-only change; no changeset needed.

Refs #142
Refs #162