### PR TITLE
test: cover public localization e2e

### DIFF
--- a/app/pages/jobs/[slug]/apply.vue
+++ b/app/pages/jobs/[slug]/apply.vue
@@ -9,6 +9,7 @@ definePageMeta({
 
 const route = useRoute()
 const jobSlug = route.params.slug as string
+const localePath = useLocalePath()
 const { track } = useTrack()
 
 // Capture source tracking params from the URL
@@ -426,7 +427,7 @@ async function handleSubmit() {
     }
 
     track('application_submitted', { slug: jobSlug })
-    await navigateTo(`/jobs/${jobSlug}/confirmation`)
+    await navigateTo(localePath(`/jobs/${jobSlug}/confirmation`))
   } catch (err: any) {
     const message = err.data?.statusMessage ?? 'Something went wrong. Please try again.'
     submitError.value = message

--- a/e2e/critical-flows/public-localization.spec.ts
+++ b/e2e/critical-flows/public-localization.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect, selectFactorySelectOption } from '../fixtures'
+
+type JobResponse = {
+  id: string
+  slug: string
+  status: string
+}
+
+test.describe('Public localization flow', () => {
+  test('keeps localized public job and application paths working with default fallback', async ({ authenticatedPage, browser }, testInfo) => {
+    expect(process.env.FEATURE_FLAG_LANGUAGE_SUPPORT, 'public localization E2E must enable language routes').toBe('true')
+    expect(process.env.FACTORY_EMAIL_TEST_MODE, 'localized application submission must use fake mail capture').toBe('capture')
+
+    const page = authenticatedPage
+    const unique = `${Date.now()}-r${testInfo.retry}`
+    const jobTitle = `Localized Candidate Experience ${unique}`
+    const applicant = {
+      firstName: 'Locale',
+      lastName: 'Candidate',
+      email: `localized.candidate.${unique}@example.com`,
+    }
+
+    await page.goto('/dashboard/settings/localization')
+    await expect(page.getByRole('heading', { name: 'Localization' })).toBeVisible({ timeout: 15_000 })
+
+    const [dateFormatResponse] = await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/org-settings') && resp.request().method() === 'PATCH',
+        { timeout: 30_000 },
+      ),
+      selectFactorySelectOption(page, 'Date format', 'DD/MM/YYYY - Europe, Vietnam & most regions'),
+    ])
+    expect(dateFormatResponse.status(), `Date format update returned ${dateFormatResponse.status()}`).toBe(200)
+    await expect(page.getByText('24/05/1990', { exact: true })).toBeVisible()
+
+    const createJobResponse = await page.request.post('/api/jobs', {
+      data: {
+        title: jobTitle,
+        description: 'A localized public candidate experience fixture.',
+        location: 'Madrid, Spain',
+        type: 'full_time',
+        salaryMin: 45_000,
+        salaryMax: 55_000,
+        salaryCurrency: 'EUR',
+        salaryUnit: 'YEAR',
+        activeFrom: '2026-05-24T12:00:00.000Z',
+        requireResume: false,
+        requireCoverLetter: false,
+        applicationComplianceEnabled: false,
+        autoScoreOnApply: false,
+      },
+    })
+    expect(createJobResponse.status(), `Create job API returned ${createJobResponse.status()}`).toBe(201)
+    const createdJob = await createJobResponse.json() as JobResponse
+
+    const publishJobResponse = await page.request.patch(`/api/jobs/${createdJob.id}`, {
+      data: { status: 'open' },
+    })
+    expect(publishJobResponse.status(), `Publish job API returned ${publishJobResponse.status()}`).toBe(200)
+    const publishedJob = await publishJobResponse.json() as JobResponse
+    expect(publishedJob.status).toBe('open')
+
+    const candidateContext = await browser.newContext()
+    const candidatePage = await candidateContext.newPage()
+
+    await candidatePage.goto('/jobs?i18nTest=1')
+    await expect(candidatePage.getByTestId('i18n-probe')).toHaveText('Language')
+    await expect(candidatePage.getByRole('link', { name: jobTitle })).toBeVisible({ timeout: 15_000 })
+
+    await candidatePage.goto(`/es/jobs/${publishedJob.slug}?i18nTest=1`)
+    await expect(candidatePage.getByTestId('i18n-probe')).toHaveText('Idioma')
+    await expect(candidatePage.getByRole('heading', { name: jobTitle })).toBeVisible()
+    await expect(candidatePage.getByText(new Intl.NumberFormat('es', {
+      style: 'currency',
+      currency: 'EUR',
+      maximumFractionDigits: 0,
+    }).format(45_000), { exact: false })).toBeVisible()
+
+    await candidatePage.getByRole('link', { name: 'Apply Now' }).first().click()
+    await candidatePage.waitForURL(`**/es/jobs/${publishedJob.slug}/apply**`, { waitUntil: 'commit', timeout: 15_000 })
+    await expect(candidatePage.getByRole('heading', { name: jobTitle })).toBeVisible()
+
+    const applyResponse = await candidatePage.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
+      data: {
+        firstName: applicant.firstName,
+        lastName: applicant.lastName,
+        email: applicant.email,
+        country: 'United States',
+        state: 'CA',
+      },
+    })
+    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
+
+    await candidatePage.goto(`/es/jobs/${publishedJob.slug}/confirmation`)
+    await candidatePage.waitForURL(`**/es/jobs/${publishedJob.slug}/confirmation`, {
+      waitUntil: 'commit',
+      timeout: 15_000,
+    })
+    await expect(candidatePage.getByRole('heading', { name: 'Application submitted' })).toBeVisible()
+    await expect(candidatePage.getByRole('link', { name: 'Browse more positions' })).toHaveAttribute('href', '/es/jobs')
+
+    await candidateContext.close()
+  })
+})

--- a/e2e/critical-flows/public-localization.spec.ts
+++ b/e2e/critical-flows/public-localization.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, selectFactorySelectOption } from '../fixtures'
+import { advanceToSubmitButton } from '../helpers/application-form'
 
 type JobResponse = {
   id: string
@@ -63,42 +64,49 @@ test.describe('Public localization flow', () => {
     const candidateContext = await browser.newContext()
     const candidatePage = await candidateContext.newPage()
 
-    await candidatePage.goto('/jobs?i18nTest=1')
-    await expect(candidatePage.getByTestId('i18n-probe')).toHaveText('Language')
-    await expect(candidatePage.getByRole('link', { name: jobTitle })).toBeVisible({ timeout: 15_000 })
+    try {
+      await candidatePage.goto('/jobs?i18nTest=1')
+      await expect(candidatePage.getByTestId('i18n-probe')).toHaveText('Language')
+      await expect(candidatePage.getByRole('link', { name: jobTitle })).toBeVisible({ timeout: 15_000 })
 
-    await candidatePage.goto(`/es/jobs/${publishedJob.slug}?i18nTest=1`)
-    await expect(candidatePage.getByTestId('i18n-probe')).toHaveText('Idioma')
-    await expect(candidatePage.getByRole('heading', { name: jobTitle })).toBeVisible()
-    await expect(candidatePage.getByText(new Intl.NumberFormat('es', {
-      style: 'currency',
-      currency: 'EUR',
-      maximumFractionDigits: 0,
-    }).format(45_000), { exact: false })).toBeVisible()
+      await candidatePage.goto(`/es/jobs/${publishedJob.slug}?i18nTest=1`)
+      await expect(candidatePage.getByTestId('i18n-probe')).toHaveText('Idioma')
+      await expect(candidatePage.getByRole('heading', { name: jobTitle })).toBeVisible()
+      await expect(candidatePage.getByText(new Intl.NumberFormat('es', {
+        style: 'currency',
+        currency: 'EUR',
+        maximumFractionDigits: 0,
+      }).format(45_000), { exact: false })).toBeVisible()
 
-    await candidatePage.getByRole('link', { name: 'Apply Now' }).first().click()
-    await candidatePage.waitForURL(`**/es/jobs/${publishedJob.slug}/apply**`, { waitUntil: 'commit', timeout: 15_000 })
-    await expect(candidatePage.getByRole('heading', { name: jobTitle })).toBeVisible()
+      await candidatePage.getByRole('link', { name: 'Apply Now' }).first().click()
+      await candidatePage.waitForURL(`**/es/jobs/${publishedJob.slug}/apply**`, { waitUntil: 'commit', timeout: 15_000 })
+      await candidatePage.waitForLoadState('networkidle')
+      await expect(candidatePage.getByRole('heading', { name: jobTitle })).toBeVisible()
 
-    const applyResponse = await candidatePage.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
-      data: {
-        firstName: applicant.firstName,
-        lastName: applicant.lastName,
-        email: applicant.email,
-        country: 'United States',
-        state: 'CA',
-      },
-    })
-    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
+      await candidatePage.getByLabel('First name').fill(applicant.firstName)
+      await candidatePage.getByLabel('Last name').fill(applicant.lastName)
+      await candidatePage.getByLabel('Email').fill(applicant.email)
+      await selectFactorySelectOption(candidatePage, /Country/, 'United States')
+      await selectFactorySelectOption(candidatePage, /State/, 'California')
 
-    await candidatePage.goto(`/es/jobs/${publishedJob.slug}/confirmation`)
-    await candidatePage.waitForURL(`**/es/jobs/${publishedJob.slug}/confirmation`, {
-      waitUntil: 'commit',
-      timeout: 15_000,
-    })
-    await expect(candidatePage.getByRole('heading', { name: 'Application submitted' })).toBeVisible()
-    await expect(candidatePage.getByRole('link', { name: 'Browse more positions' })).toHaveAttribute('href', '/es/jobs')
+      const submitButton = await advanceToSubmitButton(candidatePage)
+      const [applyResponse] = await Promise.all([
+        candidatePage.waitForResponse(
+          resp => resp.url().includes(`/api/public/jobs/${publishedJob.slug}/apply`) && resp.request().method() === 'POST',
+          { timeout: 30_000 },
+        ),
+        submitButton.click(),
+      ])
+      expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
 
-    await candidateContext.close()
+      await candidatePage.waitForURL(`**/es/jobs/${publishedJob.slug}/confirmation`, {
+        waitUntil: 'commit',
+        timeout: 15_000,
+      })
+      await expect(candidatePage.getByRole('heading', { name: 'Application submitted' })).toBeVisible()
+      await expect(candidatePage.getByRole('link', { name: 'Browse more positions' })).toHaveAttribute('href', '/es/jobs')
+    } finally {
+      await candidateContext.close()
+    }
   })
 })

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:e2e": "npx playwright test",
     "test:e2e:smoke": "playwright test e2e/critical-flows/dropdown-styling.spec.ts e2e/critical-flows/job-creation.spec.ts e2e/critical-flows/source-tracking.spec.ts",
     "test:e2e:uploads": "playwright test e2e/critical-flows/resume-upload.spec.ts e2e/critical-flows/candidate-documents.spec.ts",
-    "test:e2e:candidate": "playwright test e2e/critical-flows/candidate-application.spec.ts",
+    "test:e2e:candidate": "FEATURE_FLAG_LANGUAGE_SUPPORT=true FACTORY_EMAIL_TEST_MODE=capture FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-candidate-email.jsonl FACTORY_CAREERS_HIRING_INBOX=hiring-e2e@example.com playwright test e2e/critical-flows/candidate-application.spec.ts e2e/critical-flows/public-localization.spec.ts",
     "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts e2e/critical-flows/application-saved-views.spec.ts e2e/critical-flows/application-custom-properties.spec.ts e2e/critical-flows/candidate-custom-properties.spec.ts e2e/critical-flows/application-board.spec.ts",
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts e2e/critical-flows/application-form-builder.spec.ts",
     "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts e2e/critical-flows/auth-recovery-fake-mail.spec.ts --workers=1",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -92,11 +92,13 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:candidate']).toBe(
-      'playwright test e2e/critical-flows/candidate-application.spec.ts',
+      'FEATURE_FLAG_LANGUAGE_SUPPORT=true FACTORY_EMAIL_TEST_MODE=capture FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-candidate-email.jsonl FACTORY_CAREERS_HIRING_INBOX=hiring-e2e@example.com playwright test e2e/critical-flows/candidate-application.spec.ts e2e/critical-flows/public-localization.spec.ts',
     )
     expect(workflow).toContain('name: Playwright candidate')
     expect(workflow).toContain('npm run test:e2e:candidate')
     expect(workflow).toContain('factory-careers-candidate-minio')
+    expect(read('e2e/critical-flows/public-localization.spec.ts')).toContain('FEATURE_FLAG_LANGUAGE_SUPPORT')
+    expect(read('e2e/critical-flows/public-localization.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
     expect(workflow).toContain('needs.candidate.result')
   })
 


### PR DESCRIPTION
## Summary
- Add a fast public localization E2E slice covering dashboard localization settings, English fallback listing behavior, Spanish job/detail/apply/confirmation routing, localized EUR salary formatting, and a fake-mail public application POST.
- Pair the new localization spec with the existing candidate application lane so full UI submission coverage continues to run alongside it.
- Preserve locale when the public application form redirects to the confirmation page.

Closes #163.

## Validation run
- Safety precheck: only .env.example present; no inherited production database, site URL, email/API/calendar/storage env; local app/database/storage only.
- Focused public localization spec passed against disposable local Postgres with fake email capture.
- Harness contract unit test passed.
- Typecheck passed; existing Vue/Volar package export warning still appears.
- Candidate lane passed against disposable local Postgres plus local MinIO and fake email capture.
- Pre-push preflight passed, including full unit suite, typecheck, CLI smoke, production env contract, and build.

## Known risks or skipped checks
- The new localization spec keeps runtime low by using API setup/submission for mutating setup and pairs with candidate-application.spec.ts for the full public form UI submission path.
- No production services were targeted; email used FACTORY_EMAIL_TEST_MODE=capture, DB was disposable local Postgres, storage was local MinIO only.

## Release/version notes
- No changeset needed; test coverage plus a small public-route locale redirect fix.