### PR TITLE
test: cover chatbot knowledge upload e2e

### DIFF
--- a/app/composables/useChatbot.ts
+++ b/app/composables/useChatbot.ts
@@ -383,7 +383,8 @@ export function useChatbot() {
 
   async function send(content: string) {
     const trimmed = content.trim()
-    if (!trimmed && pendingAttachments.value.length === 0) return
+    const attachmentsForMessage = [...pendingAttachments.value]
+    if (!trimmed && attachmentsForMessage.length === 0) return
     if (isStreaming.value) return
 
     // Lazy-create a conversation if there's no active one.
@@ -400,7 +401,7 @@ export function useChatbot() {
       id: newId(),
       role: 'user',
       content: trimmed,
-      attachments: pendingAttachments.value.length ? [...pendingAttachments.value] : undefined,
+      attachments: attachmentsForMessage.length ? attachmentsForMessage : undefined,
       createdAt: Date.now(),
     }
     messages.value = [...messages.value, userMessage]
@@ -416,7 +417,7 @@ export function useChatbot() {
     }
     messages.value = [...messages.value, assistantMessage]
 
-    const attachmentIds = userMessage.attachments?.map((a) => a.id) ?? []
+    const attachmentIds = attachmentsForMessage.map((a) => a.id)
     pendingAttachments.value = []
 
     // Use a per-call controller and only mutate the shared `abortController`

--- a/e2e/critical-flows/chatbot-conversations.spec.ts
+++ b/e2e/critical-flows/chatbot-conversations.spec.ts
@@ -11,6 +11,12 @@ type CapturedChatbotRequest = {
   scopeLabel: string
   agentId: string | null
   attachmentCount: number
+  attachments?: Array<{
+    filename: string
+    mimeType: string
+    textLength: number
+    textPreview: string
+  }>
   toolNames: string[]
 }
 
@@ -134,6 +140,108 @@ test.describe('Chatbot agents and conversations', () => {
     expect(chatRequest?.agentId).toBeTruthy()
     expect(chatRequest?.attachmentCount).toBe(0)
     expect(chatRequest?.toolNames).toContain('list_jobs')
+    expect(chatRequest?.messages).toContainEqual(expect.objectContaining({
+      role: 'user',
+      content: userPrompt,
+    }))
+  })
+
+  test('uploads a knowledge file and includes it in mocked chatbot context', async ({ authenticatedPage }, testInfo) => {
+    const page = authenticatedPage
+    const baseURL = String(testInfo.project.use.baseURL ?? '')
+    const capturePath = process.env.FACTORY_AI_CAPTURE_PATH
+
+    assertMutatingE2ESafety({
+      env: {
+        PLAYWRIGHT_BASE_URL: baseURL,
+        DATABASE_URL: process.env.DATABASE_URL,
+      },
+    })
+    expect(process.env.FACTORY_AI_TEST_MODE, 'Chatbot knowledge E2E must use mock mode, not a real provider').toBe('mock')
+    expect(capturePath, 'FACTORY_AI_CAPTURE_PATH must be set for chatbot E2E').toBeTruthy()
+    await rm(capturePath!, { force: true })
+
+    const runId = `${Date.now()}-${testInfo.workerIndex}-${testInfo.retry}`
+    const modelName = 'factory-e2e-chatbot-knowledge-response'
+    const folderName = `Knowledge ${runId}`
+    const filename = `factory-knowledge-${runId}.txt`
+    const knowledgeText = [
+      `Factory Knowledge Marker ${runId}`,
+      'Priority hiring lane: concierge operators with venue partnerships and founder support experience.',
+      'Do not include unrelated tenant data in this answer.',
+    ].join('\n')
+    const userPrompt = `Use the uploaded knowledge brief ${runId}`
+
+    const configResponse = await page.request.post('/api/ai-config', {
+      data: {
+        name: `Chatbot knowledge AI ${runId}`,
+        provider: 'openai',
+        model: modelName,
+        apiKey: 'fake-local-only-key',
+        maxTokens: 2048,
+      },
+    })
+    expect(configResponse.status(), `Create AI config returned ${configResponse.status()}`).toBe(201)
+
+    await page.goto('/dashboard/chatbot', { waitUntil: 'networkidle' })
+    await expect(page.getByRole('heading', { name: 'Factory Careers Assistant' })).toBeVisible({ timeout: 15_000 })
+
+    await page.getByRole('button', { name: 'New folder' }).click()
+    await page.getByPlaceholder('Folder name').fill(folderName)
+    await Promise.all([
+      page.waitForResponse(resp => resp.url().includes('/api/chatbot/folders') && resp.request().method() === 'POST' && resp.status() === 200),
+      page.getByRole('button', { name: 'Create' }).click(),
+    ])
+    await expect(page.getByText(folderName)).toBeVisible()
+
+    await Promise.all([
+      page.waitForResponse(resp => resp.url().includes('/api/chatbot/upload') && resp.request().method() === 'POST' && resp.status() === 200),
+      page.locator('input[type="file"]').setInputFiles({
+        name: filename,
+        mimeType: 'text/plain',
+        buffer: Buffer.from(knowledgeText, 'utf8'),
+      }),
+    ])
+    await expect(page.getByText(filename)).toBeVisible()
+
+    await page.getByPlaceholder('Ask Factory Careers Assistant anything…').fill(userPrompt)
+    await Promise.all([
+      page.waitForResponse(resp => resp.url().includes('/api/chatbot/chat') && resp.request().method() === 'POST' && resp.status() === 200),
+      page.getByRole('button', { name: 'Send' }).click(),
+    ])
+
+    const deterministicResponse = 'Deterministic E2E chatbot response for entire organization.'
+    await expect(page.getByText(userPrompt, { exact: true }).last()).toBeVisible()
+    await expect(page.getByText(deterministicResponse).last()).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText(`Uploaded file context: ${filename}.`).last()).toBeVisible()
+
+    const invalidAttachmentResponse = await page.request.post('/api/chatbot/chat', {
+      data: {
+        conversationId: page.url().split('/').at(-1),
+        scope: { kind: 'organization' },
+        messages: [{ role: 'user', content: 'Read an inaccessible upload.', attachmentIds: ['not-this-users-attachment'] }],
+      },
+    })
+    expect(invalidAttachmentResponse.status(), `Invalid attachment returned ${invalidAttachmentResponse.status()}`).toBe(410)
+
+    await expect.poll(async () => (await readCapturedChatbotRequests(capturePath!)).length, {
+      message: 'chatbot mock stream should capture uploaded knowledge context',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(1)
+
+    const captured = await readCapturedChatbotRequests(capturePath!)
+    const chatRequest = captured.find(request => request.model === modelName)
+    expect(chatRequest, 'chatbot knowledge request should be captured').toBeTruthy()
+    expect(chatRequest?.provider).toBe('openai')
+    expect(chatRequest?.attachmentCount).toBe(1)
+    expect(chatRequest?.attachments).toContainEqual(expect.objectContaining({
+      filename,
+      mimeType: 'text/plain',
+      textPreview: expect.stringContaining(`Factory Knowledge Marker ${runId}`),
+    }))
+    expect(chatRequest?.attachments?.[0]?.textPreview).toContain('venue partnerships')
+    expect(chatRequest?.attachments?.[0]?.textPreview).not.toContain('unrelated tenant secret')
+    expect(chatRequest?.toolNames).toEqual(expect.arrayContaining(['list_attachments', 'read_attachment']))
     expect(chatRequest?.messages).toContainEqual(expect.objectContaining({
       role: 'user',
       content: userPrompt,

--- a/server/api/chatbot/chat.post.ts
+++ b/server/api/chatbot/chat.post.ts
@@ -263,9 +263,12 @@ export default defineEventHandler(async (event) => {
   }
 
   if (env.FACTORY_AI_TEST_MODE === 'mock') {
+    const uploadedFileSummary = attachmentRecords.length
+      ? ` Uploaded file context: ${attachmentRecords.map((attachment) => attachment.filename).join(', ')}.`
+      : ''
     const assistantContent = [
       `Deterministic E2E chatbot response for ${scopeLabel}.`,
-      `I can see ${modelMessages.length} message(s), ${attachmentRecords.length} attachment(s), and the selected agent instructions are active.`,
+      `I can see ${modelMessages.length} message(s), ${attachmentRecords.length} attachment(s), and the selected agent instructions are active.${uploadedFileSummary}`,
     ].join(' ')
 
     await appendFile(env.FACTORY_AI_CAPTURE_PATH!, `${JSON.stringify({
@@ -279,6 +282,14 @@ export default defineEventHandler(async (event) => {
       conversationId: conversation.id,
       agentId: effectiveAgentId,
       attachmentCount: attachmentRecords.length,
+      attachments: attachmentRecords.map((attachment) => ({
+        id: attachment.id,
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        sizeBytes: attachment.sizeBytes,
+        textLength: attachment.textLength,
+        textPreview: attachment.text.slice(0, 1000),
+      })),
       toolNames: Object.keys(tools),
     })}\n`)
 

--- a/tests/unit/cli-chatbot-commands.test.ts
+++ b/tests/unit/cli-chatbot-commands.test.ts
@@ -96,7 +96,7 @@ describe('CLI chatbot commands', () => {
         expect(JSON.parse(String(init.body))).toEqual({
           conversationId: 'conv_1',
           scope: { kind: 'organization' },
-          messages: [{ role: 'user', content: 'Summarize open roles.' }],
+          messages: [{ role: 'user', content: 'Summarize open roles.', attachmentIds: ['att_1'] }],
         })
         return new Response('data: {"type":"conversation-meta","conversationId":"conv_1","title":"Summarize open roles."}\n\ndata: {"type":"text-delta","text":"Done"}\n\ndata: {"type":"finish","usage":{"promptTokens":1,"completionTokens":1}}\n\n', {
           headers: { 'content-type': 'text/event-stream' },
@@ -149,7 +149,7 @@ describe('CLI chatbot commands', () => {
         stdin: async () => JSON.stringify({
           conversationId: 'conv_1',
           scope: { kind: 'organization' },
-          messages: [{ role: 'user', content: 'Summarize open roles.' }],
+          messages: [{ role: 'user', content: 'Summarize open roles.', attachmentIds: ['att_1'] }],
         }),
       },
     )

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -289,6 +289,8 @@ describe('Playwright E2E harness contract', () => {
     expect(read('e2e/critical-flows/ai-config-lifecycle.spec.ts')).toContain('FACTORY_AI_TEST_MODE')
     expect(read('e2e/critical-flows/chatbot-conversations.spec.ts')).toContain('FACTORY_AI_TEST_MODE')
     expect(read('e2e/critical-flows/chatbot-conversations.spec.ts')).toContain('/api/chatbot/chat')
+    expect(read('e2e/critical-flows/chatbot-conversations.spec.ts')).toContain('/api/chatbot/upload')
+    expect(read('e2e/critical-flows/chatbot-conversations.spec.ts')).toContain('Factory Knowledge Marker')
     expect(read('e2e/critical-flows/chatbot-conversations.spec.ts')).toContain('assertMutatingE2ESafety')
     expect(workflow).toContain('needs.ai_review.result')
     expect(workflow).toContain(e2eRequiredNeeds)


### PR DESCRIPTION
## Summary
- Add browser coverage for chatbot knowledge-file upload through the Assistant UI, including folder creation, upload handoff, mocked response rendering, inaccessible attachment failure, and captured provider context assertions.
- Preserve first-turn uploaded attachments when `send()` lazy-creates a new chatbot conversation; this fixes a production-relevant bug where uploads could be cleared before the first chat request.
- Extend deterministic chatbot AI mock captures with attachment metadata/text preview so E2E can prove the model context references the intended local document without calling a real provider.

## Validation run
- `npm run test:unit -- tests/unit/cli-chatbot-commands.test.ts tests/unit/e2e-harness-contract.test.ts tests/unit/ai-test-mode-env.test.ts tests/unit/ai-provider-mock.test.ts`
- `npm run typecheck` (exits 0; existing Nuxt i18n/Volar warnings still print)
- `PLAYWRIGHT_SKIP_WEB_SERVER=1 ... npx playwright test e2e/critical-flows/chatbot-conversations.spec.ts --workers=1` against disposable local Postgres on `127.0.0.1:55437`: 2 passed in 7.7s
- `PLAYWRIGHT_SKIP_WEB_SERVER=1 ... npm run test:e2e:ai-review` against the same disposable local stack: 4 passed in 17.8s
- `npm run check:conventions`
- `npm run preflight:cli-parity`
- `git diff --check`
- Pre-push `npm run preflight:pr`: CLI parity, 905 unit tests, typecheck, CLI smoke, production env preflight, and build passed

## Known risks or skipped checks
- Browser validation is Chromium-only, matching the existing Playwright CI lane.
- The mocked capture stores a short E2E text preview only while `FACTORY_AI_TEST_MODE=mock`, which production env validation rejects.
- This covers transient chatbot file uploads, not a future durable knowledge-base product surface if one is added later.

## Release/version notes
- Test coverage plus first-turn chatbot upload bugfix; no changeset needed.

Closes #138