### PR TITLE
fix: align public landing width

### DIFF
--- a/app/layouts/public.vue
+++ b/app/layouts/public.vue
@@ -2,14 +2,16 @@
 const route = useRoute()
 const localePath = useLocalePath()
 
+const publicContainerClass = 'factory-layout-container mx-auto max-w-screen-2xl'
+
 const mainClass = computed(() => {
   if (route.meta.publicWide) {
     return route.meta.publicFlushTop
-      ? 'factory-layout-container pb-10 pt-0 sm:pb-14'
-      : 'factory-layout-container py-10 sm:py-14'
+      ? `${publicContainerClass} pb-10 pt-0 sm:pb-14`
+      : `${publicContainerClass} py-10 sm:py-14`
   }
 
-  return 'factory-layout-container py-10 sm:py-14'
+  return `${publicContainerClass} py-10 sm:py-14`
 })
 </script>
 
@@ -19,7 +21,7 @@ const mainClass = computed(() => {
       class="border-b border-white/10 bg-black/90 backdrop-blur-xl"
       :class="route.meta.publicPinnedNav ? 'sticky top-0 z-50' : ''"
     >
-      <div class="factory-layout-container flex h-16 items-center justify-between">
+      <div :class="`${publicContainerClass} flex h-16 items-center justify-between`">
         <NuxtLink
           :to="localePath('/jobs')"
           class="inline-flex shrink-0 items-center gap-3 text-white no-underline transition-opacity hover:opacity-85"

--- a/tests/unit/public-jobs-layout.test.ts
+++ b/tests/unit/public-jobs-layout.test.ts
@@ -14,4 +14,13 @@ describe('public jobs layout', () => {
     expect(layout).toContain("route.meta.publicPinnedNav ? 'sticky top-0 z-50' : ''")
     expect(source).toContain('publicPinnedNav: true')
   })
+
+  it('uses the same centered max width for the public header and content', () => {
+    const layout = readProjectFile('app/layouts/public.vue')
+
+    expect(layout).toContain("const publicContainerClass = 'factory-layout-container mx-auto max-w-screen-2xl'")
+    expect(layout).toContain('`${publicContainerClass} flex h-16 items-center justify-between`')
+    expect(layout).toContain('`${publicContainerClass} pb-10 pt-0 sm:pb-14`')
+    expect(layout).toContain('`${publicContainerClass} py-10 sm:py-14`')
+  })
 })


### PR DESCRIPTION
## Summary
- Align the public careers header and main content on the same centered `max-w-screen-2xl` container.
- Add a focused unit guard so the public jobs layout keeps header/content width in sync.

## Validation run
- `npm run test:unit -- tests/unit/public-jobs-layout.test.ts`
- Browser QA at `http://127.0.0.1:3000/jobs`: header, main, and footer reported matching rendered bounds and the job type dropdown opened correctly.
- Pre-push `npm run preflight:pr` ran via git hook: CLI parity, full unit suite, typecheck, CLI smoke, production env validation, and build.

## Known risks or skipped checks
- Typecheck emitted the existing Vue/Volar `vue-router/volar/sfc-route-blocks` warning while exiting successfully.
- Build emitted existing Tailwind sourcemap warnings while completing successfully.

## Release/version notes
- No user-facing release note or changeset needed; this is a public layout polish fix.
