### PR TITLE
test: cover public listbox keyboard flows

### DIFF
--- a/app/components/LanguageSwitcher.vue
+++ b/app/components/LanguageSwitcher.vue
@@ -16,14 +16,18 @@ const { locale, locales, t } = useI18n()
 
 const isOpen = ref(false)
 const dropdownRef = ref<HTMLElement | null>(null)
-const triggerRef = ref<HTMLElement | null>(null)
+const triggerRef = ref<HTMLButtonElement | null>(null)
 const listboxRef = ref<HTMLElement | null>(null)
+const languageSelectId = useId()
 const languageFeatureEnabled = computed(
   () => runtimeConfig.public.languageFeatureEnabled === true,
 )
 
-function closeDropdown() {
+function closeDropdown(restoreFocus = false) {
   isOpen.value = false
+  if (restoreFocus) {
+    nextTick(() => triggerRef.value?.focus())
+  }
 }
 
 function handleClickOutside(event: MouseEvent) {
@@ -153,6 +157,9 @@ const selectedLocaleCode = computed({
     void handleLocaleChange(nextLocale)
   },
 })
+const selectedLocaleIndex = computed(() =>
+  localeOptions.value.findIndex(option => option.code === selectedLocaleCode.value),
+)
 
 const showI18nProbe = computed(() => {
   const i18nTestQuery = route.query.i18nTest
@@ -180,14 +187,14 @@ const { floatingStyle: dropdownStyle } = useFloatingMenu({
   zIndex: 90,
 })
 
-function optionClasses(code: string) {
+function optionClasses(code: string, active = false) {
   if (isFactoryTone.value) {
-    return code === selectedLocaleCode.value
+    return active || code === selectedLocaleCode.value
       ? 'bg-brand-500/12 text-white'
       : 'text-white/68 hover:bg-brand-500/12 hover:text-white'
   }
 
-  return code === selectedLocaleCode.value
+  return active || code === selectedLocaleCode.value
     ? 'bg-surface-100 dark:bg-surface-800 text-surface-900 dark:text-surface-100'
     : 'text-surface-600 dark:text-surface-300 hover:bg-surface-50 dark:hover:bg-surface-800'
 }
@@ -196,9 +203,24 @@ const partialBadgeClasses = computed(() => isFactoryTone.value
   ? 'border border-warning-500/40 bg-warning-500/10 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-warning-300'
   : 'rounded bg-amber-100 dark:bg-amber-900/40 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400')
 
-async function handleLocaleChange(nextLocale: string) {
+const languageListboxNavigation = useListboxNavigation({
+  idBase: languageSelectId,
+  open: isOpen,
+  optionCount: computed(() => localeOptions.value.length),
+  selectedIndex: selectedLocaleIndex,
+  openListbox: () => {
+    isOpen.value = true
+  },
+  closeListbox: () => closeDropdown(true),
+  selectIndex: (index) => {
+    const option = localeOptions.value[index]
+    if (option) void handleLocaleChange(option.code, true)
+  },
+})
+
+async function handleLocaleChange(nextLocale: string, restoreFocus = false) {
   if (!nextLocale || nextLocale === selectedLocaleCode.value) {
-    closeDropdown()
+    closeDropdown(restoreFocus)
     return
   }
   if (!isSwitchLocale(nextLocale)) return
@@ -222,12 +244,16 @@ async function handleLocaleChange(nextLocale: string) {
       <!-- Trigger button -->
       <button
         ref="triggerRef"
+        :id="languageSelectId"
         type="button"
         :aria-label="t('common.selectLanguage')"
         :aria-expanded="isOpen"
+        :aria-controls="`${languageSelectId}-listbox`"
+        :aria-activedescendant="languageListboxNavigation.activeDescendantId.value"
         aria-haspopup="listbox"
         :class="triggerClasses"
         @click="isOpen = !isOpen"
+        @keydown="languageListboxNavigation.onKeydown"
       >
         <span>{{ localeOptions.find(o => o.code === selectedLocaleCode)?.flag ?? '🌐' }} {{ selectedLocaleCode }}</span>
         <ChevronDown class="size-3 opacity-60 transition-transform duration-150" :class="{ 'rotate-180': isOpen }" />
@@ -238,10 +264,12 @@ async function handleLocaleChange(nextLocale: string) {
         <ul
           v-if="isOpen"
           ref="listboxRef"
+          :id="`${languageSelectId}-listbox`"
           role="listbox"
           :aria-label="t('common.selectLanguage')"
           :class="dropdownClasses"
           :style="dropdownStyle"
+          @keydown="languageListboxNavigation.onKeydown"
         >
           <li
             role="presentation"
@@ -252,12 +280,14 @@ async function handleLocaleChange(nextLocale: string) {
             Language
           </li>
           <li
-            v-for="option in localeOptions"
+            v-for="(option, index) in localeOptions"
+            :id="languageListboxNavigation.optionId(index)"
             :key="option.code"
             role="option"
             :aria-selected="option.code === selectedLocaleCode"
             class="flex cursor-pointer items-center justify-between gap-2 px-3 py-1.5 transition-colors"
-            :class="optionClasses(option.code)"
+            :class="optionClasses(option.code, languageListboxNavigation.activeIndex.value === index)"
+            @mouseenter="languageListboxNavigation.activate(index)"
             @click="handleLocaleChange(option.code)"
           >
             <span class="flex items-center gap-1.5">

--- a/app/composables/useListboxNavigation.ts
+++ b/app/composables/useListboxNavigation.ts
@@ -7,7 +7,7 @@ type UseListboxNavigationOptions = {
   optionCount: MaybeRefOrGetter<number>
   selectedIndex?: MaybeRefOrGetter<number>
   openListbox?: () => void
-  closeListbox?: () => void
+  closeListbox?: (restoreFocus?: boolean) => void
   selectIndex: (index: number) => void
 }
 
@@ -72,7 +72,9 @@ export function useListboxNavigation(options: UseListboxNavigationOptions) {
       selectActive()
     } else if (event.key === 'Escape') {
       event.preventDefault()
-      options.closeListbox?.()
+      options.closeListbox?.(true)
+    } else if (event.key === 'Tab') {
+      options.closeListbox?.(false)
     }
   }
 

--- a/app/pages/jobs/index.vue
+++ b/app/pages/jobs/index.vue
@@ -46,8 +46,9 @@ const searchQuery = ref('')
 const typeFilter = ref<string | undefined>(undefined)
 const typeDropdownOpen = ref(false)
 const typeDropdownRef = ref<HTMLElement | null>(null)
-const typeDropdownTriggerRef = ref<HTMLElement | null>(null)
+const typeDropdownTriggerRef = ref<HTMLButtonElement | null>(null)
 const typeDropdownListboxRef = ref<HTMLElement | null>(null)
+const typeDropdownId = useId()
 const { floatingStyle: typeDropdownStyle } = useFloatingMenu({
   open: typeDropdownOpen,
   triggerRef: typeDropdownTriggerRef,
@@ -109,11 +110,34 @@ const typeOptions = [
 ] as const
 
 const selectedTypeLabel = computed(() => typeOptions.find(option => option.value === typeFilter.value)?.label ?? 'All types')
+const selectedTypeIndex = computed(() => typeOptions.findIndex(option => option.value === typeFilter.value))
 
-function setTypeFilter(value: string | undefined) {
-  typeFilter.value = value
+function closeTypeDropdown(restoreFocus = false) {
   typeDropdownOpen.value = false
+  if (restoreFocus) {
+    nextTick(() => typeDropdownTriggerRef.value?.focus())
+  }
 }
+
+function setTypeFilter(value: string | undefined, restoreFocus = false) {
+  typeFilter.value = value
+  closeTypeDropdown(restoreFocus)
+}
+
+const typeListboxNavigation = useListboxNavigation({
+  idBase: typeDropdownId,
+  open: typeDropdownOpen,
+  optionCount: computed(() => typeOptions.length),
+  selectedIndex: selectedTypeIndex,
+  openListbox: () => {
+    typeDropdownOpen.value = true
+  },
+  closeListbox: () => closeTypeDropdown(true),
+  selectIndex: (index) => {
+    const option = typeOptions[index]
+    if (option) setTypeFilter(option.value, true)
+  },
+})
 
 function handleTypeDropdownClickOutside(event: MouseEvent) {
   const target = event.target as Node
@@ -177,14 +201,15 @@ function formatPostedDate(activeFrom?: string | null, createdAt?: string | null)
       <div ref="typeDropdownRef" class="relative sm:w-40">
         <button
           ref="typeDropdownTriggerRef"
+          :id="typeDropdownId"
           type="button"
           class="flex h-10 min-h-10 w-full items-center justify-between border border-white/14 bg-black/35 px-3 py-0 text-left text-sm text-white outline-none transition-colors hover:border-brand-500/60 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/25"
           :aria-expanded="typeDropdownOpen"
+          :aria-controls="`${typeDropdownId}-listbox`"
+          :aria-activedescendant="typeListboxNavigation.activeDescendantId.value"
           aria-haspopup="listbox"
           @click="typeDropdownOpen = !typeDropdownOpen"
-          @keydown.enter.prevent="typeDropdownOpen = !typeDropdownOpen"
-          @keydown.space.prevent="typeDropdownOpen = !typeDropdownOpen"
-          @keydown.escape="typeDropdownOpen = false"
+          @keydown="typeListboxNavigation.onKeydown"
         >
           <span>{{ selectedTypeLabel }}</span>
           <ChevronDown
@@ -197,20 +222,25 @@ function formatPostedDate(activeFrom?: string | null, createdAt?: string | null)
           <ul
             v-if="typeDropdownOpen"
             ref="typeDropdownListboxRef"
+            :id="`${typeDropdownId}-listbox`"
             role="listbox"
             class="factory-public-form-portal border border-white/14 bg-black py-1 text-sm shadow-2xl shadow-black/50"
             :style="typeDropdownStyle"
+            @keydown="typeListboxNavigation.onKeydown"
           >
-            <li v-for="opt in typeOptions" :key="String(opt.value)" role="option" :aria-selected="opt.value === typeFilter">
-              <button
-                type="button"
-                class="flex w-full items-center justify-between px-3 py-2 text-left text-white/68 transition-colors hover:bg-brand-500/12 hover:text-white"
-                :class="opt.value === typeFilter ? 'text-white' : ''"
-                @click="setTypeFilter(opt.value)"
-              >
-                <span>{{ opt.label }}</span>
-                <Check v-if="opt.value === typeFilter" class="size-3.5 text-brand-500" />
-              </button>
+            <li
+              v-for="(opt, index) in typeOptions"
+              :id="typeListboxNavigation.optionId(index)"
+              :key="String(opt.value)"
+              role="option"
+              :aria-selected="opt.value === typeFilter"
+              class="flex cursor-pointer items-center justify-between px-3 py-2 text-left text-white/68 transition-colors hover:bg-brand-500/12 hover:text-white"
+              :class="opt.value === typeFilter || typeListboxNavigation.activeIndex.value === index ? 'bg-brand-500/12 text-white' : ''"
+              @mouseenter="typeListboxNavigation.activate(index)"
+              @click="setTypeFilter(opt.value)"
+            >
+              <span>{{ opt.label }}</span>
+              <Check v-if="opt.value === typeFilter" class="size-3.5 text-brand-500" />
             </li>
           </ul>
         </Teleport>
@@ -238,7 +268,7 @@ function formatPostedDate(activeFrom?: string | null, createdAt?: string | null)
             </h2>
 
             <!-- Meta -->
-            <div class="mt-3 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs font-semibold uppercase tracking-[0.14em] text-white/42">
+            <div class="mt-3 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs font-semibold uppercase tracking-[0.14em] text-white/70">
               <span class="inline-flex items-center gap-1">
                 <Briefcase class="size-3.5" />
                 {{ formatType(j.type) }}
@@ -247,7 +277,7 @@ function formatPostedDate(activeFrom?: string | null, createdAt?: string | null)
                 <MapPin class="size-3.5" />
                 {{ j.location }}
               </span>
-              <span class="text-white/34">
+              <span class="text-white/60">
                 Posted {{ formatPostedDate(j.activeFrom, j.createdAt) }}
               </span>
             </div>
@@ -289,7 +319,7 @@ function formatPostedDate(activeFrom?: string | null, createdAt?: string | null)
       </div>
 
       <!-- Total count -->
-      <p class="pt-1 text-xs text-white/34">
+      <p class="pt-1 text-xs text-white/60">
         {{ total }} open position{{ total === 1 ? '' : 's' }}
       </p>
     </div>

--- a/e2e/critical-flows/accessibility-keyboard.spec.ts
+++ b/e2e/critical-flows/accessibility-keyboard.spec.ts
@@ -20,7 +20,7 @@ test.describe('Accessibility and keyboard harness', () => {
     await tabUntilFocused(page, page.getByRole('button', { name: 'Sign in with Microsoft' }))
   })
 
-  test('closes public listboxes with Escape and restores focus', async ({ page }) => {
+  test('operates public listboxes and language picker from the keyboard', async ({ page }) => {
     await page.goto('/jobs')
     await page.waitForLoadState('networkidle')
 
@@ -28,11 +28,39 @@ test.describe('Accessibility and keyboard harness', () => {
     await typeFilter.focus()
     await expectVisibleKeyboardFocus(typeFilter)
     await page.keyboard.press('Enter')
+    const typeListboxId = await typeFilter.getAttribute('aria-controls')
+    expect(typeListboxId).toBeTruthy()
+    await expect(page.locator(`#${typeListboxId}`)).toBeVisible()
+    await expect(typeFilter).toHaveAttribute('aria-activedescendant', /-option-0$/)
+
+    await page.keyboard.press('ArrowDown')
+    await expect(typeFilter).toHaveAttribute('aria-activedescendant', /-option-1$/)
+    await page.keyboard.press('Enter')
+    await expect(page.getByRole('button', { name: 'Full-time' })).toBeVisible()
+    await expect(page.getByRole('listbox')).toHaveCount(0)
+
+    const selectedTypeFilter = page.getByRole('button', { name: 'Full-time' })
+    await selectedTypeFilter.focus()
+    await page.keyboard.press('Enter')
     await expect(page.getByRole('listbox')).toBeVisible()
 
     await page.keyboard.press('Escape')
     await expect(page.getByRole('listbox')).toHaveCount(0)
-    await expect(typeFilter).toBeFocused()
+    await expect(selectedTypeFilter).toBeFocused()
+
+    const languagePicker = page.getByRole('button', { name: /select language/i }).first()
+    await languagePicker.focus()
+    await expectVisibleKeyboardFocus(languagePicker)
+    await page.keyboard.press('Enter')
+    const languageListboxId = await languagePicker.getAttribute('aria-controls')
+    expect(languageListboxId).toBeTruthy()
+    await expect(page.locator(`#${languageListboxId}`)).toBeVisible()
+    await expect(languagePicker).toHaveAttribute('aria-activedescendant', /-option-0$/)
+
+    await page.keyboard.press('ArrowDown')
+    await expect(languagePicker).toHaveAttribute('aria-activedescendant', /-option-1$/)
+    await page.keyboard.press('Enter')
+    await expect(page).toHaveURL(/\/es\/jobs/)
   })
 
   test('keeps dashboard shell navigation keyboard-operable on mobile', async ({ authenticatedPage }) => {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test:e2e:production-session": "playwright test --config playwright.production.config.ts e2e/critical-flows/production-session-cache.spec.ts --workers=1",
     "test:e2e:security:core": "playwright test e2e/security/tenant-isolation.spec.ts --grep @security-core",
     "test:e2e:security:extended": "FEATURE_FLAG_CHATBOT_EXPERIENCE=true playwright test e2e/security/tenant-isolation.spec.ts --grep @security-extended",
-    "test:e2e:ui": "NUXT_DEVTOOLS=false playwright test e2e/critical-flows/invitation-management.spec.ts e2e/critical-flows/mobile-keyboard-smoke.spec.ts e2e/critical-flows/accessibility-keyboard.spec.ts",
+    "test:e2e:ui": "NUXT_DEVTOOLS=false FEATURE_FLAG_LANGUAGE_SUPPORT=true playwright test e2e/critical-flows/invitation-management.spec.ts e2e/critical-flows/mobile-keyboard-smoke.spec.ts e2e/critical-flows/accessibility-keyboard.spec.ts",
     "cli:pack": "npm pack --workspace @thefactory/careers-cli --dry-run",
     "cli:publish": "npm publish --workspace @thefactory/careers-cli",
     "ops:backup-restore-rehearsal": "bash scripts/backup-restore-rehearsal.sh",

--- a/tests/unit/e2e-harness-contract.test.ts
+++ b/tests/unit/e2e-harness-contract.test.ts
@@ -72,7 +72,7 @@ describe('Playwright E2E harness contract', () => {
     }
 
     expect(packageJson.scripts?.['test:e2e:ui']).toBe(
-      'NUXT_DEVTOOLS=false playwright test e2e/critical-flows/invitation-management.spec.ts e2e/critical-flows/mobile-keyboard-smoke.spec.ts e2e/critical-flows/accessibility-keyboard.spec.ts',
+      'NUXT_DEVTOOLS=false FEATURE_FLAG_LANGUAGE_SUPPORT=true playwright test e2e/critical-flows/invitation-management.spec.ts e2e/critical-flows/mobile-keyboard-smoke.spec.ts e2e/critical-flows/accessibility-keyboard.spec.ts',
     )
     expect(read('package.json')).toContain('@axe-core/playwright')
     expect(read('playwright.config.ts')).toContain('NUXT_DEVTOOLS=false')

--- a/tests/unit/shared-popover-primitives.test.ts
+++ b/tests/unit/shared-popover-primitives.test.ts
@@ -38,12 +38,15 @@ describe('shared keyboard and popover primitives', () => {
     expect(listboxNavigation).toContain('useListboxNavigation')
     expect(listboxNavigation).toContain('activeDescendantId')
     expect(listboxNavigation).toContain('selectActive')
+    expect(listboxNavigation).toContain("event.key === 'Tab'")
   })
 
   it('uses the shared primitives in representative dashboard controls', () => {
     const filterDrawer = readProjectFile('app/components/FilterDrawer.vue')
     const factorySelect = readProjectFile('app/components/FactorySelect.vue')
     const topbar = readProjectFile('app/components/AppTopBar.vue')
+    const publicJobs = readProjectFile('app/pages/jobs/index.vue')
+    const languageSwitcher = readProjectFile('app/components/LanguageSwitcher.vue')
 
     expect(filterDrawer).toContain('useFocusTrap')
     expect(filterDrawer).not.toContain("document.addEventListener('keydown', onKeydown)")
@@ -57,6 +60,12 @@ describe('shared keyboard and popover primitives', () => {
     expect(topbar).toContain('moreActionsMenu')
     expect(topbar).not.toContain('const showFactoryMoreActions = false')
     expect(topbar).not.toMatch(/v-if="showFactoryMoreActions"[\s\S]*title="More options"/)
+
+    expect(publicJobs).toContain('useListboxNavigation')
+    expect(publicJobs).toContain('aria-activedescendant')
+    expect(languageSwitcher).toContain('useListboxNavigation')
+    expect(languageSwitcher).toContain('aria-activedescendant')
+    expect(languageSwitcher).toContain('optionClasses(option.code, languageListboxNavigation.activeIndex.value === index)')
   })
 
   it('keeps Factory dropdown menus on the floating portal path', () => {


### PR DESCRIPTION
## Summary
- Wire the public jobs type filter and language switcher to shared listbox keyboard navigation.
- Extend the critical keyboard E2E slice to cover public listbox selection, focus restoration, and locale navigation.
- Keep the UI E2E lane fast while enabling language support for this coverage.

## Validation run
- npm run test:unit -- tests/unit/shared-popover-primitives.test.ts tests/unit/e2e-harness-contract.test.ts
- npm run typecheck
- Local-only disposable Postgres + localhost Nuxt: npx playwright test e2e/critical-flows/accessibility-keyboard.spec.ts --workers=1
- Local-only disposable Postgres + localhost Nuxt: npm run test:e2e:ui with PLAYWRIGHT_SKIP_WEB_SERVER=1
- npm run check:conventions
- git diff --check
- npm run preflight:pr
- push hook reran npm run preflight:pr

## Known risks or skipped checks
- No skipped checks. Browser validation used localhost only with disposable Postgres and dummy local S3 env; no production endpoints or real email providers were used.
- Typecheck emits the existing vue-router/volar package export warning but exits successfully.

## Release/version notes
- No changeset needed; test and accessibility behavior only.

Closes #49