### PR TITLE
test: cover production session cache e2e

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1178,10 +1178,80 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  production_session:
+    name: Playwright production session
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: factory_e2e
+          POSTGRES_PASSWORD: factory_e2e
+          POSTGRES_DB: factory_careers_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U factory_e2e -d factory_careers_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://factory_e2e:factory_e2e@127.0.0.1:5432/factory_careers_e2e
+      BETTER_AUTH_SECRET: ci-e2e-auth-secret-with-at-least-32-chars
+      BETTER_AUTH_URL: http://127.0.0.1:3334
+      BETTER_AUTH_TRUSTED_ORIGINS: http://127.0.0.1:3334
+      NUXT_PUBLIC_SITE_URL: http://127.0.0.1:3334
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3334
+      FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
+      FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_ACCESS_KEY: e2e-access-key
+      S3_SECRET_KEY: e2e-secret-key
+      S3_BUCKET: factory-careers-e2e
+      S3_REGION: us-east-1
+      S3_FORCE_PATH_STYLE: "true"
+      S3_SKIP_BUCKET_INIT: "true"
+      SMTP_FROM: e2e@example.com
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_READ_TOKEN }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run production-build session cache browser check
+        run: npm run test:e2e:production-session
+
+      - name: Upload Playwright production session report
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-production-session-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-required:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review]
+    needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review, production_session]
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     steps:
       - name: Verify layered E2E jobs
@@ -1250,6 +1320,10 @@ jobs:
           fi
           if [ "${{ needs.ai_review.result }}" != "success" ]; then
             echo "Playwright AI review finished with result: ${{ needs.ai_review.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.production_session.result }}" != "success" ]; then
+            echo "Playwright production session finished with result: ${{ needs.production_session.result }}"
             exit 1
           fi
           echo "Layered Playwright E2E checks passed."

--- a/e2e/critical-flows/production-session-cache.spec.ts
+++ b/e2e/critical-flows/production-session-cache.spec.ts
@@ -1,0 +1,76 @@
+import { type Page } from '@playwright/test'
+import { test, expect, type TestAccount } from '../fixtures'
+
+async function signUpAndCreateOrganization(page: Page, account: TestAccount) {
+  await page.goto('/auth/sign-up')
+  await page.waitForLoadState('networkidle')
+  await page.getByLabel('Name').fill(account.name)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password', { exact: true }).fill(account.password)
+  await page.getByLabel('Confirm password').fill(account.password)
+
+  await Promise.all([
+    page.waitForResponse(
+      resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200,
+      { timeout: 30_000 },
+    ),
+    page.getByRole('button', { name: 'Sign up' }).click(),
+  ])
+
+  await page.waitForURL(
+    url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'),
+    { waitUntil: 'commit', timeout: 30_000 },
+  )
+
+  if (page.url().includes('/auth/sign-in')) {
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Email').fill(account.email)
+    await page.getByLabel('Password').fill(account.password)
+
+    await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200,
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Sign in' }).click(),
+    ])
+
+    await page.waitForURL('**/onboarding/**', { waitUntil: 'commit', timeout: 30_000 })
+  }
+
+  await page.getByLabel('Organization name').waitFor({ state: 'visible', timeout: 30_000 })
+  await page.getByLabel('Organization name').fill(account.orgName)
+  await page.getByRole('button', { name: 'Create organization' }).click()
+  await page.waitForURL('**/dashboard**', { waitUntil: 'commit', timeout: 30_000 })
+}
+
+test.describe('Production build session cache boundaries', () => {
+  test('does not reuse unauthenticated dashboard cache after signup and reload', async ({ page, testAccount }) => {
+    const unauthenticatedStats = await page.request.get('/api/dashboard/stats')
+    expect(
+      [401, 403],
+      `Unauthenticated dashboard stats API returned ${unauthenticatedStats.status()}`,
+    ).toContain(unauthenticatedStats.status())
+
+    await signUpAndCreateOrganization(page, testAccount)
+    await expect(page.getByRole('heading', { name: 'Welcome to Factory Careers' })).toBeVisible({ timeout: 15_000 })
+
+    const signedInStats = await page.request.get('/api/dashboard/stats')
+    expect(signedInStats.status(), `Signed-in dashboard stats API returned ${signedInStats.status()}`).toBe(200)
+
+    await page.reload({ waitUntil: 'networkidle' })
+    await expect(page.getByRole('heading', { name: 'Welcome to Factory Careers' })).toBeVisible({ timeout: 15_000 })
+    await expect(page).not.toHaveURL(/\/auth\/sign-in/)
+
+    const reloadedStats = await page.request.get('/api/dashboard/stats')
+    expect(reloadedStats.status(), `Reloaded dashboard stats API returned ${reloadedStats.status()}`).toBe(200)
+
+    await page.goto('/dashboard/settings', { waitUntil: 'networkidle' })
+    await expect(page.getByRole('heading', { name: 'General' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByLabel('Organization name')).toHaveValue(testAccount.orgName)
+
+    await page.reload({ waitUntil: 'networkidle' })
+    await expect(page.getByRole('heading', { name: 'General' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByLabel('Organization name')).toHaveValue(testAccount.orgName)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:e2e:rbac": "playwright test e2e/critical-flows/rbac-role-permissions.spec.ts",
     "test:e2e:sso": "playwright test e2e/critical-flows/sso-domain-provisioning.spec.ts",
     "test:e2e:ai-review": "playwright test e2e/critical-flows/ai-candidate-review.spec.ts e2e/critical-flows/ai-config-lifecycle.spec.ts --workers=1",
+    "test:e2e:production-session": "playwright test --config playwright.production.config.ts e2e/critical-flows/production-session-cache.spec.ts --workers=1",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
     "test:e2e:ui": "playwright test e2e/critical-flows/invitation-management.spec.ts e2e/critical-flows/mobile-keyboard-smoke.spec.ts",

--- a/playwright.production.config.ts
+++ b/playwright.production.config.ts
@@ -1,0 +1,80 @@
+import { defineConfig, devices } from '@playwright/test'
+import { assertMutatingE2ESafety } from './e2e/safety'
+
+assertMutatingE2ESafety()
+
+function shellEnv(name: string, value: string | undefined) {
+  return value ? `${name}=${JSON.stringify(value)}` : ''
+}
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3334'
+const serverUrl = new URL(baseURL)
+const serverHost = serverUrl.hostname
+const serverPort = serverUrl.port || (serverUrl.protocol === 'https:' ? '443' : '80')
+
+const webServerEnv = [
+  `HOST=${JSON.stringify(serverHost)}`,
+  `PORT=${JSON.stringify(serverPort)}`,
+  `NITRO_HOST=${JSON.stringify(serverHost)}`,
+  `NITRO_PORT=${JSON.stringify(serverPort)}`,
+  `BETTER_AUTH_URL=${JSON.stringify(baseURL)}`,
+  `BETTER_AUTH_TRUSTED_ORIGINS=${JSON.stringify(process.env.BETTER_AUTH_TRUSTED_ORIGINS || baseURL)}`,
+  `NUXT_PUBLIC_SITE_URL=${JSON.stringify(process.env.NUXT_PUBLIC_SITE_URL || baseURL)}`,
+  'FACTORY_DISABLE_PUBLIC_SIGNUP=false',
+  'FACTORY_DISABLE_PUBLIC_ORG_CREATION=false',
+  shellEnv('DATABASE_URL', process.env.DATABASE_URL),
+  shellEnv('BETTER_AUTH_SECRET', process.env.BETTER_AUTH_SECRET),
+  shellEnv('S3_ENDPOINT', process.env.S3_ENDPOINT),
+  shellEnv('S3_ACCESS_KEY', process.env.S3_ACCESS_KEY),
+  shellEnv('S3_SECRET_KEY', process.env.S3_SECRET_KEY),
+  shellEnv('S3_BUCKET', process.env.S3_BUCKET),
+  shellEnv('S3_REGION', process.env.S3_REGION),
+  shellEnv('S3_FORCE_PATH_STYLE', process.env.S3_FORCE_PATH_STYLE),
+  shellEnv('S3_SKIP_BUCKET_INIT', process.env.S3_SKIP_BUCKET_INIT),
+  shellEnv('SMTP_FROM', process.env.SMTP_FROM),
+].filter(Boolean).join(' ')
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI
+    ? [
+        ['github'],
+        ['html', { open: 'never' }],
+      ]
+    : [
+        ['html'],
+      ],
+  timeout: process.env.CI ? 90_000 : 60_000,
+  expect: { timeout: 10_000 },
+
+  use: {
+    baseURL,
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+    trace: process.env.CI ? 'retain-on-failure' : 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  ...(process.env.PLAYWRIGHT_SKIP_WEB_SERVER
+    ? {}
+    : {
+        webServer: {
+          command: `${webServerEnv} npm run db:migrate && ${webServerEnv} npm run build && ${webServerEnv} node .output/server/index.mjs`,
+          url: baseURL,
+          reuseExistingServer: true,
+          timeout: process.env.CI ? 180_000 : 120_000,
+        },
+      }),
+})

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 const root = process.cwd()
 const emptyCatchPattern = /\.catch\s*\(\s*(?:\([^)]*\)|[$A-Z_a-z][$\w]*)\s*=>\s*\{\s*\}\s*\)/m
+const e2eRequiredNeeds = 'needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review, production_session]'
 
 function read(path: string): string {
   return readFileSync(join(root, path), 'utf8')
@@ -80,7 +81,7 @@ describe('Playwright E2E harness contract', () => {
 
     expect(workflow).toContain('name: Playwright UI')
     expect(workflow).toContain('npm run test:e2e:ui')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review]')
+    expect(workflow).toContain(e2eRequiredNeeds)
     expect(workflow).toContain('needs.ui.result')
   })
 
@@ -164,7 +165,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:tracking-analytics')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.tracking_analytics.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review]')
+    expect(workflow).toContain(e2eRequiredNeeds)
   })
 
   it('runs interview scheduling lifecycle browser coverage in a dedicated CI lane', () => {
@@ -185,7 +186,7 @@ describe('Playwright E2E harness contract', () => {
     expect(read('e2e/critical-flows/interview-invitation-response.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
     expect(read('e2e/critical-flows/interview-template-management.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
     expect(workflow).toContain('needs.interviews.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review]')
+    expect(workflow).toContain(e2eRequiredNeeds)
   })
 
   it('runs calendar integration browser coverage against a deterministic mock provider', () => {
@@ -205,7 +206,7 @@ describe('Playwright E2E harness contract', () => {
     expect(calendarJob).not.toContain('MICROSOFT_CALENDAR_CLIENT_SECRET')
     expect(read('e2e/critical-flows/calendar-integration.spec.ts')).toContain('FACTORY_CALENDAR_TEST_MODE')
     expect(workflow).toContain('needs.calendar.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review]')
+    expect(workflow).toContain(e2eRequiredNeeds)
   })
 
   it('runs auth and organization edge-flow browser coverage in a dedicated CI lane', () => {
@@ -221,7 +222,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:auth-org')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.auth_org.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review]')
+    expect(workflow).toContain(e2eRequiredNeeds)
   })
 
   it('runs role-permission browser coverage in a dedicated CI lane', () => {
@@ -237,7 +238,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:rbac')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
     expect(workflow).toContain('needs.rbac.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review]')
+    expect(workflow).toContain(e2eRequiredNeeds)
   })
 
   it('runs SSO domain provisioning browser coverage against local-only IdP origins', () => {
@@ -255,7 +256,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('E2E_SSO_MOCK_PORT: "3999"')
     expect(workflow).not.toContain('OIDC_CLIENT_SECRET: ${{ secrets')
     expect(workflow).toContain('needs.sso.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review]')
+    expect(workflow).toContain(e2eRequiredNeeds)
   })
 
   it('runs AI candidate-review browser coverage against a deterministic mock provider', () => {
@@ -275,7 +276,7 @@ describe('Playwright E2E harness contract', () => {
     expect(read('e2e/critical-flows/ai-candidate-review.spec.ts')).toContain('FACTORY_AI_TEST_MODE')
     expect(read('e2e/critical-flows/ai-config-lifecycle.spec.ts')).toContain('FACTORY_AI_TEST_MODE')
     expect(workflow).toContain('needs.ai_review.result')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review]')
+    expect(workflow).toContain(e2eRequiredNeeds)
   })
 
   it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
@@ -291,7 +292,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review]')
+    expect(workflow).toContain(e2eRequiredNeeds)
   })
 
   it('runs core tenant/document/RBAC security checks in CI', () => {
@@ -316,11 +317,30 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.security-extended.result')
   })
 
+  it('runs production-build session cache coverage in a dedicated CI lane', () => {
+    const workflow = read('.github/workflows/e2e-tests.yml')
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>
+    }
+
+    expect(packageJson.scripts?.['test:e2e:production-session']).toBe(
+      'playwright test --config playwright.production.config.ts e2e/critical-flows/production-session-cache.spec.ts --workers=1',
+    )
+    expect(workflow).toContain('name: Playwright production session')
+    expect(workflow).toContain('npm run test:e2e:production-session')
+    expect(workflow).toContain('PLAYWRIGHT_BASE_URL: http://127.0.0.1:3334')
+    expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(read('playwright.production.config.ts')).toContain('node .output/server/index.mjs')
+    expect(read('e2e/critical-flows/production-session-cache.spec.ts')).toContain('/api/dashboard/stats')
+    expect(workflow).toContain('needs.production_session.result')
+    expect(workflow).toContain(e2eRequiredNeeds)
+  })
+
   it('keeps the branch-protection E2E status as an aggregate of the split jobs', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
 
     expect(workflow).toContain('name: Playwright E2E')
-    expect(workflow).toContain('needs: [smoke, security-core, security-extended, uploads, ui, candidate, recruiter, job_lifecycle, email, tracking_analytics, interviews, calendar, auth_org, rbac, sso, ai_review]')
+    expect(workflow).toContain(e2eRequiredNeeds)
     expect(workflow).toContain('needs.smoke.result')
     expect(workflow).toContain('needs.security-core.result')
     expect(workflow).toContain('needs.security-extended.result')
@@ -335,6 +355,7 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.auth_org.result')
     expect(workflow).toContain('needs.rbac.result')
     expect(workflow).toContain('needs.sso.result')
+    expect(workflow).toContain('needs.production_session.result')
   })
 
   it('keeps Playwright parallel-ready for independent smoke specs', () => {


### PR DESCRIPTION
## Summary
- Adds a tiny production-build Playwright config that migrates, builds once, and starts the built Nitro server on a local-only port.
- Adds one production session/cache spec that warms an unauthenticated dashboard stats response, signs up and creates an org, verifies authenticated dashboard stats, reloads, and verifies API-backed settings still use the signed-in session.
- Wires the new production session lane into the required E2E aggregate so production-mode auth/cache regressions fail CI.

## Validation run
- Safety boundary before mutating E2E: no .env/.env.local present; app target was http://127.0.0.1:3334; DB was disposable local Postgres at 127.0.0.1:5559; no real email provider; S3 bucket init skipped.
- npm run test:e2e:production-session (1 passed, 41.5s)
- npm run test:unit -- tests/unit/e2e-harness-contract.test.ts (26 passed)
- npm run check:conventions
- ./node_modules/.bin/tsc --noEmit --pretty false
- git diff --check
- git push preflight:pr passed: unit/typecheck/CLI smoke/production env/build; existing Volar route-block warning only.

## Known risks or skipped checks
- This intentionally adds one CI job that performs a production build. Browser coverage is one spec/one worker to keep the added runtime bounded.
- No production or remote targets were used; local validation used a disposable DB and local-only app URL.

## Release/version notes
- Test/CI-only change; no changeset needed.

Refs #170