### PR TITLE
test: cover dashboard table keyboard rows

### DIFF
--- a/app/pages/dashboard/candidates/index.vue
+++ b/app/pages/dashboard/candidates/index.vue
@@ -105,6 +105,17 @@ function toggleSort(key: SortKey) {
   }
 }
 
+function getSortAria(key: SortKey) {
+  if (sortKey.value !== key) return 'none'
+  return sortDir.value === 'asc' ? 'ascending' : 'descending'
+}
+
+function getSortButtonLabel(key: SortKey, label: string) {
+  if (sortKey.value !== key) return `Sort by ${label}`
+  const nextDirection = sortDir.value === 'asc' ? 'descending' : 'ascending'
+  return `Sort by ${label} ${nextDirection}`
+}
+
 const sortedCandidates = computed(() => {
   const list = [...candidates.value]
   const dir = sortDir.value === 'asc' ? 1 : -1
@@ -443,40 +454,40 @@ const selectedCandidateId = ref<string | null>(null)
         <table class="w-full text-sm">
           <thead>
             <tr class="ui-table-header">
-              <th class="text-left px-4 py-3 font-medium text-white/60">
-                <button class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" @click="toggleSort('name')">
+              <th class="text-left px-4 py-3 font-medium text-white/60" :aria-sort="getSortAria('name')">
+                <button type="button" class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" :aria-label="getSortButtonLabel('name', 'name')" @click="toggleSort('name')">
                   Name
                   <ArrowUp v-if="sortKey === 'name' && sortDir === 'asc'" class="size-3.5" />
                   <ArrowDown v-else-if="sortKey === 'name' && sortDir === 'desc'" class="size-3.5" />
                   <ArrowUpDown v-else class="size-3.5 opacity-40" />
                 </button>
               </th>
-              <th v-if="visibleColumns.email" class="text-left px-4 py-3 font-medium text-white/60">
-                <button class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" @click="toggleSort('email')">
+              <th v-if="visibleColumns.email" class="text-left px-4 py-3 font-medium text-white/60" :aria-sort="getSortAria('email')">
+                <button type="button" class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" :aria-label="getSortButtonLabel('email', 'email')" @click="toggleSort('email')">
                   Email
                   <ArrowUp v-if="sortKey === 'email' && sortDir === 'asc'" class="size-3.5" />
                   <ArrowDown v-else-if="sortKey === 'email' && sortDir === 'desc'" class="size-3.5" />
                   <ArrowUpDown v-else class="size-3.5 opacity-40" />
                 </button>
               </th>
-              <th v-if="visibleColumns.phone" class="text-left px-4 py-3 font-medium text-white/60 hidden md:table-cell">
-                <button class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" @click="toggleSort('phone')">
+              <th v-if="visibleColumns.phone" class="text-left px-4 py-3 font-medium text-white/60 hidden md:table-cell" :aria-sort="getSortAria('phone')">
+                <button type="button" class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" :aria-label="getSortButtonLabel('phone', 'phone')" @click="toggleSort('phone')">
                   Phone
                   <ArrowUp v-if="sortKey === 'phone' && sortDir === 'asc'" class="size-3.5" />
                   <ArrowDown v-else-if="sortKey === 'phone' && sortDir === 'desc'" class="size-3.5" />
                   <ArrowUpDown v-else class="size-3.5 opacity-40" />
                 </button>
               </th>
-              <th v-if="visibleColumns.applications" class="text-center px-4 py-3 font-medium text-white/60 hidden sm:table-cell">
-                <button class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" @click="toggleSort('applications')">
+              <th v-if="visibleColumns.applications" class="text-center px-4 py-3 font-medium text-white/60 hidden sm:table-cell" :aria-sort="getSortAria('applications')">
+                <button type="button" class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" :aria-label="getSortButtonLabel('applications', 'applications')" @click="toggleSort('applications')">
                   Applications
                   <ArrowUp v-if="sortKey === 'applications' && sortDir === 'asc'" class="size-3.5" />
                   <ArrowDown v-else-if="sortKey === 'applications' && sortDir === 'desc'" class="size-3.5" />
                   <ArrowUpDown v-else class="size-3.5 opacity-40" />
                 </button>
               </th>
-              <th v-if="visibleColumns.added" class="text-left px-4 py-3 font-medium text-white/60">
-                <button class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" @click="toggleSort('created')">
+              <th v-if="visibleColumns.added" class="text-left px-4 py-3 font-medium text-white/60" :aria-sort="getSortAria('created')">
+                <button type="button" class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" :aria-label="getSortButtonLabel('created', 'added date')" @click="toggleSort('created')">
                   Added
                   <ArrowUp v-if="sortKey === 'created' && sortDir === 'asc'" class="size-3.5" />
                   <ArrowDown v-else-if="sortKey === 'created' && sortDir === 'desc'" class="size-3.5" />
@@ -497,14 +508,14 @@ const selectedCandidateId = ref<string | null>(null)
             <tr
               v-for="c in sortedCandidates"
               :key="c.id"
-              class="ui-table-row group cursor-pointer [&>td]:align-middle"
-              @click="selectedCandidateId = c.id"
+              class="ui-table-row group [&>td]:align-middle"
             >
               <td class="px-4 py-3">
                 <button
                   type="button"
                   class="font-semibold text-surface-900 dark:text-surface-100 group-hover:text-brand-600 transition-colors whitespace-nowrap text-left"
-                  @click.stop="selectedCandidateId = c.id"
+                  :aria-label="`Open candidate ${formatCandidateName(c)}`"
+                  @click="selectedCandidateId = c.id"
                 >
                   {{ formatCandidateName(c) }}
                 </button>

--- a/app/pages/dashboard/jobs/[id]/candidates.vue
+++ b/app/pages/dashboard/jobs/[id]/candidates.vue
@@ -147,6 +147,17 @@ function toggleSort(key: SortKey) {
   }
 }
 
+function getSortAria(key: SortKey) {
+  if (sortKey.value !== key) return 'none'
+  return sortDir.value === 'asc' ? 'ascending' : 'descending'
+}
+
+function getSortButtonLabel(key: SortKey, label: string) {
+  if (sortKey.value !== key) return `Sort by ${label}`
+  const nextDirection = sortDir.value === 'asc' ? 'descending' : 'ascending'
+  return `Sort by ${label} ${nextDirection}`
+}
+
 // ─────────────────────────────────────────────
 // Filtered + sorted list
 // ─────────────────────────────────────────────
@@ -402,9 +413,11 @@ const isLoading = computed(() => jobFetchStatus.value === 'pending' || appFetchS
             <thead>
               <tr class="ui-table-header">
                 <!-- Name always visible -->
-                <th class="px-4 py-3 text-left text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wide select-none">
+                <th class="px-4 py-3 text-left text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wide select-none" :aria-sort="getSortAria('name')">
                   <button
+                    type="button"
                     class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors"
+                    :aria-label="getSortButtonLabel('name', 'name')"
                     @click="toggleSort('name')"
                   >
                     Name
@@ -413,32 +426,32 @@ const isLoading = computed(() => jobFetchStatus.value === 'pending' || appFetchS
                     <ChevronsUpDown v-else class="size-3 opacity-40" />
                   </button>
                 </th>
-                <th v-if="visibleCols.email" class="hidden sm:table-cell px-4 py-3 text-left text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wide select-none">
-                  <button class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" @click="toggleSort('email')">
+                <th v-if="visibleCols.email" class="hidden sm:table-cell px-4 py-3 text-left text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wide select-none" :aria-sort="getSortAria('email')">
+                  <button type="button" class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" :aria-label="getSortButtonLabel('email', 'email')" @click="toggleSort('email')">
                     Email
                     <ChevronUp v-if="sortKey === 'email' && sortDir === 'asc'" class="size-3" />
                     <ChevronDown v-else-if="sortKey === 'email' && sortDir === 'desc'" class="size-3" />
                     <ChevronsUpDown v-else class="size-3 opacity-40" />
                   </button>
                 </th>
-                <th v-if="visibleCols.score" class="px-4 py-3 text-left text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wide select-none">
-                  <button class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" @click="toggleSort('score')">
+                <th v-if="visibleCols.score" class="px-4 py-3 text-left text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wide select-none" :aria-sort="getSortAria('score')">
+                  <button type="button" class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" :aria-label="getSortButtonLabel('score', 'score')" @click="toggleSort('score')">
                     Score
                     <ChevronUp v-if="sortKey === 'score' && sortDir === 'asc'" class="size-3" />
                     <ChevronDown v-else-if="sortKey === 'score' && sortDir === 'desc'" class="size-3" />
                     <ChevronsUpDown v-else class="size-3 opacity-40" />
                   </button>
                 </th>
-                <th v-if="visibleCols.status" class="px-4 py-3 text-left text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wide select-none">
-                  <button class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" @click="toggleSort('status')">
+                <th v-if="visibleCols.status" class="px-4 py-3 text-left text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wide select-none" :aria-sort="getSortAria('status')">
+                  <button type="button" class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" :aria-label="getSortButtonLabel('status', 'status')" @click="toggleSort('status')">
                     Status
                     <ChevronUp v-if="sortKey === 'status' && sortDir === 'asc'" class="size-3" />
                     <ChevronDown v-else-if="sortKey === 'status' && sortDir === 'desc'" class="size-3" />
                     <ChevronsUpDown v-else class="size-3 opacity-40" />
                   </button>
                 </th>
-                <th v-if="visibleCols.createdAt" class="hidden md:table-cell px-4 py-3 text-left text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wide select-none">
-                  <button class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" @click="toggleSort('createdAt')">
+                <th v-if="visibleCols.createdAt" class="hidden md:table-cell px-4 py-3 text-left text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wide select-none" :aria-sort="getSortAria('createdAt')">
+                  <button type="button" class="inline-flex items-center gap-1 hover:text-surface-900 dark:hover:text-surface-100 transition-colors" :aria-label="getSortButtonLabel('createdAt', 'applied date')" @click="toggleSort('createdAt')">
                     Applied
                     <ChevronUp v-if="sortKey === 'createdAt' && sortDir === 'asc'" class="size-3" />
                     <ChevronDown v-else-if="sortKey === 'createdAt' && sortDir === 'desc'" class="size-3" />
@@ -460,11 +473,10 @@ const isLoading = computed(() => jobFetchStatus.value === 'pending' || appFetchS
               <tr
                 v-for="app in sorted"
                 :key="app.id"
-                class="ui-table-row cursor-pointer transition-all duration-150"
+                class="ui-table-row transition-all duration-150"
                 :class="selectedAppId === app.id
                   ? 'bg-brand-50/70 dark:bg-brand-950/20'
                   : 'hover:bg-surface-50/80 dark:hover:bg-surface-900/60'"
-                @click="selectRow(app.id)"
               >
                 <td class="px-4 py-3 whitespace-nowrap">
                   <div class="flex items-center gap-3">
@@ -476,9 +488,14 @@ const isLoading = computed(() => jobFetchStatus.value === 'pending' || appFetchS
                     >
                       {{ getCandidateInitials(app.candidateFirstName, app.candidateLastName) }}
                     </div>
-                    <span class="font-medium text-surface-900 dark:text-surface-100">
+                    <button
+                      type="button"
+                      class="font-medium text-surface-900 dark:text-surface-100 text-left hover:text-brand-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-surface-950"
+                      :aria-label="`Open application for ${formatPersonName(app.candidateFirstName, app.candidateLastName)}`"
+                      @click="selectRow(app.id)"
+                    >
                       {{ formatPersonName(app.candidateFirstName, app.candidateLastName) }}
-                    </span>
+                    </button>
                   </div>
                 </td>
                 <td v-if="visibleCols.email" class="hidden sm:table-cell px-4 py-3 text-surface-600 dark:text-surface-300 max-w-[220px] truncate">

--- a/e2e/critical-flows/accessibility-keyboard.spec.ts
+++ b/e2e/critical-flows/accessibility-keyboard.spec.ts
@@ -1,6 +1,48 @@
 import { test, expect } from '../fixtures'
 import { expectNoA11yViolations, expectVisibleKeyboardFocus, tabUntilFocused } from '../accessibility'
 
+async function createKeyboardCandidate(page: import('@playwright/test').Page, label: string) {
+  const unique = `${Date.now()}-${label}`
+  const response = await page.request.post('/api/candidates', {
+    data: {
+      firstName: 'Table',
+      lastName: `Keyboard ${label}`,
+      email: `table-keyboard-${unique}@example.com`,
+      phone: '+15555550123',
+    },
+  })
+  expect(response.status(), `Create keyboard candidate returned ${response.status()}: ${await response.text()}`).toBe(201)
+  return await response.json() as { id: string, email: string, firstName: string, lastName: string }
+}
+
+async function createKeyboardJobApplication(page: import('@playwright/test').Page, label: string) {
+  const candidate = await createKeyboardCandidate(page, `job-${label}`)
+  const jobResponse = await page.request.post('/api/jobs', {
+    data: {
+      title: `Keyboard Table Job ${Date.now()}-${label}`,
+      description: 'Seeded by dashboard table keyboard E2E coverage.',
+      location: 'Remote',
+      type: 'full_time',
+      requireResume: false,
+      requireCoverLetter: false,
+      applicationComplianceEnabled: false,
+      autoScoreOnApply: false,
+    },
+  })
+  expect(jobResponse.status(), `Create keyboard job returned ${jobResponse.status()}: ${await jobResponse.text()}`).toBe(201)
+  const job = await jobResponse.json() as { id: string, title: string }
+
+  const applicationResponse = await page.request.post('/api/applications', {
+    data: {
+      candidateId: candidate.id,
+      jobId: job.id,
+      notes: 'Keyboard table coverage application.',
+    },
+  })
+  expect(applicationResponse.status(), `Create keyboard application returned ${applicationResponse.status()}: ${await applicationResponse.text()}`).toBe(201)
+  return { candidate, job }
+}
+
 test.describe('Accessibility and keyboard harness', () => {
   test('keeps public and auth entry points axe-clean with keyboard-visible focus', async ({ page }) => {
     await page.goto('/jobs')
@@ -140,5 +182,66 @@ test.describe('Accessibility and keyboard harness', () => {
     await page.keyboard.press('Escape')
     await expect(drawer).toHaveCount(0)
     await expect(filtersButton).toBeFocused()
+  })
+
+  test('opens candidate table rows and sort headers from the keyboard', async ({ authenticatedPage }, testInfo) => {
+    const page = authenticatedPage
+    const candidate = await createKeyboardCandidate(page, `pool-${testInfo.retry}`)
+
+    await page.goto('/dashboard/candidates')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('heading', { name: 'Candidates' })).toBeVisible()
+
+    await page.getByLabel('Search candidates').fill(candidate.email)
+    const row = page.getByRole('row').filter({ hasText: candidate.email })
+    await expect(row).toBeVisible()
+
+    const nameHeader = page.getByRole('columnheader').filter({ hasText: 'Name' })
+    await expect(nameHeader).toHaveAttribute('aria-sort', 'none')
+    const nameSort = page.getByRole('button', { name: 'Sort by name' })
+    await nameSort.focus()
+    await expectVisibleKeyboardFocus(nameSort)
+    await page.keyboard.press('Enter')
+    await expect(nameHeader).toHaveAttribute('aria-sort', 'ascending')
+
+    const openCandidate = row.getByRole('button', { name: /Open candidate Table Keyboard/ })
+    await openCandidate.focus()
+    await expectVisibleKeyboardFocus(openCandidate)
+    await page.keyboard.press('Enter')
+    await expect(page.getByRole('dialog', { name: 'Candidate detail' })).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('dialog', { name: 'Candidate detail' })).toHaveCount(0)
+
+    const addNotes = row.getByRole('button', { name: 'Add Notes' })
+    await addNotes.focus()
+    await expectVisibleKeyboardFocus(addNotes)
+    await page.keyboard.press('Enter')
+    await expect(row.getByRole('textbox')).toBeFocused()
+  })
+
+  test('opens job candidate table rows from keyboard controls', async ({ authenticatedPage }, testInfo) => {
+    const page = authenticatedPage
+    const { candidate, job } = await createKeyboardJobApplication(page, `${testInfo.retry}`)
+
+    await page.goto(`/dashboard/jobs/${job.id}/candidates`)
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText(job.title).first()).toBeVisible()
+
+    const row = page.getByRole('row').filter({ hasText: candidate.email })
+    await expect(row).toBeVisible()
+
+    const scoreHeader = page.getByRole('columnheader').filter({ hasText: 'Score' })
+    await expect(scoreHeader).toHaveAttribute('aria-sort', 'descending')
+    const scoreSort = page.getByRole('button', { name: 'Sort by score ascending' })
+    await scoreSort.focus()
+    await expectVisibleKeyboardFocus(scoreSort)
+    await page.keyboard.press('Enter')
+    await expect(scoreHeader).toHaveAttribute('aria-sort', 'ascending')
+
+    const openApplication = row.getByRole('button', { name: /Open application for Table Keyboard/ })
+    await openApplication.focus()
+    await expectVisibleKeyboardFocus(openApplication)
+    await page.keyboard.press('Enter')
+    await expect(page.getByRole('dialog', { name: 'Candidate detail' })).toBeVisible()
   })
 })

--- a/e2e/critical-flows/candidate-application.spec.ts
+++ b/e2e/critical-flows/candidate-application.spec.ts
@@ -396,11 +396,11 @@ test.describe('Candidate Application Flow — All Custom Question Field Types', 
     // The status for a fresh application must be "new"
     await expect(page.getByText('new').first()).toBeVisible()
 
-    // ── Open the CandidateDetailSidebar by clicking Janet's row ──────────────
-    // The row is identified by the candidate name cell
+    // ── Open the CandidateDetailSidebar from the row's keyboard-native control ─
     await page
       .getByRole('row', { name: new RegExp(`${APPLICANT.firstName}\\s+${APPLICANT.lastName}`, 'i') })
       .first()
+      .getByRole('button', { name: new RegExp(`Open application for ${APPLICANT.firstName}\\s+${APPLICANT.lastName}`, 'i') })
       .click()
 
     // Wait for the sidebar to mount: the Overview tab button becomes visible

--- a/tests/unit/dashboard-table-keyboard.test.ts
+++ b/tests/unit/dashboard-table-keyboard.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('dashboard table keyboard affordances', () => {
+  it('keeps candidate tables off pointer-only row activation', () => {
+    const candidates = readProjectFile('app/pages/dashboard/candidates/index.vue')
+    const jobCandidates = readProjectFile('app/pages/dashboard/jobs/[id]/candidates.vue')
+
+    for (const source of [candidates, jobCandidates]) {
+      expect(source).not.toMatch(/<tr[^>]*@click=/)
+      expect(source).toContain(':aria-sort="getSortAria(')
+      expect(source).toContain('getSortButtonLabel')
+    }
+
+    expect(candidates).toContain(':aria-label="`Open candidate ${formatCandidateName(c)}`"')
+    expect(jobCandidates).toContain(':aria-label="`Open application for ${formatPersonName(app.candidateFirstName, app.candidateLastName)}`"')
+  })
+})


### PR DESCRIPTION
Summary
- remove pointer-only `tr @click` row activation from the candidate pool and per-job candidate tables
- move table opening onto keyboard-native row buttons with descriptive accessible labels
- add `aria-sort` and descriptive sort button labels to sortable dashboard table headers
- add unit guards plus Playwright keyboard coverage for candidate rows, job-candidate rows, quick notes, and sort headers

Validation run
- `npm run test:unit -- tests/unit/dashboard-table-keyboard.test.ts`
- `npm run typecheck`
- `git diff --check`
- local-only disposable Postgres `127.0.0.1:55447` + localhost Nuxt `127.0.0.1:3333`: `npx playwright test e2e/critical-flows/accessibility-keyboard.spec.ts --workers=1` with `FEATURE_FLAG_LANGUAGE_SUPPORT=true`
- push hook `npm run preflight:pr`

Known risks or skipped checks
- No production E2E target used. Browser validation was localhost-only with disposable Postgres and fake/no-op providers.
- `npm run typecheck` still prints the known vue-router Volar package export warning while passing.

Release/version notes
- Test/accessibility-only behavior hardening; no changeset needed.

Closes #52