### PR TITLE
test: cover dashboard document uploads e2e

### DIFF
--- a/e2e/critical-flows/candidate-documents.spec.ts
+++ b/e2e/critical-flows/candidate-documents.spec.ts
@@ -1,0 +1,188 @@
+import type { APIRequestContext, APIResponse, Page } from '@playwright/test'
+import { test, expect } from '../fixtures'
+import { INVALID_PNG } from '../fixtures/test-buffers'
+
+type CandidateRecord = {
+  id: string
+  email: string
+  firstName: string
+  lastName: string
+}
+
+type CandidateDocument = {
+  id: string
+  type: string
+  originalFilename: string
+  mimeType: string
+  parsed: boolean
+}
+
+function createTextPdf(text: string): Buffer {
+  const pdfText = text.replace(/[\\()]/g, match => `\\${match}`)
+  const streamContent = `BT /F1 12 Tf 72 700 Td (${pdfText}) Tj ET`
+  const chunks = ['%PDF-1.4\n']
+  const offsets = [0]
+
+  function appendObject(index: number, body: string) {
+    offsets[index] = Buffer.byteLength(chunks.join(''), 'utf8')
+    chunks.push(`${index} 0 obj\n${body}\nendobj\n`)
+  }
+
+  appendObject(1, '<< /Type /Catalog /Pages 2 0 R >>')
+  appendObject(2, '<< /Type /Pages /Kids [3 0 R] /Count 1 >>')
+  appendObject(3, '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>')
+  appendObject(4, [
+    `<< /Length ${Buffer.byteLength(streamContent, 'utf8')} >>`,
+    'stream',
+    streamContent,
+    'endstream',
+  ].join('\n'))
+  appendObject(5, '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>')
+
+  const xrefOffset = Buffer.byteLength(chunks.join(''), 'utf8')
+  chunks.push([
+    'xref',
+    '0 6',
+    '0000000000 65535 f ',
+    ...offsets.slice(1).map(offset => `${offset.toString().padStart(10, '0')} 00000 n `),
+    'trailer',
+    '<< /Size 6 /Root 1 0 R >>',
+    'startxref',
+    String(xrefOffset),
+    '%%EOF',
+  ].join('\n'))
+
+  return Buffer.from(chunks.join(''))
+}
+
+async function expectResponseStatus(response: APIResponse, expected: number, label: string) {
+  const status = response.status()
+  if (status !== expected) {
+    throw new Error(`${label} returned ${status}: ${await response.text()}`)
+  }
+
+  expect(status, label).toBe(expected)
+}
+
+async function expectApiStatus(response: Awaited<ReturnType<APIRequestContext['post']>>, expected: number, label: string) {
+  await expectResponseStatus(response, expected, label)
+}
+
+async function createCandidate(request: APIRequestContext, candidate: Omit<CandidateRecord, 'id'>): Promise<CandidateRecord> {
+  const response = await request.post('/api/candidates', {
+    data: {
+      firstName: candidate.firstName,
+      lastName: candidate.lastName,
+      email: candidate.email,
+    },
+  })
+
+  await expectApiStatus(response, 201, 'Create candidate API')
+  return await response.json() as CandidateRecord
+}
+
+async function loadCandidateDocuments(request: APIRequestContext, candidateId: string): Promise<CandidateDocument[]> {
+  const response = await request.get(`/api/candidates/${candidateId}`)
+  await expectResponseStatus(response, 200, 'Candidate detail API')
+  const body = await response.json() as { documents: CandidateDocument[] }
+  return body.documents
+}
+
+async function expectStreamMetadata(
+  request: APIRequestContext,
+  url: string,
+  disposition: 'inline' | 'attachment',
+  filename: string,
+) {
+  const response = await request.get(url)
+  await expectResponseStatus(response, 200, `${url} stream`)
+  const headers = response.headers()
+  expect(headers['content-type']).toContain('application/pdf')
+  expect(headers['content-disposition']).toContain(disposition)
+  expect(headers['content-disposition']).toContain(filename)
+  return response
+}
+
+async function uploadPdfFromDashboard(page: Page, candidateId: string, filename: string, text: string) {
+  await page.goto(`/dashboard/candidates/${candidateId}`)
+  await page.waitForLoadState('networkidle')
+  await expect(page.getByRole('heading', { name: /Candidate|Document/i })).toBeVisible()
+
+  await page.getByRole('button', { name: /^Documents/i }).click()
+  await expect(page.getByRole('button', { name: 'Upload Document' })).toBeVisible()
+
+  const uploadResponse = page.waitForResponse(
+    resp =>
+      resp.url().includes(`/api/candidates/${candidateId}/documents`)
+      && resp.request().method() === 'POST',
+    { timeout: 30_000 },
+  )
+  await page.locator('input[type="file"]').setInputFiles({
+    name: filename,
+    mimeType: 'application/pdf',
+    buffer: createTextPdf(text),
+  })
+
+  const response = await uploadResponse
+  await expectResponseStatus(response, 201, 'Upload document API')
+  await expect(page.getByText(filename)).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText('Resume').first()).toBeVisible()
+  await expect(page.getByTitle('Preview PDF')).toBeVisible()
+}
+
+test.describe('Candidate document management', () => {
+  test('uploads, previews, downloads, reparses, and rejects invalid candidate documents locally', async ({ authenticatedPage }, testInfo) => {
+    const page = authenticatedPage
+    const unique = `${Date.now()}-${testInfo.retry}`
+    const candidate = await createCandidate(page.request, {
+      firstName: 'Document',
+      lastName: 'Tester',
+      email: `document-tester-${unique}@example.com`,
+    })
+    const filename = `document-e2e-${unique}.pdf`
+
+    await uploadPdfFromDashboard(page, candidate.id, filename, 'Document Tester Resume')
+
+    const documents = await loadCandidateDocuments(page.request, candidate.id)
+    const uploaded = documents.find(doc => doc.originalFilename === filename)
+    expect(uploaded, 'Uploaded PDF should be present in the candidate detail API').toBeTruthy()
+    expect(uploaded?.mimeType).toBe('application/pdf')
+    expect(uploaded?.type).toBe('resume')
+    expect(uploaded?.parsed).toBe(true)
+
+    await expectStreamMetadata(
+      page.request,
+      `/api/documents/${uploaded!.id}/preview`,
+      'inline',
+      filename,
+    )
+    await expectStreamMetadata(
+      page.request,
+      `/api/documents/${uploaded!.id}/download`,
+      'attachment',
+      filename,
+    )
+
+    const parseResponse = await page.request.post(`/api/documents/${uploaded!.id}/parse`)
+    await expectResponseStatus(parseResponse, 200, 'Parse document API')
+    const parseBody = await parseResponse.json() as { parsed: boolean, wordCount: number, sourceFormat: string }
+    expect(parseBody).toMatchObject({ parsed: true, sourceFormat: 'pdf' })
+    expect(parseBody.wordCount).toBeGreaterThan(0)
+
+    const rejectedResponse = await page.request.post(`/api/candidates/${candidate.id}/documents`, {
+      multipart: {
+        type: 'resume',
+        file: {
+          name: `not-a-document-${unique}.png`,
+          mimeType: 'image/png',
+          buffer: INVALID_PNG,
+        },
+      },
+    })
+    await expectResponseStatus(rejectedResponse, 400, 'Invalid upload API')
+
+    const documentsAfterReject = await loadCandidateDocuments(page.request, candidate.id)
+    expect(documentsAfterReject).toHaveLength(1)
+    expect(documentsAfterReject[0]?.originalFilename).toBe(filename)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typecheck": "nuxi typecheck",
     "test:e2e": "npx playwright test",
     "test:e2e:smoke": "playwright test e2e/critical-flows/dropdown-styling.spec.ts e2e/critical-flows/job-creation.spec.ts e2e/critical-flows/source-tracking.spec.ts",
-    "test:e2e:uploads": "playwright test e2e/critical-flows/resume-upload.spec.ts",
+    "test:e2e:uploads": "playwright test e2e/critical-flows/resume-upload.spec.ts e2e/critical-flows/candidate-documents.spec.ts",
     "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts e2e/critical-flows/application-saved-views.spec.ts e2e/critical-flows/application-custom-properties.spec.ts e2e/critical-flows/candidate-custom-properties.spec.ts e2e/critical-flows/application-board.spec.ts",
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts e2e/critical-flows/application-form-builder.spec.ts",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -281,19 +281,22 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain(e2eRequiredNeeds)
   })
 
-  it('runs resume upload browser coverage in a dedicated local-storage CI lane', () => {
+  it('runs upload and dashboard document browser coverage in a dedicated local-storage CI lane', () => {
     const workflow = read('.github/workflows/e2e-tests.yml')
     const packageJson = JSON.parse(read('package.json')) as {
       scripts?: Record<string, string>
     }
 
     expect(packageJson.scripts?.['test:e2e:uploads']).toBe(
-      'playwright test e2e/critical-flows/resume-upload.spec.ts',
+      'playwright test e2e/critical-flows/resume-upload.spec.ts e2e/critical-flows/candidate-documents.spec.ts',
     )
     expect(workflow).toContain('name: Playwright uploads')
     expect(workflow).toContain('npm run test:e2e:uploads')
     expect(workflow).toContain('factory-careers-uploads-minio')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "false"')
+    expect(read('e2e/critical-flows/candidate-documents.spec.ts')).toContain('/api/documents/${uploaded!.id}/preview')
+    expect(read('e2e/critical-flows/candidate-documents.spec.ts')).toContain('/api/documents/${uploaded!.id}/download')
+    expect(read('e2e/critical-flows/candidate-documents.spec.ts')).toContain('/api/documents/${uploaded!.id}/parse')
     expect(workflow).toContain(e2eRequiredNeeds)
   })
 


### PR DESCRIPTION
## Summary
- Adds a focused dashboard candidate-documents E2E for issue #167: seed candidate, upload a small PDF from the Documents tab, verify preview/download stream metadata, re-run parsing, and reject an invalid PNG multipart upload.
- Wires the new spec into the existing uploads CI lane so it reuses the local MinIO/local Postgres setup instead of adding another job.
- Updates the E2E harness contract to keep this document coverage in the uploads lane.

Closes #167

## Validation run
- Safety check before mutating E2E: no `.env`, `.env.local`, `.env.test`, or `.env.e2e`; no inherited DB/app/storage/email/AI env vars; app target `http://127.0.0.1:3333`; disposable local Postgres `127.0.0.1:5561`; local MinIO `127.0.0.1:9100`; no real mail or AI keys.
- `npm run test:unit -- tests/unit/e2e-harness-contract.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/playwright test e2e/critical-flows/candidate-documents.spec.ts --workers=1` with local-only DB/MinIO env: 1 passed in 19.6s
- `npm run test:e2e:uploads -- --workers=1` with local-only DB/MinIO env: 3 passed in 22.3s
- `npm run check:conventions`
- `git diff --check`
- `npm run preflight:pr` (also rerun by the push hook): passed; existing warnings only for missing i18n config, vue-router Volar export warning, and Tailwind sourcemap warnings.

## Known risks or skipped checks
- Did not run the full Playwright matrix; this PR only changes the uploads lane.
- Local mutating E2E used disposable local containers and those containers were stopped after the run.

## Release/version notes
- Test-only change. No changeset needed.