### PR TITLE
test: cover chatbot conversation e2e

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1136,6 +1136,7 @@ jobs:
       PLAYWRIGHT_BASE_URL: http://127.0.0.1:3333
       FACTORY_DISABLE_PUBLIC_SIGNUP: "false"
       FACTORY_DISABLE_PUBLIC_ORG_CREATION: "false"
+      FEATURE_FLAG_CHATBOT_EXPERIENCE: "true"
       FACTORY_AI_TEST_MODE: mock
       FACTORY_AI_CAPTURE_PATH: /tmp/factory-careers-e2e-ai.jsonl
       S3_ENDPOINT: http://127.0.0.1:9000

--- a/e2e/critical-flows/chatbot-conversations.spec.ts
+++ b/e2e/critical-flows/chatbot-conversations.spec.ts
@@ -1,0 +1,142 @@
+import { readFile, rm } from 'node:fs/promises'
+import { test, expect } from '../fixtures'
+import { assertMutatingE2ESafety } from '../safety'
+
+type CapturedChatbotRequest = {
+  schemaName: string
+  system: string
+  messages: Array<{ role: 'user' | 'assistant', content: string }>
+  provider: string
+  model: string
+  scopeLabel: string
+  agentId: string | null
+  attachmentCount: number
+  toolNames: string[]
+}
+
+async function readCapturedChatbotRequests(capturePath: string): Promise<CapturedChatbotRequest[]> {
+  try {
+    const contents = await readFile(capturePath, 'utf8')
+    return contents
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as CapturedChatbotRequest)
+      .filter((request) => request.schemaName === 'ChatbotChat')
+  }
+  catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return []
+    throw error
+  }
+}
+
+test.describe('Chatbot agents and conversations', () => {
+  test('creates an agent, sends a mocked conversation turn, and persists it after reload', async ({ authenticatedPage }, testInfo) => {
+    const page = authenticatedPage
+    const baseURL = String(testInfo.project.use.baseURL ?? '')
+    const capturePath = process.env.FACTORY_AI_CAPTURE_PATH
+
+    assertMutatingE2ESafety({
+      env: {
+        PLAYWRIGHT_BASE_URL: baseURL,
+        DATABASE_URL: process.env.DATABASE_URL,
+      },
+    })
+    expect(process.env.FACTORY_AI_TEST_MODE, 'Chatbot E2E must use mock mode, not a real provider').toBe('mock')
+    expect(capturePath, 'FACTORY_AI_CAPTURE_PATH must be set for chatbot E2E').toBeTruthy()
+    await rm(capturePath!, { force: true })
+
+    const runId = `${Date.now()}-${testInfo.workerIndex}-${testInfo.retry}`
+    const modelName = 'factory-e2e-chatbot-response'
+    const agentName = `E2E Chatbot Agent ${runId}`
+    const agentPrompt = `Answer as the deterministic E2E chatbot agent for ${runId}.`
+    const userPrompt = `Summarize hiring slate ${runId}`
+
+    const configResponse = await page.request.post('/api/ai-config', {
+      data: {
+        name: `Chatbot deterministic AI ${runId}`,
+        provider: 'openai',
+        model: modelName,
+        apiKey: 'fake-local-only-key',
+        maxTokens: 2048,
+      },
+    })
+    expect(configResponse.status(), `Create AI config returned ${configResponse.status()}`).toBe(201)
+
+    await page.goto('/dashboard/chatbot', { waitUntil: 'networkidle' })
+    await expect(page.getByRole('heading', { name: 'Factory Careers Assistant' })).toBeVisible({ timeout: 15_000 })
+
+    await page.getByRole('button', { name: 'Manage agents' }).click()
+    await expect(page.getByRole('heading', { name: 'Manage agents' })).toBeVisible()
+    await page.getByPlaceholder('e.g. Recruiter coach').fill(agentName)
+    await page.getByPlaceholder('e.g. Reviews resumes against a job').fill('Deterministic chatbot e2e agent')
+    await page.getByPlaceholder('Describe how this agent should behave').fill(agentPrompt)
+    await page.getByLabel('Use this agent by default for new conversations').check()
+
+    await Promise.all([
+      page.waitForResponse(resp => resp.url().includes('/api/chatbot/agents') && resp.request().method() === 'POST' && resp.status() === 200),
+      page.getByRole('button', { name: 'Create agent' }).click(),
+    ])
+    await expect(page.getByText(agentName)).toBeVisible()
+    await page.getByRole('button', { name: 'Close' }).click()
+    await expect(page.getByRole('heading', { name: 'Manage agents' })).toBeHidden()
+
+    await page.getByRole('button', { name: /Default assistant/ }).click()
+    await page.getByRole('button', { name: agentName }).click()
+    await expect(page.getByRole('button', { name: new RegExp(agentName) })).toBeVisible()
+
+    const [conversationResponse] = await Promise.all([
+      page.waitForResponse(resp => resp.url().includes('/api/chatbot/conversations') && resp.request().method() === 'POST' && resp.status() === 200),
+      page.getByRole('button', { name: 'New chat' }).click(),
+    ])
+    const conversationPayload = await conversationResponse.json() as { conversation: { id: string } }
+    await expect(page).toHaveURL(new RegExp(`/dashboard/chatbot/${conversationPayload.conversation.id}$`))
+
+    await page.getByPlaceholder('Ask Factory Careers Assistant anything…').fill(userPrompt)
+    await Promise.all([
+      page.waitForResponse(resp => resp.url().includes('/api/chatbot/chat') && resp.request().method() === 'POST' && resp.status() === 200),
+      page.getByRole('button', { name: 'Send' }).click(),
+    ])
+
+    const deterministicResponse = 'Deterministic E2E chatbot response for entire organization.'
+    await expect(page.getByText(userPrompt, { exact: true }).last()).toBeVisible()
+    await expect(page.getByText(deterministicResponse).last()).toBeVisible({ timeout: 15_000 })
+
+    await page.reload({ waitUntil: 'networkidle' })
+    await expect(page.getByText(userPrompt, { exact: true }).last()).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText(deterministicResponse).last()).toBeVisible()
+
+    await page.goto('/dashboard/chatbot', { waitUntil: 'networkidle' })
+    await expect(page.getByText(userPrompt, { exact: true }).first()).toBeVisible({ timeout: 15_000 })
+    await page.getByText(userPrompt, { exact: true }).first().click()
+    await expect(page).toHaveURL(new RegExp(`/dashboard/chatbot/${conversationPayload.conversation.id}$`))
+    await expect(page.getByText(deterministicResponse).last()).toBeVisible()
+
+    const missingConversationResponse = await page.request.post('/api/chatbot/chat', {
+      data: {
+        conversationId: 'missing-conversation',
+        scope: { kind: 'organization' },
+        messages: [{ role: 'user', content: 'Hello' }],
+      },
+    })
+    expect(missingConversationResponse.status(), `Missing conversation returned ${missingConversationResponse.status()}`).toBe(404)
+
+    await expect.poll(async () => (await readCapturedChatbotRequests(capturePath!)).length, {
+      message: 'chatbot mock stream should capture the prompt context',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(1)
+
+    const captured = await readCapturedChatbotRequests(capturePath!)
+    const chatRequest = captured.find(request => request.model === modelName)
+    expect(chatRequest, 'chatbot request should be captured').toBeTruthy()
+    expect(chatRequest?.provider).toBe('openai')
+    expect(chatRequest?.system).toContain(agentPrompt)
+    expect(chatRequest?.scopeLabel).toBe('entire organization')
+    expect(chatRequest?.agentId).toBeTruthy()
+    expect(chatRequest?.attachmentCount).toBe(0)
+    expect(chatRequest?.toolNames).toContain('list_jobs')
+    expect(chatRequest?.messages).toContainEqual(expect.objectContaining({
+      role: 'user',
+      content: userPrompt,
+    }))
+  })
+})

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:e2e:auth-org": "FACTORY_EMAIL_TEST_MODE=capture FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-auth-org-email.jsonl playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts e2e/critical-flows/organization-settings.spec.ts e2e/critical-flows/org-admin-membership.spec.ts",
     "test:e2e:rbac": "playwright test e2e/critical-flows/rbac-role-permissions.spec.ts",
     "test:e2e:sso": "playwright test e2e/critical-flows/sso-domain-provisioning.spec.ts",
-    "test:e2e:ai-review": "playwright test e2e/critical-flows/ai-candidate-review.spec.ts e2e/critical-flows/ai-config-lifecycle.spec.ts --workers=1",
+    "test:e2e:ai-review": "playwright test e2e/critical-flows/ai-candidate-review.spec.ts e2e/critical-flows/ai-config-lifecycle.spec.ts e2e/critical-flows/chatbot-conversations.spec.ts --workers=1",
     "test:e2e:production-session": "playwright test --config playwright.production.config.ts e2e/critical-flows/production-session-cache.spec.ts --workers=1",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",

--- a/server/api/chatbot/chat.post.ts
+++ b/server/api/chatbot/chat.post.ts
@@ -1,3 +1,4 @@
+import { appendFile } from 'node:fs/promises'
 import { and, eq } from 'drizzle-orm'
 import { stepCountIs, streamText, type ModelMessage } from 'ai'
 import { z } from 'zod'
@@ -236,13 +237,6 @@ export default defineEventHandler(async (event) => {
     await assertSafeServerSideUrl(config.baseUrl)
   }
 
-  const model = createLanguageModel({
-    provider: config.provider as SupportedProvider,
-    model: config.model,
-    apiKeyEncrypted: config.apiKeyEncrypted,
-    baseUrl: config.baseUrl,
-    maxTokens: Math.max(config.maxTokens, 2048),
-  })
   const tools = buildChatbotTools({
     orgId,
     scope: body.scope,
@@ -253,6 +247,7 @@ export default defineEventHandler(async (event) => {
     role: m.role,
     content: m.content,
   }))
+  const systemPrompt = buildSystemPrompt(scopeLabel, agentPrompt)
 
   // ── Set SSE headers ──
   setResponseHeaders(event, {
@@ -262,9 +257,97 @@ export default defineEventHandler(async (event) => {
     'X-Accel-Buffering': 'no',
   })
 
+  const encoder = new TextEncoder()
+  const writeEvent = (controller: ReadableStreamDefaultController, e: ChatbotStreamEvent) => {
+    controller.enqueue(encoder.encode(`data: ${JSON.stringify(e)}\n\n`))
+  }
+
+  if (env.FACTORY_AI_TEST_MODE === 'mock') {
+    const assistantContent = [
+      `Deterministic E2E chatbot response for ${scopeLabel}.`,
+      `I can see ${modelMessages.length} message(s), ${attachmentRecords.length} attachment(s), and the selected agent instructions are active.`,
+    ].join(' ')
+
+    await appendFile(env.FACTORY_AI_CAPTURE_PATH!, `${JSON.stringify({
+      schemaName: 'ChatbotChat',
+      provider: config.provider,
+      model: config.model,
+      system: systemPrompt,
+      messages: modelMessages,
+      scope: body.scope,
+      scopeLabel,
+      conversationId: conversation.id,
+      agentId: effectiveAgentId,
+      attachmentCount: attachmentRecords.length,
+      toolNames: Object.keys(tools),
+    })}\n`)
+
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        try {
+          if (updatedTitle) {
+            writeEvent(controller, {
+              type: 'conversation-meta',
+              conversationId: conversation.id,
+              title: updatedTitle,
+            })
+          }
+
+          writeEvent(controller, { type: 'text-delta', text: assistantContent })
+          writeEvent(controller, {
+            type: 'finish',
+            usage: {
+              promptTokens: systemPrompt.length + modelMessages.reduce((sum, message) => sum + String(message.content).length, 0),
+              completionTokens: assistantContent.length,
+            },
+          })
+
+          const [persistedAssistant] = await db.insert(chatbotMessage).values({
+            conversationId: conversation.id,
+            organizationId: orgId,
+            userId: session.user.id,
+            role: 'assistant',
+            content: assistantContent,
+            reasoning: null,
+            toolCalls: null,
+            sources: null,
+          }).returning({ createdAt: chatbotMessage.createdAt })
+
+          await db.update(chatbotConversation)
+            .set({
+              lastMessagePreview: previewFromContent(assistantContent),
+              lastMessageAt: persistedAssistant?.createdAt ?? new Date(),
+              updatedAt: new Date(),
+            })
+            .where(eq(chatbotConversation.id, conversation.id))
+        } finally {
+          controller.close()
+        }
+      },
+    })
+
+    trackEvent(event, session, 'chatbot_message_sent', {
+      scope: body.scope.kind,
+      has_attachments: attachmentRecords.length > 0,
+      message_count: body.messages.length,
+      thinking: body.thinking === true,
+      has_agent: !!effectiveAgentId,
+      conversation_id: conversation.id,
+    })
+
+    return sendStream(event, stream)
+  }
+
+  const model = createLanguageModel({
+    provider: config.provider as SupportedProvider,
+    model: config.model,
+    apiKeyEncrypted: config.apiKeyEncrypted,
+    baseUrl: config.baseUrl,
+    maxTokens: Math.max(config.maxTokens, 2048),
+  })
   const result = streamText({
     model,
-    system: buildSystemPrompt(scopeLabel, agentPrompt),
+    system: systemPrompt,
     messages: modelMessages,
     tools,
     stopWhen: stepCountIs(8),
@@ -273,11 +356,6 @@ export default defineEventHandler(async (event) => {
       ? { providerOptions: { anthropic: { thinking: { type: 'enabled', budgetTokens: 4000 } } } }
       : {}),
   })
-
-  const encoder = new TextEncoder()
-  const writeEvent = (controller: ReadableStreamDefaultController, e: ChatbotStreamEvent) => {
-    controller.enqueue(encoder.encode(`data: ${JSON.stringify(e)}\n\n`))
-  }
 
   // ── Accumulators for persistence ──
   let assistantContent = ''

--- a/tests/unit/cli-chatbot-commands.test.ts
+++ b/tests/unit/cli-chatbot-commands.test.ts
@@ -98,7 +98,7 @@ describe('CLI chatbot commands', () => {
           scope: { kind: 'organization' },
           messages: [{ role: 'user', content: 'Summarize open roles.' }],
         })
-        return new Response('data: {"type":"text-delta","text":"Done"}\n\ndata: {"type":"finish","usage":{"promptTokens":1,"completionTokens":1}}\n\n', {
+        return new Response('data: {"type":"conversation-meta","conversationId":"conv_1","title":"Summarize open roles."}\n\ndata: {"type":"text-delta","text":"Done"}\n\ndata: {"type":"finish","usage":{"promptTokens":1,"completionTokens":1}}\n\n', {
           headers: { 'content-type': 'text/event-stream' },
         })
       }
@@ -170,6 +170,7 @@ describe('CLI chatbot commands', () => {
     expect(JSON.parse(updateOut[0])).toEqual({ conversation: { id: 'conv_1', pinned: true } })
     expect(JSON.parse(chatOut[0])).toEqual({
       events: [
+        { type: 'conversation-meta', conversationId: 'conv_1', title: 'Summarize open roles.' },
         { type: 'text-delta', text: 'Done' },
         { type: 'finish', usage: { promptTokens: 1, completionTokens: 1 } },
       ],

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -277,15 +277,19 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:ai-review']).toBe(
-      'playwright test e2e/critical-flows/ai-candidate-review.spec.ts e2e/critical-flows/ai-config-lifecycle.spec.ts --workers=1',
+      'playwright test e2e/critical-flows/ai-candidate-review.spec.ts e2e/critical-flows/ai-config-lifecycle.spec.ts e2e/critical-flows/chatbot-conversations.spec.ts --workers=1',
     )
     expect(workflow).toContain('name: Playwright AI review')
     expect(workflow).toContain('npm run test:e2e:ai-review')
+    expect(workflow).toContain('FEATURE_FLAG_CHATBOT_EXPERIENCE: "true"')
     expect(workflow).toContain('FACTORY_AI_TEST_MODE: mock')
     expect(workflow).toContain('FACTORY_AI_CAPTURE_PATH: /tmp/factory-careers-e2e-ai.jsonl')
     expect(workflow).not.toContain('OPENAI_API_KEY: ${{ secrets')
     expect(read('e2e/critical-flows/ai-candidate-review.spec.ts')).toContain('FACTORY_AI_TEST_MODE')
     expect(read('e2e/critical-flows/ai-config-lifecycle.spec.ts')).toContain('FACTORY_AI_TEST_MODE')
+    expect(read('e2e/critical-flows/chatbot-conversations.spec.ts')).toContain('FACTORY_AI_TEST_MODE')
+    expect(read('e2e/critical-flows/chatbot-conversations.spec.ts')).toContain('/api/chatbot/chat')
+    expect(read('e2e/critical-flows/chatbot-conversations.spec.ts')).toContain('assertMutatingE2ESafety')
     expect(workflow).toContain('needs.ai_review.result')
     expect(workflow).toContain(e2eRequiredNeeds)
   })


### PR DESCRIPTION
## Summary
- Add a deterministic `FACTORY_AI_TEST_MODE=mock` path for `/api/chatbot/chat` so chatbot E2E captures prompt context and never contacts a real AI provider.
- Add critical chatbot E2E coverage for dashboard agent creation, conversation creation, mocked chat response, reload/sidebar persistence, missing-conversation failure handling, and AI capture assertions.
- Wire the spec into the existing AI-review lane with the chatbot feature flag and CLI stream parity evidence.

## Validation run
- `npm run test:unit -- tests/unit/cli-chatbot-commands.test.ts tests/unit/e2e-harness-contract.test.ts tests/unit/ai-test-mode-env.test.ts tests/unit/ai-provider-mock.test.ts`
- `npm run typecheck` (exits 0; existing Nuxt i18n/Volar warnings still print)
- `PLAYWRIGHT_SKIP_WEB_SERVER=1 ... npx playwright test e2e/critical-flows/chatbot-conversations.spec.ts --workers=1` against disposable local Postgres on `127.0.0.1:55436`: 1 passed in 4.4s
- `PLAYWRIGHT_SKIP_WEB_SERVER=1 ... npm run test:e2e:ai-review` against the same disposable local stack: 3 passed in 25.6s
- `npm run check:conventions`
- `npm run preflight:cli-parity`
- `git diff --check`
- Pre-push `npm run preflight:pr`: CLI parity, 905 unit tests, typecheck, CLI smoke, production env preflight, and build passed

## Known risks or skipped checks
- Browser validation is Chromium-only, matching the existing Playwright CI lane.
- Knowledge-base/upload chatbot coverage remains separate follow-up work (#138).
- The chatbot E2E requires mock AI mode plus a capture path; no real provider secrets or production targets are used.

## Release/version notes
- Test-only coverage and test-mode server behavior; no changeset needed.

Closes #161