### PR TITLE
test: cover org admin e2e

### DIFF
--- a/app/pages/dashboard/settings/index.vue
+++ b/app/pages/dashboard/settings/index.vue
@@ -82,7 +82,7 @@ async function handleSaveOrg() {
     await authClient.organization.update({
       data: {
         name: trimmedName,
-        slug: trimmedSlug,
+        ...(isFactorySlugLocked.value ? {} : { slug: trimmedSlug }),
       },
     })
     await updateSettings({

--- a/e2e/critical-flows/org-admin-membership.spec.ts
+++ b/e2e/critical-flows/org-admin-membership.spec.ts
@@ -1,0 +1,290 @@
+import type { Browser, Page } from '@playwright/test'
+import postgres from 'postgres'
+import { assertMutatingE2ESafety } from '../safety'
+import { expect, selectFactorySelectOption, test } from '../fixtures'
+
+interface SignedInApplicant {
+  email: string
+  name: string
+  page: Page
+  close: () => Promise<void>
+}
+
+interface MembershipLookup {
+  userId: string
+  memberId: string
+  organizationId: string
+}
+
+async function lookupMembership(email: string, organizationName: string): Promise<MembershipLookup> {
+  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for org admin e2e membership lookup').toBeTruthy()
+  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+
+  try {
+    const [membership] = await sql<MembershipLookup[]>`
+      select
+        u.id as "userId",
+        m.id as "memberId",
+        o.id as "organizationId"
+      from "user" u
+      inner join "member" m on m."user_id" = u.id
+      inner join "organization" o on o.id = m."organization_id"
+      where u.email = ${email} and o.name = ${organizationName}
+      limit 1
+    `
+
+    expect(membership, `expected ${email} to belong to ${organizationName}`).toBeTruthy()
+    return membership
+  }
+  finally {
+    await sql.end()
+  }
+}
+
+async function lookupMemberByEmail(email: string, organizationId: string) {
+  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for org admin e2e member lookup').toBeTruthy()
+  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+
+  try {
+    const [member] = await sql<Array<{ id: string, role: string }>>`
+      select m.id, m.role
+      from "member" m
+      inner join "user" u on u.id = m."user_id"
+      where u.email = ${email} and m."organization_id" = ${organizationId}
+      limit 1
+    `
+    return member
+  }
+  finally {
+    await sql.end()
+  }
+}
+
+async function lookupJoinRequestStatus(requestId: string) {
+  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for org admin e2e join-request lookup').toBeTruthy()
+  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+
+  try {
+    const [request] = await sql<Array<{ status: string, reviewedAt: Date | null }>>`
+      select status, "reviewed_at" as "reviewedAt"
+      from "join_request"
+      where id = ${requestId}
+      limit 1
+    `
+    return request
+  }
+  finally {
+    await sql.end()
+  }
+}
+
+async function signUpWithoutOrganization(browser: Browser, baseURL: string, label: string): Promise<SignedInApplicant> {
+  const context = await browser.newContext({ baseURL })
+  const page = await context.newPage()
+  const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const account = {
+    name: `Org Admin ${label} ${id}`,
+    email: `org-admin-${label}-${id}@test.local`,
+    password: process.env.E2E_TEST_PASSWORD || 'TestPassword123!',
+  }
+
+  await page.goto('/auth/sign-up')
+  await page.waitForLoadState('networkidle')
+  await page.getByLabel('Name').fill(account.name)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password', { exact: true }).fill(account.password)
+  await page.getByLabel('Confirm password').fill(account.password)
+
+  await Promise.all([
+    page.waitForResponse(
+      resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200,
+      { timeout: 30_000 },
+    ),
+    page.getByRole('button', { name: 'Sign up' }).click(),
+  ])
+
+  await page.waitForURL(
+    url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'),
+    { waitUntil: 'commit', timeout: 30_000 },
+  )
+
+  if (page.url().includes('/auth/sign-in')) {
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Email').fill(account.email)
+    await page.getByLabel('Password').fill(account.password)
+
+    await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200,
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Sign in' }).click(),
+    ])
+
+    await page.waitForURL('**/onboarding/**', { waitUntil: 'networkidle', timeout: 30_000 })
+  }
+  else {
+    await page.waitForLoadState('networkidle')
+  }
+
+  return {
+    ...account,
+    page,
+    close: () => context.close(),
+  }
+}
+
+async function createJoinRequest(page: Page, organizationId: string, message: string) {
+  const response = await page.request.post('/api/join-requests', {
+    data: {
+      organizationId,
+      message,
+    },
+  })
+  expect(response.status(), `Create join request returned ${response.status()}`).toBe(201)
+  return await response.json() as { id: string, status: string, organizationName: string }
+}
+
+test.describe('Organization administration and join requests', () => {
+  test('persists org settings, manages join requests, and blocks member-level mutations', async ({ authenticatedPage, testAccount, browser }, testInfo) => {
+    const page = authenticatedPage
+    const baseURL = String(testInfo.project.use.baseURL ?? '')
+    assertMutatingE2ESafety({
+      env: {
+        PLAYWRIGHT_BASE_URL: baseURL,
+        DATABASE_URL: process.env.DATABASE_URL,
+      },
+    })
+    expect(process.env.FACTORY_EMAIL_TEST_MODE, 'Org admin E2E must not use real email delivery').toBe('capture')
+
+    const ownerMembership = await lookupMembership(testAccount.email, testAccount.orgName)
+    const unique = `${Date.now()}-r${testInfo.retry}`
+    const renamedOrg = `E2E Org Admin ${unique}`
+    const approvedApplicant = await signUpWithoutOrganization(browser, baseURL, `approved-${testInfo.workerIndex}`)
+    const rejectedApplicant = await signUpWithoutOrganization(browser, baseURL, `rejected-${testInfo.workerIndex}`)
+
+    try {
+      await page.goto('/dashboard/settings', { waitUntil: 'networkidle' })
+      await expect(page.getByRole('heading', { name: 'General' })).toBeVisible({ timeout: 15_000 })
+      await page.getByLabel('Organization name').fill(renamedOrg)
+      await selectFactorySelectOption(page, 'Default pay period', 'Per month')
+
+      const [orgUpdateResponse, settingsUpdateResponse] = await Promise.all([
+        page.waitForResponse(
+          resp => resp.url().includes('/api/auth/organization/update') && resp.request().method() === 'POST',
+          { timeout: 30_000 },
+        ),
+        page.waitForResponse(
+          resp => resp.url().includes('/api/org-settings') && resp.request().method() === 'PATCH',
+          { timeout: 30_000 },
+        ),
+        page.getByRole('button', { name: 'Save changes' }).click(),
+      ])
+      expect(orgUpdateResponse.status(), `Organization update returned ${orgUpdateResponse.status()}`).toBe(200)
+      expect(settingsUpdateResponse.status(), `Org settings update returned ${settingsUpdateResponse.status()}`).toBe(200)
+
+      await page.reload({ waitUntil: 'networkidle' })
+      await expect(page.getByLabel('Organization name')).toHaveValue(renamedOrg)
+      await expect(page.getByLabel('Default pay period')).toContainText('Per month')
+
+      const approvedRequest = await createJoinRequest(
+        approvedApplicant.page,
+        ownerMembership.organizationId,
+        'Please approve me for the org-admin E2E happy path.',
+      )
+      const rejectedRequest = await createJoinRequest(
+        rejectedApplicant.page,
+        ownerMembership.organizationId,
+        'Please reject me for the org-admin E2E denial path.',
+      )
+
+      await page.goto('/dashboard/settings/members', { waitUntil: 'networkidle' })
+      await expect(page.getByRole('heading', { name: 'Members', exact: true })).toBeVisible({ timeout: 15_000 })
+      await expect(page.getByText(approvedApplicant.email)).toBeVisible()
+      await expect(page.getByText(rejectedApplicant.email)).toBeVisible()
+
+      const approvedRequestRow = page.locator('.ui-list-row').filter({ hasText: approvedApplicant.email }).first()
+      const [approveResponse] = await Promise.all([
+        page.waitForResponse(
+          resp => resp.url().includes(`/api/join-requests/${approvedRequest.id}/approve`) && resp.request().method() === 'POST',
+          { timeout: 30_000 },
+        ),
+        approvedRequestRow.getByRole('button', { name: 'Approve' }).click(),
+      ])
+      expect(approveResponse.status(), `Approve join request returned ${approveResponse.status()}`).toBe(200)
+
+      await expect.poll(
+        async () => await lookupMemberByEmail(approvedApplicant.email, ownerMembership.organizationId),
+        { timeout: 30_000, message: 'approved applicant should become an organization member' },
+      ).toMatchObject({ role: 'member' })
+      const approvedMember = await lookupMemberByEmail(approvedApplicant.email, ownerMembership.organizationId)
+      expect(approvedMember).toBeTruthy()
+
+      const origin = new URL(baseURL).origin
+      const setActiveResponse = await approvedApplicant.page.request.post('/api/auth/organization/set-active', {
+        headers: { origin },
+        data: { organizationId: ownerMembership.organizationId },
+      })
+      expect(setActiveResponse.status(), `Approved applicant set-active returned ${setActiveResponse.status()}`).toBe(200)
+
+      await approvedApplicant.page.goto('/dashboard/settings/members', { waitUntil: 'networkidle' })
+      await expect(approvedApplicant.page.getByRole('heading', { name: 'Members', exact: true })).toBeVisible()
+      await expect(approvedApplicant.page.getByText("You don't have permission to manage team members.")).toBeVisible()
+
+      const forbiddenSettingsResponse = await approvedApplicant.page.request.patch('/api/org-settings', {
+        data: { defaultSalaryUnit: 'HOUR' },
+      })
+      expect(forbiddenSettingsResponse.status(), `Member org-settings PATCH returned ${forbiddenSettingsResponse.status()}`).toBe(403)
+
+      const forbiddenJoinRequestResponse = await approvedApplicant.page.request.post(`/api/join-requests/${rejectedRequest.id}/approve`)
+      expect(forbiddenJoinRequestResponse.status(), `Member join-request approve returned ${forbiddenJoinRequestResponse.status()}`).toBe(403)
+
+      await page.goto('/dashboard/settings/members', { waitUntil: 'networkidle' })
+      const approvedMemberRow = page.locator('.ui-list-row').filter({ hasText: approvedApplicant.email }).first()
+      await expect(approvedMemberRow.getByText('Member', { exact: true })).toBeVisible()
+      await approvedMemberRow.locator('[data-member-actions] button').click()
+      const [roleResponse] = await Promise.all([
+        page.waitForResponse(
+          resp => resp.url().includes('/api/auth/organization/update-member-role') && resp.request().method() === 'POST',
+          { timeout: 30_000 },
+        ),
+        page.getByRole('button', { name: 'Make admin' }).click(),
+      ])
+      expect(roleResponse.status(), `Update member role returned ${roleResponse.status()}`).toBe(200)
+      await expect(approvedMemberRow.getByText('Admin', { exact: true })).toBeVisible({ timeout: 15_000 })
+
+      const promotedMember = await lookupMemberByEmail(approvedApplicant.email, ownerMembership.organizationId)
+      expect(promotedMember).toMatchObject({ role: 'admin' })
+
+      const rejectedRequestRow = page.locator('.ui-list-row').filter({ hasText: rejectedApplicant.email }).first()
+      const [rejectResponse] = await Promise.all([
+        page.waitForResponse(
+          resp => resp.url().includes(`/api/join-requests/${rejectedRequest.id}/reject`) && resp.request().method() === 'POST',
+          { timeout: 30_000 },
+        ),
+        rejectedRequestRow.getByRole('button', { name: 'Reject' }).click(),
+      ])
+      expect(rejectResponse.status(), `Reject join request returned ${rejectResponse.status()}`).toBe(200)
+      await expect(page.getByText(rejectedApplicant.email)).toHaveCount(0)
+
+      const rejectedStatus = await lookupJoinRequestStatus(rejectedRequest.id)
+      expect(rejectedStatus).toMatchObject({ status: 'rejected' })
+      expect(rejectedStatus?.reviewedAt).toBeTruthy()
+
+      const rejectedRetryResponse = await rejectedApplicant.page.request.post('/api/join-requests', {
+        data: {
+          organizationId: ownerMembership.organizationId,
+          message: 'Trying again immediately after rejection should show the applicant denial path.',
+        },
+      })
+      expect(rejectedRetryResponse.status(), `Rejected applicant retry returned ${rejectedRetryResponse.status()}`).toBe(429)
+      expect(JSON.stringify(await rejectedRetryResponse.json())).toContain('previous request was recently declined')
+    }
+    finally {
+      await Promise.all([
+        approvedApplicant.close(),
+        rejectedApplicant.close(),
+      ])
+    }
+  })
+})

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts e2e/critical-flows/interview-invitation-response.spec.ts e2e/critical-flows/interview-template-management.spec.ts --workers=1",
     "test:e2e:calendar": "FACTORY_CALENDAR_TEST_MODE=mock playwright test e2e/critical-flows/calendar-integration.spec.ts",
-    "test:e2e:auth-org": "playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts e2e/critical-flows/organization-settings.spec.ts",
+    "test:e2e:auth-org": "FACTORY_EMAIL_TEST_MODE=capture FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-auth-org-email.jsonl playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts e2e/critical-flows/organization-settings.spec.ts e2e/critical-flows/org-admin-membership.spec.ts",
     "test:e2e:rbac": "playwright test e2e/critical-flows/rbac-role-permissions.spec.ts",
     "test:e2e:sso": "playwright test e2e/critical-flows/sso-domain-provisioning.spec.ts",
     "test:e2e:ai-review": "playwright test e2e/critical-flows/ai-candidate-review.spec.ts e2e/critical-flows/ai-config-lifecycle.spec.ts --workers=1",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -220,7 +220,7 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:auth-org']).toBe(
-      'playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts e2e/critical-flows/organization-settings.spec.ts',
+      'FACTORY_EMAIL_TEST_MODE=capture FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-auth-org-email.jsonl playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts e2e/critical-flows/organization-settings.spec.ts e2e/critical-flows/org-admin-membership.spec.ts',
     )
     expect(workflow).toContain('name: Playwright auth and org')
     expect(workflow).toContain('npm run test:e2e:auth-org')
@@ -229,6 +229,9 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).not.toContain('MICROSOFT_CALENDAR_CLIENT_SECRET')
     expect(read('e2e/critical-flows/organization-settings.spec.ts')).toContain('/api/calendar/status')
     expect(read('e2e/critical-flows/organization-settings.spec.ts')).toContain('Connect shared calendar')
+    expect(read('e2e/critical-flows/org-admin-membership.spec.ts')).toContain('assertMutatingE2ESafety')
+    expect(read('e2e/critical-flows/org-admin-membership.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
+    expect(read('e2e/critical-flows/org-admin-membership.spec.ts')).toContain('/api/join-requests')
     expect(workflow).toContain('needs.auth_org.result')
     expect(workflow).toContain(e2eRequiredNeeds)
   })


### PR DESCRIPTION
Summary
- Add focused Playwright coverage for issue #159: organization settings persistence, join-request approve/reject, member role promotion, applicant-visible rejection retry, and member-level mutation denials.
- Wire the new spec into the auth-org E2E lane with email capture mode enforced.
- Fix the General settings save path so locked Factory slug config does not overwrite every local/test org slug when only saving org settings.

Validation run
- npm run test:unit -- tests/unit/e2e-harness-contract.test.ts tests/unit/e2e-safety.test.ts tests/unit/org-default-salary-unit.test.ts
- npm run typecheck
- npm run check:conventions
- Local safe E2E: disposable Postgres on 127.0.0.1:55435, PLAYWRIGHT_BASE_URL http://127.0.0.1:3333, FACTORY_EMAIL_TEST_MODE capture, S3 bucket init skipped.
- Focused Playwright: npx playwright test e2e/critical-flows/org-admin-membership.spec.ts --workers=1 passed in 8.2s.
- Auth/org lane: npm run test:e2e:auth-org -- --workers=1 passed, 3 tests in 17.0s.
- Push preflight: full unit suite, typecheck, CLI smoke, production env contract, and build passed.

Known risks or skipped checks
- Local browser validation used Playwright Chromium, matching the current CI project config. No Safari/WebKit lane exists in this PR.
- Typecheck still emits the existing vue-router/volar package export warning but exits successfully.

Release/version notes
- No changeset needed; test coverage plus a narrow dashboard settings bug fix.

Closes #159