### PR TITLE
test: cover modal and drawer focus traps

### DIFF
--- a/app/components/AppModalShell.vue
+++ b/app/components/AppModalShell.vue
@@ -9,12 +9,14 @@ const props = withDefaults(defineProps<{
   paddingClass?: string
   zIndexClass?: string
   closeOnBackdrop?: boolean
+  ariaLabel?: string
 }>(), {
   teleportTo: 'body',
   layout: 'grid',
   paddingClass: 'p-4',
   zIndexClass: 'z-50',
   closeOnBackdrop: true,
+  ariaLabel: 'Dialog',
 })
 
 const emit = defineEmits<{
@@ -26,9 +28,11 @@ const shellRef = ref<HTMLElement | null>(null)
 
 const shellAttrs = computed(() => {
   const { class: _class, ...rest } = attrs
+  const hasAccessibleName = rest['aria-label'] || rest['aria-labelledby']
   return {
     role: 'dialog',
     'aria-modal': true,
+    ...(hasAccessibleName ? {} : { 'aria-label': props.ariaLabel }),
     ...rest,
   }
 })

--- a/app/components/AppModalShell.vue
+++ b/app/components/AppModalShell.vue
@@ -22,10 +22,15 @@ const emit = defineEmits<{
 }>()
 
 const attrs = useAttrs()
+const shellRef = ref<HTMLElement | null>(null)
 
 const shellAttrs = computed(() => {
   const { class: _class, ...rest } = attrs
-  return rest
+  return {
+    role: 'dialog',
+    'aria-modal': true,
+    ...rest,
+  }
 })
 
 const shellClasses = computed(() => [
@@ -41,13 +46,21 @@ function handleBackdropClick() {
     emit('close')
   }
 }
+
+useFocusTrap({
+  root: shellRef,
+  active: true,
+  onEscape: () => emit('close'),
+})
 </script>
 
 <template>
   <Teleport :to="teleportTo">
     <div
+      ref="shellRef"
       v-bind="shellAttrs"
       :class="shellClasses"
+      tabindex="-1"
       @click.self="handleBackdropClick"
     >
       <slot />

--- a/app/components/ApplicationDetailDrawer.vue
+++ b/app/components/ApplicationDetailDrawer.vue
@@ -53,6 +53,7 @@ const scoringSummaryFallback = computed(() => {
 const scoreBand = computed(() => scoringData.value?.scoreBand ?? null)
 
 const showInterviewSidebar = ref(false)
+const drawerRef = ref<HTMLElement | null>(null)
 
 const { allowedTransitions, isTransitioning, transitionToStatus } = useApplicationStatusActions({
   application,
@@ -78,20 +79,20 @@ async function scoreCurrentApplication() {
   await refreshScoring()
 }
 
-// ─── Body scroll lock + keyboard handling ─────────────────────────────────────
-
-function onKeydown(e: KeyboardEvent) {
-  if (e.key === 'Escape') emit('close')
-}
+// ─── Body scroll lock + focus handling ────────────────────────────────────────
 
 onMounted(() => {
-  document.addEventListener('keydown', onKeydown)
   document.body.style.overflow = 'hidden'
 })
 
 onUnmounted(() => {
-  document.removeEventListener('keydown', onKeydown)
   document.body.style.overflow = ''
+})
+
+useFocusTrap({
+  root: drawerRef,
+  active: true,
+  onEscape: () => emit('close'),
 })
 </script>
 
@@ -118,6 +119,7 @@ onUnmounted(() => {
       leave-to-class="translate-x-full"
     >
       <aside
+        ref="drawerRef"
         class="factory-dashboard-portal fixed inset-y-0 right-0 z-[60] w-full max-w-2xl flex flex-col border-l border-white/12 bg-black text-white shadow-none"
         role="dialog"
         aria-modal="true"

--- a/app/components/CandidateDetailDrawer.vue
+++ b/app/components/CandidateDetailDrawer.vue
@@ -34,6 +34,7 @@ function handleApplied() {
 const showInterviewSidebar = ref(false)
 const interviewTargetApp = ref<{ id: string; jobTitle: string } | null>(null)
 const transitioningApplicationIds = ref<Set<string>>(new Set())
+const drawerRef = ref<HTMLElement | null>(null)
 
 function openScheduleInterview(app: { id: string; job: { title: string } }) {
   interviewTargetApp.value = { id: app.id, jobTitle: app.job.title }
@@ -80,20 +81,20 @@ const documentPreviewState = computed(() => ({
   isPdfPreview: documentPreview.isPdfPreview.value,
 }))
 
-// ─── Body scroll lock + keyboard handling ─────────────────────────────────────
-
-function onKeydown(e: KeyboardEvent) {
-  if (e.key === 'Escape') emit('close')
-}
+// ─── Body scroll lock + focus handling ────────────────────────────────────────
 
 onMounted(() => {
-  document.addEventListener('keydown', onKeydown)
   document.body.style.overflow = 'hidden'
 })
 
 onUnmounted(() => {
-  document.removeEventListener('keydown', onKeydown)
   document.body.style.overflow = ''
+})
+
+useFocusTrap({
+  root: drawerRef,
+  active: true,
+  onEscape: () => emit('close'),
 })
 </script>
 
@@ -120,6 +121,7 @@ onUnmounted(() => {
       leave-to-class="translate-x-full"
     >
       <aside
+        ref="drawerRef"
         class="factory-dashboard-portal fixed inset-y-0 right-0 z-[60] w-full max-w-2xl flex flex-col border-l border-white/12 bg-black text-white shadow-none"
         role="dialog"
         aria-modal="true"

--- a/app/components/CandidateDetailSidebar.vue
+++ b/app/components/CandidateDetailSidebar.vue
@@ -42,6 +42,7 @@ const hasSubNav = computed(() => {
 // ─────────────────────────────────────────────
 
 const activeTab = ref<'overview' | 'documents' | 'responses' | 'ai_analysis' | 'timeline'>('overview')
+const sidebarRef = ref<HTMLElement | null>(null)
 
 // ─────────────────────────────────────────────
 // Fetch application detail
@@ -246,20 +247,21 @@ async function handleDeleteDoc(docId: string) {
 // Escape key to close (layered: preview → delete → sidebar)
 // ─────────────────────────────────────────────
 
-function onKeydown(e: KeyboardEvent) {
-  if (e.key === 'Escape') {
-    if (showPreview.value) {
-      closePreview()
-    } else if (showDocDeleteConfirm.value) {
-      showDocDeleteConfirm.value = null
-    } else {
-      emit('close')
-    }
+function closeTopLayer() {
+  if (showPreview.value) {
+    closePreview()
+  } else if (showDocDeleteConfirm.value) {
+    showDocDeleteConfirm.value = null
+  } else {
+    emit('close')
   }
 }
 
-onMounted(() => window.addEventListener('keydown', onKeydown))
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+useFocusTrap({
+  root: sidebarRef,
+  active: computed(() => props.open),
+  onEscape: closeTopLayer,
+})
 
 // ─────────────────────────────────────────────
 // Timeline data for the candidate
@@ -395,9 +397,13 @@ function formatInterviewDate(dateStr: string) {
 <template>
   <Transition name="slide">
     <aside
+      ref="sidebarRef"
       v-if="open"
       class="ui-drawer-panel fixed right-0 z-40 w-full sm:w-[640px] sm:max-w-[calc(100vw-4rem)] flex flex-col"
       :class="hasSubNav ? 'top-24 h-[calc(100vh-6rem)]' : 'top-14 h-[calc(100vh-3.5rem)]'"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Candidate detail"
     >
       <!-- Header -->
       <div class="ui-drawer-header flex items-center justify-between px-4 sm:px-6 py-4 shrink-0">

--- a/app/components/ChatbotAgentManagerModal.vue
+++ b/app/components/ChatbotAgentManagerModal.vue
@@ -124,6 +124,7 @@ const atCap = computed(() => agents.value.length >= CHATBOT_AGENT_MAX_PER_USER)
           </div>
           <button
             class="ui-button ui-button-ghost size-8 p-0"
+            aria-label="Close agent manager modal"
             @click="emit('close')"
           >
             <X class="size-4" />

--- a/app/components/FeedbackModal.vue
+++ b/app/components/FeedbackModal.vue
@@ -234,6 +234,7 @@ function resetAndClose() {
           </div>
           <button
             class="ui-button ui-button-ghost p-1"
+            aria-label="Close feedback modal"
             @click="resetAndClose"
           >
             <X class="size-5" />

--- a/app/components/InterviewEmailModal.vue
+++ b/app/components/InterviewEmailModal.vue
@@ -171,6 +171,7 @@ const canSend = computed(() => {
             </div>
             <button
               class="ui-button ui-button-ghost p-1.5"
+              aria-label="Close interview invitation modal"
               @click="emit('close')"
             >
               <X class="size-5" />

--- a/app/components/InterviewScheduleSidebar.vue
+++ b/app/components/InterviewScheduleSidebar.vue
@@ -57,6 +57,7 @@ const isSubmitting = ref(false)
 const isMoving = ref(false)
 const newInterviewerEmail = ref('')
 const timeScroller = ref<HTMLElement | null>(null)
+const sidebarRef = ref<HTMLElement | null>(null)
 
 // ─── Notification method ──────────────────────────────────────────
 const notifyViaEmail = ref(false)
@@ -150,6 +151,12 @@ function handleDropdownOutsideClick(event: MouseEvent) {
 
 onMounted(() => document.addEventListener('mousedown', handleDropdownOutsideClick))
 onUnmounted(() => document.removeEventListener('mousedown', handleDropdownOutsideClick))
+
+useFocusTrap({
+  root: sidebarRef,
+  active: true,
+  onEscape: () => emit('close'),
+})
 
 watch(canUseCalendar, (enabled) => {
   if (!enabled) {
@@ -490,7 +497,13 @@ async function handleMoveToInterview() {
         leave-from-class="translate-x-0"
         leave-to-class="translate-x-full"
       >
-        <div class="relative w-full max-w-2xl bg-white dark:bg-surface-900 shadow-2xl overflow-hidden flex flex-col border-l border-surface-200/40 dark:border-surface-800/60">
+        <div
+          ref="sidebarRef"
+          class="relative w-full max-w-2xl bg-white dark:bg-surface-900 shadow-2xl overflow-hidden flex flex-col border-l border-surface-200/40 dark:border-surface-800/60"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Schedule interview"
+        >
           <!-- Header -->
           <div class="shrink-0 px-6 pt-5 pb-4">
             <div class="flex items-start justify-between">

--- a/app/components/PreviewUpsellModal.vue
+++ b/app/components/PreviewUpsellModal.vue
@@ -23,6 +23,7 @@ function closeModal() {
 
           <button
             class="ui-button ui-button-ghost p-1.5"
+            aria-label="Close preview upsell modal"
             @click="closeModal"
           >
             <X class="size-5" />

--- a/app/composables/useFocusTrap.ts
+++ b/app/composables/useFocusTrap.ts
@@ -18,6 +18,17 @@ const focusableSelector = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(',')
 
+const activeTrapStack: symbol[] = []
+
+function removeTrap(trapId: symbol) {
+  const index = activeTrapStack.lastIndexOf(trapId)
+  if (index !== -1) activeTrapStack.splice(index, 1)
+}
+
+function isTopTrap(trapId: symbol) {
+  return activeTrapStack[activeTrapStack.length - 1] === trapId
+}
+
 function getFocusable(root: HTMLElement) {
   return Array.from(root.querySelectorAll<HTMLElement>(focusableSelector))
     .filter(el => !el.hasAttribute('disabled') && el.getAttribute('aria-hidden') !== 'true')
@@ -25,6 +36,7 @@ function getFocusable(root: HTMLElement) {
 
 export function useFocusTrap(options: FocusTrapOptions) {
   let previousFocus: HTMLElement | null = null
+  const trapId = Symbol('focus-trap')
   const shouldFocusFirst = options.focusFirst ?? true
   const shouldRestoreFocus = options.restoreFocus ?? true
 
@@ -43,8 +55,11 @@ export function useFocusTrap(options: FocusTrapOptions) {
 
   function onKeydown(event: KeyboardEvent) {
     if (!toValue(options.active)) return
+    if (!isTopTrap(trapId)) return
 
     if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
       options.onEscape?.()
       return
     }
@@ -79,6 +94,8 @@ export function useFocusTrap(options: FocusTrapOptions) {
       if (typeof document === 'undefined') return
       if (active) {
         previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null
+        removeTrap(trapId)
+        activeTrapStack.push(trapId)
         document.addEventListener('keydown', onKeydown)
         if (shouldFocusFirst) {
           await nextTick()
@@ -86,6 +103,7 @@ export function useFocusTrap(options: FocusTrapOptions) {
         }
       } else {
         document.removeEventListener('keydown', onKeydown)
+        removeTrap(trapId)
         restoreFocus()
       }
     },
@@ -94,6 +112,7 @@ export function useFocusTrap(options: FocusTrapOptions) {
 
   onBeforeUnmount(() => {
     if (typeof document !== 'undefined') document.removeEventListener('keydown', onKeydown)
+    removeTrap(trapId)
     restoreFocus()
   })
 

--- a/app/composables/useFocusTrap.ts
+++ b/app/composables/useFocusTrap.ts
@@ -60,6 +60,7 @@ export function useFocusTrap(options: FocusTrapOptions) {
     if (event.key === 'Escape') {
       event.preventDefault()
       event.stopPropagation()
+      event.stopImmediatePropagation()
       options.onEscape?.()
       return
     }

--- a/e2e/critical-flows/accessibility-keyboard.spec.ts
+++ b/e2e/critical-flows/accessibility-keyboard.spec.ts
@@ -120,4 +120,25 @@ test.describe('Accessibility and keyboard harness', () => {
     await expect(page.locator('#topbar-user-menu')).toHaveCount(0)
     await expect(accountMenu).toBeFocused()
   })
+
+  test('traps and restores focus in dashboard filter drawers', async ({ authenticatedPage }) => {
+    const page = authenticatedPage
+    await page.goto('/dashboard/applications')
+    await page.waitForLoadState('networkidle')
+
+    const filtersButton = page.getByRole('button', { name: /^Filters/ })
+    await filtersButton.focus()
+    await page.keyboard.press('Enter')
+
+    const drawer = page.getByRole('dialog', { name: 'Filter applications' })
+    await expect(drawer).toBeVisible()
+    await expect(drawer.getByRole('button', { name: 'Close' })).toBeFocused()
+
+    await page.keyboard.press('Shift+Tab')
+    await expect(drawer.getByRole('button', { name: 'Done' })).toBeFocused()
+
+    await page.keyboard.press('Escape')
+    await expect(drawer).toHaveCount(0)
+    await expect(filtersButton).toBeFocused()
+  })
 })

--- a/e2e/critical-flows/chatbot-conversations.spec.ts
+++ b/e2e/critical-flows/chatbot-conversations.spec.ts
@@ -83,7 +83,7 @@ test.describe('Chatbot agents and conversations', () => {
       page.getByRole('button', { name: 'Create agent' }).click(),
     ])
     await expect(page.getByText(agentName)).toBeVisible()
-    await page.getByRole('button', { name: 'Close' }).click()
+    await page.getByRole('button', { name: 'Close', exact: true }).click()
     await expect(page.getByRole('heading', { name: 'Manage agents' })).toBeHidden()
 
     await page.getByRole('button', { name: /Default assistant/ }).click()

--- a/tests/unit/app-modal-primitives.test.ts
+++ b/tests/unit/app-modal-primitives.test.ts
@@ -18,6 +18,8 @@ describe('dashboard modal primitives', () => {
       'useFocusTrap',
       "role: 'dialog'",
       "'aria-modal': true",
+      "ariaLabel: 'Dialog'",
+      "rest['aria-label'] || rest['aria-labelledby']",
     ]) {
       expect(shell).toContain(className)
     }

--- a/tests/unit/app-modal-primitives.test.ts
+++ b/tests/unit/app-modal-primitives.test.ts
@@ -15,6 +15,9 @@ describe('dashboard modal primitives', () => {
       'flex items-center justify-center',
       'p-4',
       'z-50',
+      'useFocusTrap',
+      "role: 'dialog'",
+      "'aria-modal': true",
     ]) {
       expect(shell).toContain(className)
     }
@@ -47,6 +50,19 @@ describe('dashboard modal primitives', () => {
       expect(source, file).toContain('<AppModalShell')
       expect(source, file).toContain('<AppModalPanel')
       expect(source, file).not.toContain('factory-dashboard-portal ui-modal-backdrop fixed inset-0 z-50')
+    }
+  })
+
+  it('keeps shared modal close controls accessible by name', () => {
+    const labeledCloseButtons = [
+      ['app/components/FeedbackModal.vue', 'aria-label="Close feedback modal"'],
+      ['app/components/InterviewEmailModal.vue', 'aria-label="Close interview invitation modal"'],
+      ['app/components/ChatbotAgentManagerModal.vue', 'aria-label="Close agent manager modal"'],
+      ['app/components/PreviewUpsellModal.vue', 'aria-label="Close preview upsell modal"'],
+    ]
+
+    for (const [file, label] of labeledCloseButtons) {
+      expect(readProjectFile(file), file).toContain(label)
     }
   })
 })

--- a/tests/unit/shared-popover-primitives.test.ts
+++ b/tests/unit/shared-popover-primitives.test.ts
@@ -35,6 +35,7 @@ describe('shared keyboard and popover primitives', () => {
     expect(focusTrap).toContain('activeTrapStack')
     expect(focusTrap).toContain('isTopTrap')
     expect(focusTrap).toContain('event.stopPropagation()')
+    expect(focusTrap).toContain('event.stopImmediatePropagation()')
     expect(menuButton).toContain('useMenuButton')
     expect(menuButton).toContain('aria-expanded')
     expect(menuButton).toContain('focusTrigger')

--- a/tests/unit/shared-popover-primitives.test.ts
+++ b/tests/unit/shared-popover-primitives.test.ts
@@ -32,6 +32,9 @@ describe('shared keyboard and popover primitives', () => {
     expect(focusTrap).toContain('useFocusTrap')
     expect(focusTrap).toContain('restoreFocus')
     expect(focusTrap).toContain('focusFirst')
+    expect(focusTrap).toContain('activeTrapStack')
+    expect(focusTrap).toContain('isTopTrap')
+    expect(focusTrap).toContain('event.stopPropagation()')
     expect(menuButton).toContain('useMenuButton')
     expect(menuButton).toContain('aria-expanded')
     expect(menuButton).toContain('focusTrigger')
@@ -46,6 +49,10 @@ describe('shared keyboard and popover primitives', () => {
 
   it('uses the shared primitives in representative dashboard controls', () => {
     const filterDrawer = readProjectFile('app/components/FilterDrawer.vue')
+    const applicationDetailDrawer = readProjectFile('app/components/ApplicationDetailDrawer.vue')
+    const candidateDetailDrawer = readProjectFile('app/components/CandidateDetailDrawer.vue')
+    const candidateDetailSidebar = readProjectFile('app/components/CandidateDetailSidebar.vue')
+    const interviewScheduleSidebar = readProjectFile('app/components/InterviewScheduleSidebar.vue')
     const factorySelect = readProjectFile('app/components/FactorySelect.vue')
     const topbar = readProjectFile('app/components/AppTopBar.vue')
     const publicJobs = readProjectFile('app/pages/jobs/index.vue')
@@ -53,6 +60,13 @@ describe('shared keyboard and popover primitives', () => {
 
     expect(filterDrawer).toContain('useFocusTrap')
     expect(filterDrawer).not.toContain("document.addEventListener('keydown', onKeydown)")
+    for (const source of [applicationDetailDrawer, candidateDetailDrawer, candidateDetailSidebar, interviewScheduleSidebar]) {
+      expect(source).toContain('useFocusTrap')
+      expect(source).toContain('role="dialog"')
+      expect(source).toContain('aria-modal="true"')
+      expect(source).not.toContain("document.addEventListener('keydown', onKeydown)")
+      expect(source).not.toContain("window.addEventListener('keydown', onKeydown)")
+    }
 
     expect(factorySelect).toContain('useOutsidePointer')
     expect(factorySelect).toContain('useListboxNavigation')


### PR DESCRIPTION
Summary
- make `useFocusTrap` stack-aware so only the top modal/drawer handles Escape/Tab
- wire `AppModalShell` into the shared focus trap by default and add dialog attributes
- migrate application/candidate/interview drawer and sidebar surfaces to the shared focus trap
- add accessible labels to shared modal close buttons
- extend keyboard E2E coverage for filter drawer focus trap and focus restoration

Validation run
- `npm run test:unit -- tests/unit/shared-popover-primitives.test.ts tests/unit/app-modal-primitives.test.ts tests/unit/panel-close-buttons.test.ts`
- `npm run typecheck`
- `git diff --check`
- local-only disposable Postgres `127.0.0.1:55445` + localhost Nuxt `127.0.0.1:3333`: `npx playwright test e2e/critical-flows/accessibility-keyboard.spec.ts --workers=1`
- same local-only setup: `npm run test:e2e:ui`
- `npm run check:conventions`
- push hook `npm run preflight:pr`

Known risks or skipped checks
- No production E2E target used. Browser validation was localhost-only with disposable Postgres and fake/no-op providers.
- `npm run typecheck` still prints the known vue-router Volar package export warning while passing.

Release/version notes
- Test/accessibility-only change; no changeset needed.

Closes #51