### PR TITLE
test: cover organization settings e2e

### DIFF
--- a/e2e/critical-flows/organization-settings.spec.ts
+++ b/e2e/critical-flows/organization-settings.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, selectFactorySelectOption } from '../fixtures'
+
+test.describe('Organization settings safety', () => {
+  test('persists profile and localization settings while integrations stay safe when unconfigured', async ({ authenticatedPage }, testInfo) => {
+    const page = authenticatedPage
+    const baseURL = String(testInfo.project.use.baseURL ?? '')
+    expect(baseURL, 'Settings E2E must run against a local Playwright webServer').toMatch(/^http:\/\/(127\.0\.0\.1|localhost):\d+$/)
+
+    const unique = `${Date.now()}-r${testInfo.retry}`
+    const updatedDisplayName = `Settings Owner ${unique}`
+
+    await page.goto('/dashboard/settings/account')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('heading', { name: 'Account' })).toBeVisible({ timeout: 15_000 })
+
+    await page.getByLabel('Display name').fill(updatedDisplayName)
+    const [profileResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/auth/update-user') && resp.request().method() === 'POST',
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Save profile' }).click(),
+    ])
+    expect(profileResponse.status(), `Profile update returned ${profileResponse.status()}`).toBe(200)
+
+    await page.reload({ waitUntil: 'networkidle' })
+    await expect(page.getByLabel('Display name')).toHaveValue(updatedDisplayName)
+
+    await page.goto('/dashboard/settings/localization')
+    await expect(page.getByRole('heading', { name: 'Localization' })).toBeVisible({ timeout: 15_000 })
+
+    const [nameFormatResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/org-settings') && resp.request().method() === 'PATCH',
+        { timeout: 30_000 },
+      ),
+      selectFactorySelectOption(page, 'Name display format', 'Last First - Doe Jane'),
+    ])
+    expect(nameFormatResponse.status(), `Name format update returned ${nameFormatResponse.status()}`).toBe(200)
+
+    const [dateFormatResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/org-settings') && resp.request().method() === 'PATCH',
+        { timeout: 30_000 },
+      ),
+      selectFactorySelectOption(page, 'Date format', 'YYYY-MM-DD - ISO 8601 / East Asia'),
+    ])
+    expect(dateFormatResponse.status(), `Date format update returned ${dateFormatResponse.status()}`).toBe(200)
+
+    await expect(page.getByText('Doe Jane', { exact: true })).toBeVisible()
+    await expect(page.getByText('1990-05-24', { exact: true })).toBeVisible()
+
+    await page.reload({ waitUntil: 'networkidle' })
+    await expect(page.getByLabel('Name display format')).toContainText('Last First - Doe Jane')
+    await expect(page.getByLabel('Date format')).toContainText('YYYY-MM-DD - ISO 8601 / East Asia')
+
+    const settingsResponse = await page.request.get('/api/org-settings')
+    expect(settingsResponse.status(), `Org settings read returned ${settingsResponse.status()}`).toBe(200)
+    await expect(settingsResponse).toBeOK()
+    const settings = await settingsResponse.json() as { nameDisplayFormat: string; dateFormat: string }
+    expect(settings).toMatchObject({
+      nameDisplayFormat: 'last_first',
+      dateFormat: 'ymd',
+    })
+
+    await page.goto('/dashboard/settings/integrations', { waitUntil: 'networkidle' })
+    await expect(page.getByRole('heading', { name: 'Integrations' })).toBeVisible()
+    await expect(page.getByText('Not configured')).toBeVisible()
+    await expect(page.getByText('Microsoft Calendar integration requires server configuration.')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Connect shared calendar' })).toHaveCount(0)
+
+    const calendarStatusResponse = await page.request.get('/api/calendar/status')
+    expect(calendarStatusResponse.status(), `Calendar status returned ${calendarStatusResponse.status()}`).toBe(200)
+    const calendarStatus = await calendarStatusResponse.json() as { available: boolean; connected: boolean }
+    expect(calendarStatus).toMatchObject({
+      available: false,
+      connected: false,
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts e2e/critical-flows/interview-invitation-response.spec.ts e2e/critical-flows/interview-template-management.spec.ts --workers=1",
     "test:e2e:calendar": "FACTORY_CALENDAR_TEST_MODE=mock playwright test e2e/critical-flows/calendar-integration.spec.ts",
-    "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts",
+    "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts e2e/critical-flows/organization-settings.spec.ts",
     "test:e2e:rbac": "playwright test e2e/critical-flows/rbac-role-permissions.spec.ts",
     "test:e2e:sso": "playwright test e2e/critical-flows/sso-domain-provisioning.spec.ts",
     "test:e2e:ai-review": "playwright test e2e/critical-flows/ai-candidate-review.spec.ts e2e/critical-flows/ai-config-lifecycle.spec.ts --workers=1",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -218,11 +218,15 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:auth-org']).toBe(
-      'playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts',
+      'playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts e2e/critical-flows/organization-settings.spec.ts',
     )
     expect(workflow).toContain('name: Playwright auth and org')
     expect(workflow).toContain('npm run test:e2e:auth-org')
     expect(workflow).toContain('S3_SKIP_BUCKET_INIT: "true"')
+    expect(workflow).not.toContain('GOOGLE_CLIENT_SECRET')
+    expect(workflow).not.toContain('MICROSOFT_CALENDAR_CLIENT_SECRET')
+    expect(read('e2e/critical-flows/organization-settings.spec.ts')).toContain('/api/calendar/status')
+    expect(read('e2e/critical-flows/organization-settings.spec.ts')).toContain('Connect shared calendar')
     expect(workflow).toContain('needs.auth_org.result')
     expect(workflow).toContain(e2eRequiredNeeds)
   })


### PR DESCRIPTION
## Summary

- Adds a compact Playwright settings safety spec covering account profile persistence, localization autosave persistence, and integrations-safe rendering when calendar providers are unconfigured.
- Extends the existing auth/org E2E lane instead of adding another CI job, keeping runtime low while covering issue #146.
- Pins the harness contract so the auth/org lane includes the new spec and does not require real Google/Microsoft calendar secrets.

Closes #146

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Chore

## Validation

- [x] I tested locally
- [ ] I added/updated relevant documentation
- [x] I verified multi-tenant scoping and auth behavior for affected API paths

Validation run:
- `find . -maxdepth 1 -name ".env*" -print` -> only `.env.example`
- `printenv | rg "^(DATABASE_URL|BETTER_AUTH_URL|NUXT_PUBLIC_SITE_URL|PLAYWRIGHT_BASE_URL|RESEND_API_KEY|OPENAI_API_KEY|GOOGLE_CLIENT_SECRET|MICROSOFT_CALENDAR_CLIENT_SECRET|FACTORY_EMAIL_TEST_MODE|S3_ENDPOINT)="` -> no matches
- `npm run test:unit -- tests/unit/e2e-harness-contract.test.ts`
- `DATABASE_URL=postgresql://factory_e2e:factory_e2e@127.0.0.1:55433/factory_careers_e2e ... npx playwright test e2e/critical-flows/organization-settings.spec.ts --workers=1`
- `DATABASE_URL=postgresql://factory_e2e:factory_e2e@127.0.0.1:55433/factory_careers_e2e ... npm run test:e2e:auth-org`
- `npm run typecheck`
- pre-push `npm run preflight:pr` via `git push` (CLI parity, full unit suite, typecheck, CLI smoke, production env contract, build)

## CLI parity

- [x] I checked whether this changes portal/API workflow payload shapes, response shapes, auth requirements, or resource coverage
- [ ] I updated `packages/careers-cli/src/routeCoverage.ts` when API routes were added, removed, renamed, or intentionally excluded
- [ ] I updated `docs/CLI.md`, CLI commands, shared schemas, or CLI tests when the portal/API workflow should be agent-accessible
- [x] I documented the reason when a changed portal/API workflow should not be exposed through the CLI

CLI parity note: test-only E2E harness change; no API route, schema, payload, or CLI surface changes.

## Keyboard / accessibility acceptance

- [x] Visible focus is preserved for every interactive control I touched
- [x] No core action in this change is pointer-only
- [x] `Escape` behavior is intentional for transient UI I changed
- [x] Focus restores to the invoking control after closing modals/popovers/drawers
- [x] Any modal I changed traps focus correctly while open
- [x] Any custom listbox/menu/combobox behavior still works from the keyboard
- [x] New custom controls include keyboard-focused tests where applicable

Keyboard note: no UI implementation changed; the new test uses the existing accessible labels/listbox roles for FactorySelect.

## Known risks or skipped checks

- Local Playwright validation used Chromium, matching the repo Playwright project. No Safari/WebKit lane exists in this repo yet.
- The local typecheck/preflight logs include existing Nuxt i18n/Volar and Tailwind sourcemap warnings, but all commands exited 0.

## Release/version notes

- Test-only change. No changeset or release note needed.

## DCO

- [ ] All commits in this PR are signed off (`Signed-off-by`) via `git commit -s`