### PR TITLE
test: cover cli device authorization e2e

### DIFF
--- a/e2e/critical-flows/device-authorization.spec.ts
+++ b/e2e/critical-flows/device-authorization.spec.ts
@@ -1,0 +1,121 @@
+import type { APIRequestContext, APIResponse } from '@playwright/test'
+import { assertMutatingE2ESafety } from '../safety'
+import { expect, test } from '../fixtures'
+
+const CLI_CLIENT_ID = 'factory-careers-cli'
+const DEVICE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code'
+
+type DeviceCodeResponse = {
+  device_code: string
+  user_code: string
+  verification_uri: string
+  verification_uri_complete: string
+  expires_in: number
+  interval: number
+}
+
+type DeviceTokenResponse = {
+  access_token: string
+  token_type: string
+  expires_in: number
+  scope: string
+}
+
+type DeviceTokenError = {
+  error: string
+  error_description: string
+}
+
+async function expectStatus(response: APIResponse, expected: number, label: string) {
+  expect(response.status(), `${label} returned ${response.status()}: ${await response.text()}`).toBe(expected)
+}
+
+async function requestDeviceCode(request: APIRequestContext): Promise<DeviceCodeResponse> {
+  const response = await request.post('/api/auth/device/code', {
+    data: {
+      client_id: CLI_CLIENT_ID,
+      scope: 'openid profile email',
+    },
+  })
+  await expectStatus(response, 200, 'Device code API')
+  const body = await response.json() as DeviceCodeResponse
+  expect(body.device_code, 'device code must be returned for CLI polling').toBeTruthy()
+  expect(body.user_code, 'user code must be returned for browser approval').toBeTruthy()
+  expect(body.verification_uri).toContain('/device')
+  expect(body.verification_uri_complete).toContain(`/device?user_code=${encodeURIComponent(body.user_code)}`)
+  expect(body.expires_in).toBeGreaterThan(0)
+  expect(body.interval).toBeGreaterThan(0)
+  return body
+}
+
+async function exchangeDeviceToken(request: APIRequestContext, deviceCode: string): Promise<APIResponse> {
+  return await request.post('/api/auth/device/token', {
+    data: {
+      grant_type: DEVICE_GRANT_TYPE,
+      device_code: deviceCode,
+      client_id: CLI_CLIENT_ID,
+    },
+  })
+}
+
+test.describe('CLI device authorization handoff', () => {
+  test('approves a CLI device code in the browser and rejects denied or invalid exchanges', async ({ authenticatedPage, request }, testInfo) => {
+    const page = authenticatedPage
+    const baseURL = String(testInfo.project.use.baseURL ?? '')
+    assertMutatingE2ESafety({
+      env: {
+        PLAYWRIGHT_BASE_URL: baseURL,
+        DATABASE_URL: process.env.DATABASE_URL,
+        BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
+        NUXT_PUBLIC_SITE_URL: process.env.NUXT_PUBLIC_SITE_URL,
+      },
+    })
+
+    const invalidExchange = await exchangeDeviceToken(request, 'not-a-real-device-code')
+    await expectStatus(invalidExchange, 400, 'Invalid device token exchange')
+    const invalidExchangeBody = await invalidExchange.json() as DeviceTokenError
+    expect(invalidExchangeBody.error).toBe('invalid_grant')
+
+    const approvedDevice = await requestDeviceCode(request)
+    await page.goto(`/device?user_code=${encodeURIComponent(approvedDevice.user_code)}`, { waitUntil: 'networkidle' })
+    await expect(page.getByRole('heading', { name: 'Approve CLI access?' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByLabel('Device code')).toHaveValue(approvedDevice.user_code)
+    await page.getByRole('button', { name: 'Approve' }).click()
+    await expect(page.getByText('This device request was approved. You can close this page.')).toBeVisible()
+
+    const tokenResponse = await exchangeDeviceToken(request, approvedDevice.device_code)
+    await expectStatus(tokenResponse, 200, 'Approved device token exchange')
+    const token = await tokenResponse.json() as DeviceTokenResponse
+    expect(token.token_type).toBe('Bearer')
+    expect(token.access_token, 'approved device exchange must return a bearer token').toBeTruthy()
+    expect(token.expires_in).toBeGreaterThan(0)
+
+    const capabilitiesResponse = await request.get('/api/cli/capabilities', {
+      headers: { Authorization: `Bearer ${token.access_token}` },
+    })
+    await expectStatus(capabilitiesResponse, 200, 'Bearer capabilities API')
+    const capabilities = await capabilitiesResponse.json() as { application: string, route: string }
+    expect(capabilities).toMatchObject({
+      application: 'factory-careers',
+      route: '/api/cli/capabilities',
+    })
+
+    const dashboardStatsResponse = await request.get('/api/dashboard/stats', {
+      headers: { Authorization: `Bearer ${token.access_token}` },
+    })
+    await expectStatus(dashboardStatsResponse, 200, 'Bearer dashboard stats API')
+    const dashboardStats = await dashboardStatsResponse.json() as { counts?: { openJobs?: number } }
+    expect(typeof dashboardStats.counts?.openJobs).toBe('number')
+
+    const deniedDevice = await requestDeviceCode(request)
+    await page.goto(`/device?user_code=${encodeURIComponent(deniedDevice.user_code)}`, { waitUntil: 'networkidle' })
+    await expect(page.getByRole('heading', { name: 'Approve CLI access?' })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('button', { name: 'Deny' }).click()
+    await expect(page.getByText('This device request was denied. You can close this page.')).toBeVisible()
+
+    const deniedExchange = await exchangeDeviceToken(request, deniedDevice.device_code)
+    await expectStatus(deniedExchange, 400, 'Denied device token exchange')
+    const deniedExchangeBody = await deniedExchange.json() as DeviceTokenError
+    expect(deniedExchangeBody.error).toBe('access_denied')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:e2e:tracking-analytics": "playwright test e2e/critical-flows/tracking-analytics.spec.ts",
     "test:e2e:interviews": "playwright test e2e/critical-flows/interview-lifecycle.spec.ts e2e/critical-flows/interview-invitation-response.spec.ts e2e/critical-flows/interview-template-management.spec.ts --workers=1",
     "test:e2e:calendar": "FACTORY_CALENDAR_TEST_MODE=mock playwright test e2e/critical-flows/calendar-integration.spec.ts",
-    "test:e2e:auth-org": "FACTORY_EMAIL_TEST_MODE=capture FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-auth-org-email.jsonl playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts e2e/critical-flows/organization-settings.spec.ts e2e/critical-flows/org-admin-membership.spec.ts",
+    "test:e2e:auth-org": "FACTORY_EMAIL_TEST_MODE=capture FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-auth-org-email.jsonl playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts e2e/critical-flows/organization-settings.spec.ts e2e/critical-flows/org-admin-membership.spec.ts e2e/critical-flows/device-authorization.spec.ts",
     "test:e2e:rbac": "playwright test e2e/critical-flows/rbac-role-permissions.spec.ts",
     "test:e2e:sso": "playwright test e2e/critical-flows/sso-domain-provisioning.spec.ts",
     "test:e2e:ai-review": "playwright test e2e/critical-flows/ai-candidate-review.spec.ts e2e/critical-flows/ai-config-lifecycle.spec.ts e2e/critical-flows/chatbot-conversations.spec.ts --workers=1",

--- a/server/api/dashboard/stats.get.ts
+++ b/server/api/dashboard/stats.get.ts
@@ -147,7 +147,7 @@ export default defineCachedEventHandler(async (event) => {
   maxAge: 30,
   swr: true,
   // Nitro cached handlers strip request headers unless they are listed here.
-  // The auth/permission check needs cookies, and the cached response must stay
-  // scoped to the caller's session.
-  varies: ['cookie'],
+  // The auth/permission check needs cookie and bearer sessions, and the cached
+  // response must stay scoped to the caller's session.
+  varies: ['cookie', 'authorization'],
 })

--- a/server/utils/activeOrganization.ts
+++ b/server/utils/activeOrganization.ts
@@ -1,0 +1,54 @@
+import { eq } from 'drizzle-orm'
+import { member, session as sessionTable } from '../database/schema'
+
+type SessionWithOptionalActiveOrg = {
+  user: {
+    id: string
+  }
+  session: {
+    id?: string
+    token?: string
+    activeOrganizationId?: string | null
+  }
+}
+
+export async function resolveActiveOrganizationId(
+  authSession: SessionWithOptionalActiveOrg,
+): Promise<string | null> {
+  if (authSession.session.activeOrganizationId) {
+    return authSession.session.activeOrganizationId
+  }
+
+  const memberships = await db
+    .select({ organizationId: member.organizationId })
+    .from(member)
+    .where(eq(member.userId, authSession.user.id))
+    .limit(2)
+
+  if (memberships.length !== 1) {
+    return null
+  }
+
+  const activeOrganizationId = memberships[0]?.organizationId
+  if (!activeOrganizationId) {
+    return null
+  }
+
+  if (authSession.session.id) {
+    await db
+      .update(sessionTable)
+      .set({ activeOrganizationId, updatedAt: new Date() })
+      .where(eq(sessionTable.id, authSession.session.id))
+  }
+  else if (authSession.session.token) {
+    await db
+      .update(sessionTable)
+      .set({ activeOrganizationId, updatedAt: new Date() })
+      .where(eq(sessionTable.token, authSession.session.token))
+  }
+  else {
+    return null
+  }
+
+  return activeOrganizationId
+}

--- a/server/utils/requireAuth.ts
+++ b/server/utils/requireAuth.ts
@@ -1,4 +1,5 @@
 import type { H3Event } from 'h3'
+import { resolveActiveOrganizationId } from './activeOrganization'
 import { assertFactoryStaffAccess } from './factoryAccess'
 
 type AuthSession = NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>
@@ -24,7 +25,7 @@ export async function requireAuth(event: H3Event) {
     throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
   }
 
-  const activeOrganizationId = (session.session as { activeOrganizationId?: string }).activeOrganizationId
+  const activeOrganizationId = await resolveActiveOrganizationId(session)
 
   if (!activeOrganizationId) {
     throw createError({ statusCode: 403, statusMessage: 'No active organization' })

--- a/server/utils/requirePermission.ts
+++ b/server/utils/requirePermission.ts
@@ -1,5 +1,6 @@
 import type { H3Event } from 'h3'
 import type { statements } from '~~/shared/permissions'
+import { resolveActiveOrganizationId } from './activeOrganization'
 import { assertFactoryStaffAccess } from './factoryAccess'
 
 /**
@@ -56,7 +57,7 @@ export async function requirePermission(
   }
 
   // ── Step 2: Active organization ──
-  const activeOrganizationId = (session.session as { activeOrganizationId?: string }).activeOrganizationId
+  const activeOrganizationId = await resolveActiveOrganizationId(session)
 
   if (!activeOrganizationId) {
     throw createError({ statusCode: 403, statusMessage: 'No active organization' })

--- a/tests/unit/active-organization.test.ts
+++ b/tests/unit/active-organization.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  from: vi.fn(),
+  where: vi.fn(),
+  limit: vi.fn(),
+  update: vi.fn(),
+  set: vi.fn(),
+  updateWhere: vi.fn(),
+}))
+
+vi.stubGlobal('db', {
+  select: mocks.select,
+  update: mocks.update,
+})
+
+const { resolveActiveOrganizationId } = await import('../../server/utils/activeOrganization')
+
+function mockMemberships(rows: Array<{ organizationId: string }>) {
+  mocks.select.mockReturnValue({ from: mocks.from })
+  mocks.from.mockReturnValue({ where: mocks.where })
+  mocks.where.mockReturnValue({ limit: mocks.limit })
+  mocks.limit.mockResolvedValue(rows)
+}
+
+function mockUpdate() {
+  mocks.update.mockReturnValue({ set: mocks.set })
+  mocks.set.mockReturnValue({ where: mocks.updateWhere })
+  mocks.updateWhere.mockResolvedValue(undefined)
+}
+
+describe('resolveActiveOrganizationId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUpdate()
+  })
+
+  it('returns an existing active organization without querying memberships', async () => {
+    await expect(resolveActiveOrganizationId({
+      user: { id: 'user-1' },
+      session: { id: 'session-1', activeOrganizationId: 'org-active' },
+    })).resolves.toBe('org-active')
+
+    expect(mocks.select).not.toHaveBeenCalled()
+    expect(mocks.update).not.toHaveBeenCalled()
+  })
+
+  it('persists the only organization membership onto sessions minted without an active organization', async () => {
+    mockMemberships([{ organizationId: 'org-only' }])
+
+    await expect(resolveActiveOrganizationId({
+      user: { id: 'user-1' },
+      session: { id: 'session-1', token: 'session-token' },
+    })).resolves.toBe('org-only')
+
+    expect(mocks.update).toHaveBeenCalledTimes(1)
+    expect(mocks.set).toHaveBeenCalledWith(expect.objectContaining({
+      activeOrganizationId: 'org-only',
+      updatedAt: expect.any(Date),
+    }))
+  })
+
+  it('does not choose an active organization when membership selection is ambiguous', async () => {
+    mockMemberships([
+      { organizationId: 'org-one' },
+      { organizationId: 'org-two' },
+    ])
+
+    await expect(resolveActiveOrganizationId({
+      user: { id: 'user-1' },
+      session: { id: 'session-1' },
+    })).resolves.toBeNull()
+
+    expect(mocks.update).not.toHaveBeenCalled()
+  })
+
+  it('does not choose an active organization when the session cannot be persisted', async () => {
+    mockMemberships([{ organizationId: 'org-only' }])
+
+    await expect(resolveActiveOrganizationId({
+      user: { id: 'user-1' },
+      session: {},
+    })).resolves.toBeNull()
+
+    expect(mocks.update).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/cli-dashboard-commands.test.ts
+++ b/tests/unit/cli-dashboard-commands.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 })
 
 describe('CLI dashboard commands', () => {
-  it('fetches dashboard summary stats', async () => {
+  it('fetches dashboard summary stats with the bearer token used by the cached API route', async () => {
     const dir = tempDir()
     const configPath = join(dir, 'config.json')
     writeAuthedConfig(configPath)

--- a/tests/unit/dashboard-stats-cache.test.ts
+++ b/tests/unit/dashboard-stats-cache.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 describe('dashboard stats cache', () => {
   const source = readFileSync(join(process.cwd(), 'server/api/dashboard/stats.get.ts'), 'utf8')
 
-  it('varies by cookie so the cached handler preserves auth headers', () => {
-    expect(source).toContain("varies: ['cookie']")
+  it('varies by cookie and bearer tokens so the cached handler preserves auth headers', () => {
+    expect(source).toContain("varies: ['cookie', 'authorization']")
   })
 })

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -235,7 +235,7 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:auth-org']).toBe(
-      'FACTORY_EMAIL_TEST_MODE=capture FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-auth-org-email.jsonl playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts e2e/critical-flows/organization-settings.spec.ts e2e/critical-flows/org-admin-membership.spec.ts',
+      'FACTORY_EMAIL_TEST_MODE=capture FACTORY_EMAIL_CAPTURE_PATH=/tmp/factory-careers-e2e-auth-org-email.jsonl playwright test e2e/critical-flows/auth-org-edge-flows.spec.ts e2e/critical-flows/organization-settings.spec.ts e2e/critical-flows/org-admin-membership.spec.ts e2e/critical-flows/device-authorization.spec.ts',
     )
     expect(workflow).toContain('name: Playwright auth and org')
     expect(workflow).toContain('npm run test:e2e:auth-org')
@@ -247,6 +247,12 @@ describe('Playwright E2E harness contract', () => {
     expect(read('e2e/critical-flows/org-admin-membership.spec.ts')).toContain('assertMutatingE2ESafety')
     expect(read('e2e/critical-flows/org-admin-membership.spec.ts')).toContain('FACTORY_EMAIL_TEST_MODE')
     expect(read('e2e/critical-flows/org-admin-membership.spec.ts')).toContain('/api/join-requests')
+    expect(read('e2e/critical-flows/device-authorization.spec.ts')).toContain('assertMutatingE2ESafety')
+    expect(read('e2e/critical-flows/device-authorization.spec.ts')).toContain('/api/auth/device/code')
+    expect(read('e2e/critical-flows/device-authorization.spec.ts')).toContain('/api/auth/device/token')
+    expect(read('e2e/critical-flows/device-authorization.spec.ts')).toContain('/api/cli/capabilities')
+    expect(read('e2e/critical-flows/device-authorization.spec.ts')).toContain('/api/dashboard/stats')
+    expect(read('e2e/critical-flows/device-authorization.spec.ts')).toContain('access_denied')
     expect(workflow).toContain('needs.auth_org.result')
     expect(workflow).toContain(e2eRequiredNeeds)
   })


### PR DESCRIPTION
## Summary
- Add a fast CLI device authorization E2E spec to the existing auth/org Playwright lane.
- Cover invalid, approved, and denied device-code exchanges, browser approval UI, bearer access to CLI capabilities, and bearer dashboard stats access.
- Fix the production bug the test exposed: device-token sessions can now resolve exactly-one organization membership into an active organization, and cached dashboard stats now vary by bearer authorization as well as cookies.

Closes #156

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Validation
- [x] I tested locally
- [ ] I added/updated relevant documentation
- [x] I verified multi-tenant scoping and auth behavior for affected API paths

Validation run:
- npm run test:unit -- tests/unit/active-organization.test.ts tests/unit/require-permission.test.ts tests/unit/require-permission-security.test.ts tests/unit/dashboard-stats-cache.test.ts tests/unit/e2e-harness-contract.test.ts tests/unit/cli-auth-foundation.test.ts tests/unit/cli-auth-commands.test.ts
- npm run test:unit -- tests/unit/cli-dashboard-commands.test.ts tests/unit/active-organization.test.ts tests/unit/e2e-harness-contract.test.ts
- Local-only disposable DB: npx playwright test e2e/critical-flows/device-authorization.spec.ts --workers=1
- Local-only disposable DB: npm run test:e2e:auth-org
- npm run check:conventions
- npm run preflight:cli-parity
- npm run preflight:pr
- git diff --check

## CLI parity
- [x] I checked whether this changes portal/API workflow payload shapes, response shapes, auth requirements, or resource coverage
- [ ] I updated packages/careers-cli/src/routeCoverage.ts when API routes were added, removed, renamed, or intentionally excluded
- [x] I updated docs/CLI.md, CLI commands, shared schemas, or CLI tests when the portal/API workflow should be agent-accessible
- [ ] I documented the reason when a changed portal/API workflow should not be exposed through the CLI

## Keyboard / accessibility acceptance
- [ ] Visible focus is preserved for every interactive control I touched
- [ ] No core action in this change is pointer-only
- [ ] Escape behavior is intentional for transient UI I changed
- [ ] Focus restores to the invoking control after closing modals/popovers/drawers
- [ ] Any modal I changed traps focus correctly while open
- [ ] Any custom listbox/menu/combobox behavior still works from the keyboard
- [ ] New custom controls include keyboard-focused tests where applicable

Not applicable: this PR exercises an existing device approval page but does not change interactive UI behavior.

## Known risks or skipped checks
- Local Playwright runs were explicitly pinned to 127.0.0.1 with a disposable Postgres database and fake email capture paths. No production URLs or production database were used.
- Existing Nuxt/Volar and Tailwind sourcemap warnings appear during typecheck/build, but commands exit successfully.

## Release/version notes
- No changeset needed; test coverage plus auth/cache bug fix only.

## DCO
- [ ] All commits in this PR are signed off (Signed-off-by) via git commit -s
