### PR TITLE
test: cover activity timeline e2e

### DIFF
--- a/e2e/critical-flows/activity-timeline.spec.ts
+++ b/e2e/critical-flows/activity-timeline.spec.ts
@@ -1,0 +1,349 @@
+import type { APIRequestContext, APIResponse, Browser, Page } from '@playwright/test'
+import { assertMutatingE2ESafety } from '../safety'
+import { expect, test } from '../fixtures'
+
+type JobRecord = {
+  id: string
+  title: string
+}
+
+type CandidateRecord = {
+  id: string
+  firstName: string
+  lastName: string
+  email: string
+}
+
+type ApplicationRecord = {
+  id: string
+  status: string
+}
+
+type InterviewRecord = {
+  id: string
+}
+
+type ActivityItem = {
+  id: string
+  action: string
+  resourceType: string
+  resourceId: string
+  metadata: Record<string, unknown> | null
+  createdAt: string
+  actorName?: string | null
+  resourceName?: string | null
+  candidateName?: string | null
+  jobName?: string | null
+}
+
+type TimelineResponse = {
+  items: ActivityItem[]
+  upcoming: ActivityItem[]
+}
+
+async function expectStatus(response: APIResponse, expected: number, label: string) {
+  expect(response.status(), `${label} returned ${response.status()}: ${await response.text()}`).toBe(expected)
+}
+
+async function createJob(request: APIRequestContext, title: string): Promise<JobRecord> {
+  const response = await request.post('/api/jobs', {
+    data: {
+      title,
+      description: 'Seeded by activity timeline E2E.',
+      location: 'Remote',
+      type: 'full_time',
+      requireResume: false,
+      requireCoverLetter: false,
+      applicationComplianceEnabled: false,
+      autoScoreOnApply: false,
+    },
+  })
+  await expectStatus(response, 201, 'Create job API')
+  return await response.json() as JobRecord
+}
+
+async function createCandidate(request: APIRequestContext, unique: string): Promise<CandidateRecord> {
+  const response = await request.post('/api/candidates', {
+    data: {
+      firstName: 'Timeline',
+      lastName: `Audit ${unique}`,
+      email: `timeline.audit.${unique}@example.com`,
+    },
+  })
+  await expectStatus(response, 201, 'Create candidate API')
+  return await response.json() as CandidateRecord
+}
+
+async function createApplication(
+  request: APIRequestContext,
+  candidateId: string,
+  jobId: string,
+): Promise<ApplicationRecord> {
+  const response = await request.post('/api/applications', {
+    data: {
+      candidateId,
+      jobId,
+      notes: 'Initial activity timeline E2E application note.',
+    },
+  })
+  await expectStatus(response, 201, 'Create application API')
+  return await response.json() as ApplicationRecord
+}
+
+async function moveApplicationToScreening(request: APIRequestContext, applicationId: string): Promise<ApplicationRecord> {
+  const response = await request.patch(`/api/applications/${applicationId}`, {
+    data: { status: 'screening' },
+  })
+  await expectStatus(response, 200, 'Move application API')
+  return await response.json() as ApplicationRecord
+}
+
+async function createApplicationComment(request: APIRequestContext, applicationId: string, unique: string) {
+  const response = await request.post('/api/comments', {
+    data: {
+      targetType: 'application',
+      targetId: applicationId,
+      body: `Activity timeline audit comment ${unique}`,
+    },
+  })
+  await expectStatus(response, 201, 'Create comment API')
+  return await response.json() as { id: string }
+}
+
+async function createInterview(request: APIRequestContext, applicationId: string, unique: string): Promise<InterviewRecord> {
+  const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000)
+  const response = await request.post('/api/interviews', {
+    data: {
+      applicationId,
+      title: `Activity timeline interview ${unique}`,
+      type: 'phone',
+      scheduledAt: tomorrow.toISOString(),
+      duration: 30,
+      timezone: 'UTC',
+      location: 'Video call',
+      calendarSync: false,
+    },
+  })
+  await expectStatus(response, 201, 'Create interview API')
+  const interview = await response.json() as InterviewRecord & {
+    calendarEventProvider?: string | null
+    googleCalendarEventId?: string | null
+  }
+  expect(interview.calendarEventProvider ?? null, 'activity timeline e2e must not sync a real calendar provider').toBeNull()
+  expect(interview.googleCalendarEventId ?? null, 'activity timeline e2e must not create a calendar event').toBeNull()
+  return interview
+}
+
+async function signUpWithOrganization(browser: Browser, baseURL: string, label: string) {
+  const context = await browser.newContext({ baseURL })
+  const page = await context.newPage()
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const account = {
+    name: `Timeline Isolation ${label} ${unique}`,
+    email: `timeline-isolation-${label}-${unique}@test.local`,
+    password: process.env.E2E_TEST_PASSWORD || 'TestPassword123!',
+    orgName: `Timeline Isolation Org ${label} ${unique}`,
+  }
+
+  await page.goto('/auth/sign-up')
+  await page.waitForLoadState('networkidle')
+  await page.getByLabel('Name').fill(account.name)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password', { exact: true }).fill(account.password)
+  await page.getByLabel('Confirm password').fill(account.password)
+
+  await Promise.all([
+    page.waitForResponse(
+      resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200,
+      { timeout: 30_000 },
+    ),
+    page.getByRole('button', { name: 'Sign up' }).click(),
+  ])
+
+  await page.waitForURL(
+    url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'),
+    { waitUntil: 'commit', timeout: 30_000 },
+  )
+
+  if (page.url().includes('/auth/sign-in')) {
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Email').fill(account.email)
+    await page.getByLabel('Password').fill(account.password)
+    await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200,
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Sign in' }).click(),
+    ])
+    await page.waitForURL('**/onboarding/**', { waitUntil: 'commit', timeout: 30_000 })
+  }
+
+  await page.getByLabel('Organization name').waitFor({ state: 'visible', timeout: 30_000 })
+  await page.getByLabel('Organization name').fill(account.orgName)
+  await page.getByRole('button', { name: 'Create organization' }).click()
+  await page.waitForURL('**/dashboard**', { waitUntil: 'commit', timeout: 30_000 })
+
+  return {
+    page,
+    close: () => context.close(),
+  }
+}
+
+async function getActivityItems(request: APIRequestContext, resourceType: string, resourceId: string) {
+  const response = await request.get(`/api/activity-log?resourceType=${resourceType}&resourceId=${resourceId}&limit=20`)
+  await expectStatus(response, 200, 'Activity log API')
+  const body = await response.json() as { data: ActivityItem[] }
+  return body.data
+}
+
+async function getTimeline(request: APIRequestContext): Promise<TimelineResponse> {
+  const response = await request.get('/api/activity-log/timeline?limit=50')
+  await expectStatus(response, 200, 'Timeline API')
+  return await response.json() as TimelineResponse
+}
+
+function expectSortedNewestFirst(items: ActivityItem[]) {
+  for (let i = 1; i < items.length; i += 1) {
+    const previous = Date.parse(items[i - 1]!.createdAt)
+    const current = Date.parse(items[i]!.createdAt)
+    expect(Number.isFinite(previous), `timeline item ${i - 1} must have a parseable timestamp`).toBe(true)
+    expect(Number.isFinite(current), `timeline item ${i} must have a parseable timestamp`).toBe(true)
+    expect(previous, `timeline item ${i - 1} must be newer than or tied with item ${i}`).toBeGreaterThanOrEqual(current)
+  }
+}
+
+test.describe('Activity timeline and audit log', () => {
+  test('records representative dashboard mutations in order and keeps them tenant-scoped', async ({ authenticatedPage, browser }, testInfo) => {
+    const page = authenticatedPage
+    const baseURL = String(testInfo.project.use.baseURL ?? '')
+    assertMutatingE2ESafety({
+      env: {
+        PLAYWRIGHT_BASE_URL: baseURL,
+        DATABASE_URL: process.env.DATABASE_URL,
+        BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
+        NUXT_PUBLIC_SITE_URL: process.env.NUXT_PUBLIC_SITE_URL,
+      },
+    })
+
+    const unique = `${Date.now()}-r${testInfo.retry}`
+    const job = await createJob(page.request, `Activity Timeline Job ${unique}`)
+    const candidate = await createCandidate(page.request, unique)
+    const candidateName = `${candidate.firstName} ${candidate.lastName}`
+    const application = await createApplication(page.request, candidate.id, job.id)
+    await moveApplicationToScreening(page.request, application.id)
+    await createApplicationComment(page.request, application.id, unique)
+    const interview = await createInterview(page.request, application.id, unique)
+
+    await expect.poll(async () => {
+      const applicationEvents = await getActivityItems(page.request, 'application', application.id)
+      return applicationEvents.map(item => item.action)
+    }, { timeout: 15_000 }).toEqual(expect.arrayContaining(['created', 'status_changed', 'comment_added']))
+
+    const applicationEvents = await getActivityItems(page.request, 'application', application.id)
+    expect(applicationEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        action: 'created',
+        resourceType: 'application',
+        resourceId: application.id,
+      }),
+      expect.objectContaining({
+        action: 'status_changed',
+        resourceType: 'application',
+        resourceId: application.id,
+        metadata: expect.objectContaining({ from: 'new', to: 'screening' }),
+      }),
+      expect.objectContaining({
+        action: 'comment_added',
+        resourceType: 'application',
+        resourceId: application.id,
+      }),
+    ]))
+    expectSortedNewestFirst(applicationEvents)
+
+    const candidateEvents = await getActivityItems(page.request, 'candidate', candidate.id)
+    expect(candidateEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        action: 'created',
+        resourceType: 'candidate',
+        resourceId: candidate.id,
+        metadata: expect.objectContaining({ name: candidateName }),
+      }),
+    ]))
+
+    const interviewEvents = await getActivityItems(page.request, 'interview', interview.id)
+    expect(interviewEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        action: 'created',
+        resourceType: 'interview',
+        resourceId: interview.id,
+      }),
+    ]))
+
+    const timeline = await getTimeline(page.request)
+    expectSortedNewestFirst(timeline.items)
+    expect(timeline.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        action: 'status_changed',
+        resourceType: 'application',
+        resourceName: expect.stringContaining(candidateName),
+        jobName: job.title,
+        candidateName,
+      }),
+      expect.objectContaining({
+        action: 'comment_added',
+        resourceType: 'application',
+        resourceName: expect.stringContaining(candidateName),
+        jobName: job.title,
+        candidateName,
+      }),
+      expect.objectContaining({
+        action: 'created',
+        resourceType: 'interview',
+        resourceName: expect.stringContaining(candidateName),
+        jobName: job.title,
+        candidateName,
+      }),
+    ]))
+    expect(timeline.upcoming).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        action: 'scheduled',
+        resourceType: 'interview',
+        resourceId: interview.id,
+        resourceName: expect.stringContaining(candidateName),
+        jobName: job.title,
+        candidateName,
+        isUpcoming: true,
+      }),
+    ]))
+
+    await page.goto('/dashboard/timeline', { waitUntil: 'networkidle' })
+    await expect(page.getByRole('heading', { name: 'Timeline' })).toBeVisible({ timeout: 15_000 })
+    await page.getByLabel('Search timeline').fill(candidate.lastName)
+    await expect(page.getByText('Candidate created')).toBeVisible()
+    await expect(page.getByText('Application moved')).toBeVisible()
+    await expect(page.getByText('Comment added to application')).toBeVisible()
+    await expect(page.getByText('Interview created')).toBeVisible()
+    await expect(page.getByText('Interview scheduled')).toBeVisible()
+    await expect(page.getByText(job.title).first()).toBeVisible()
+    await expect(page.getByText(candidateName).first()).toBeVisible()
+
+    const otherOrg = await signUpWithOrganization(browser, baseURL, `other-${testInfo.workerIndex}`)
+    try {
+      const otherOrgApplicationEvents = await getActivityItems(otherOrg.page.request, 'application', application.id)
+      expect(otherOrgApplicationEvents, 'another org must not see application activity by direct resource id').toEqual([])
+
+      const otherOrgCandidateTimelineResponse = await otherOrg.page.request.get(`/api/activity-log/candidate-timeline?candidateId=${candidate.id}`)
+      await expectStatus(otherOrgCandidateTimelineResponse, 200, 'Other org candidate timeline API')
+      const otherOrgCandidateTimeline = await otherOrgCandidateTimelineResponse.json() as { items: ActivityItem[] }
+      expect(otherOrgCandidateTimeline.items, 'another org must not see candidate timeline activity by direct candidate id').toEqual([])
+
+      const otherOrgTimeline = await getTimeline(otherOrg.page.request)
+      expect([...otherOrgTimeline.items, ...otherOrgTimeline.upcoming].some(item => item.resourceId === application.id || item.resourceId === interview.id)).toBe(false)
+      expect([...otherOrgTimeline.items, ...otherOrgTimeline.upcoming].some(item => item.candidateName === candidateName || item.jobName === job.title)).toBe(false)
+    }
+    finally {
+      await otherOrg.close()
+    }
+  })
+})

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:e2e:smoke": "playwright test e2e/critical-flows/dropdown-styling.spec.ts e2e/critical-flows/job-creation.spec.ts e2e/critical-flows/source-tracking.spec.ts",
     "test:e2e:uploads": "playwright test e2e/critical-flows/resume-upload.spec.ts e2e/critical-flows/candidate-documents.spec.ts",
     "test:e2e:candidate": "FEATURE_FLAG_LANGUAGE_SUPPORT=true FACTORY_EMAIL_TEST_MODE=capture FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-candidate-email.jsonl FACTORY_CAREERS_HIRING_INBOX=hiring-e2e@example.com playwright test e2e/critical-flows/candidate-application.spec.ts e2e/critical-flows/public-localization.spec.ts",
-    "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts e2e/critical-flows/application-saved-views.spec.ts e2e/critical-flows/application-custom-properties.spec.ts e2e/critical-flows/candidate-custom-properties.spec.ts e2e/critical-flows/application-board.spec.ts",
+    "test:e2e:recruiter": "playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts e2e/critical-flows/application-saved-views.spec.ts e2e/critical-flows/application-custom-properties.spec.ts e2e/critical-flows/candidate-custom-properties.spec.ts e2e/critical-flows/application-board.spec.ts e2e/critical-flows/activity-timeline.spec.ts",
     "test:e2e:job-lifecycle": "playwright test e2e/critical-flows/job-lifecycle.spec.ts e2e/critical-flows/application-form-builder.spec.ts",
     "test:e2e:email": "playwright test e2e/critical-flows/fake-mail.spec.ts e2e/critical-flows/privacy-request-fake-mail.spec.ts e2e/critical-flows/auth-recovery-fake-mail.spec.ts --workers=1",
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -117,7 +117,7 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:recruiter']).toBe(
-      'playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts e2e/critical-flows/application-saved-views.spec.ts e2e/critical-flows/application-custom-properties.spec.ts e2e/critical-flows/candidate-custom-properties.spec.ts e2e/critical-flows/application-board.spec.ts',
+      'playwright test e2e/critical-flows/recruiter-application-lifecycle.spec.ts e2e/critical-flows/application-saved-views.spec.ts e2e/critical-flows/application-custom-properties.spec.ts e2e/critical-flows/candidate-custom-properties.spec.ts e2e/critical-flows/application-board.spec.ts e2e/critical-flows/activity-timeline.spec.ts',
     )
     expect(workflow).toContain('name: Playwright recruiter')
     expect(workflow).toContain('npm run test:e2e:recruiter')
@@ -125,6 +125,13 @@ describe('Playwright E2E harness contract', () => {
     expect(workflow).toContain('needs.recruiter.result')
     expect(read('e2e/critical-flows/application-board.spec.ts')).toContain('/api/comments')
     expect(read('e2e/critical-flows/application-board.spec.ts')).toContain('/dashboard/timeline')
+    expect(read('e2e/critical-flows/activity-timeline.spec.ts')).toContain('assertMutatingE2ESafety')
+    expect(read('e2e/critical-flows/activity-timeline.spec.ts')).toContain('/api/activity-log?resourceType=')
+    expect(read('e2e/critical-flows/activity-timeline.spec.ts')).toContain('/api/activity-log/timeline?limit=50')
+    expect(read('e2e/critical-flows/activity-timeline.spec.ts')).toContain('/api/activity-log/candidate-timeline?candidateId=')
+    expect(read('e2e/critical-flows/activity-timeline.spec.ts')).toContain('expectSortedNewestFirst')
+    expect(read('e2e/critical-flows/activity-timeline.spec.ts')).toContain('another org must not see')
+    expect(read('e2e/critical-flows/activity-timeline.spec.ts')).toContain('calendarSync: false')
   })
 
   it('runs post-publish job lifecycle browser coverage in a dedicated CI lane', () => {


### PR DESCRIPTION
## Summary

- Adds a focused Playwright activity/timeline E2E for representative dashboard mutations: candidate creation, application creation, application status change, application comment, and interview scheduling.
- Asserts raw activity-log entries, enriched timeline entries, visible dashboard timeline labels, timestamp ordering, and cross-organization invisibility by direct resource ID.
- Wires the spec into the existing recruiter E2E lane instead of adding another CI job, and pins the coverage in the harness contract.

Closes #145

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Chore

## Validation

- [x] I tested locally
- [ ] I added/updated relevant documentation
- [x] I verified multi-tenant scoping and auth behavior for affected API paths

Validation run:

- npm run test:unit -- tests/unit/e2e-harness-contract.test.ts
- Local-only disposable DB: npx playwright test e2e/critical-flows/activity-timeline.spec.ts --workers=1
- Local-only disposable DB: npm run test:e2e:recruiter
- npm run typecheck
- npm run check:conventions
- git diff --check
- npm run preflight:pr
- Post-rebase: npm run test:unit -- tests/unit/e2e-harness-contract.test.ts
- Post-rebase local-only disposable DB: npx playwright test e2e/critical-flows/activity-timeline.spec.ts --workers=1
- Pre-push hook reran npm run preflight:pr

## CLI parity

- [x] I checked whether this changes portal/API workflow payload shapes, response shapes, auth requirements, or resource coverage
- [ ] I updated packages/careers-cli/src/routeCoverage.ts when API routes were added, removed, renamed, or intentionally excluded
- [ ] I updated docs/CLI.md, CLI commands, shared schemas, or CLI tests when the portal/API workflow should be agent-accessible
- [x] I documented the reason when a changed portal/API workflow should not be exposed through the CLI

No CLI updates are needed; this PR adds browser coverage for existing routes and does not change API contracts or route coverage.

## Keyboard / accessibility acceptance

- [ ] Visible focus is preserved for every interactive control I touched
- [ ] No core action in this change is pointer-only
- [ ] Escape behavior is intentional for transient UI I changed
- [ ] Focus restores to the invoking control after closing modals/popovers/drawers
- [ ] Any modal I changed traps focus correctly while open
- [ ] Any custom listbox/menu/combobox behavior still works from the keyboard
- [ ] New custom controls include keyboard-focused tests where applicable

Not applicable; this PR only adds E2E coverage and does not change interactive UI behavior.

## Known risks or skipped checks

- The new mutating E2E is guarded with assertMutatingE2ESafety and was only run against 127.0.0.1 with a disposable Postgres database.
- Interview creation explicitly sets calendarSync: false and asserts no calendar event provider/id is returned.
- Expected local warnings remain: Nuxt i18n missing config warning, Vue router Volar export warning during typecheck, and Tailwind sourcemap warnings during build.

## Release/version notes

- No changeset needed; test-only change.

## DCO

- [ ] All commits in this PR are signed off (Signed-off-by) via git commit -s