### PR TITLE
refactor: consolidate dashboard form field formatting

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -490,6 +490,54 @@
     color: var(--color-surface-500);
   }
 
+  .ui-form-label {
+    display: block;
+    margin-bottom: 0.25rem;
+    color: var(--color-surface-700);
+    font-size: 0.75rem;
+    line-height: 1rem;
+    font-weight: 500;
+  }
+
+  .dark .ui-form-label {
+    color: var(--color-surface-300);
+  }
+
+  .ui-preview-label {
+    display: block;
+    color: var(--color-surface-500);
+    font-size: 0.75rem;
+    line-height: 1rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+  }
+
+  .dark .ui-preview-label {
+    color: var(--color-surface-400);
+  }
+
+  .ui-preview-label > .ui-preview-field {
+    margin-top: 0.25rem;
+  }
+
+  .ui-preview-field {
+    opacity: 0.8;
+  }
+
+  .ui-preview-upload-placeholder {
+    border: 1px dashed var(--color-surface-300);
+    padding: 1rem;
+    color: var(--color-surface-500);
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+  }
+
+  .dark .ui-preview-upload-placeholder {
+    border-color: var(--color-surface-700);
+    color: var(--color-surface-400);
+  }
+
   .ui-filter-chip {
     display: inline-flex;
     box-sizing: border-box;
@@ -1670,6 +1718,19 @@
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-field:focus-within {
     border-color: color-mix(in srgb, var(--color-brand-500) 75%, transparent) !important;
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-brand-500) 20%, transparent) !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-form-label {
+    color: var(--ui-muted) !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-preview-label {
+    color: var(--ui-faint) !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-preview-upload-placeholder {
+    border-color: var(--ui-border-strong) !important;
+    color: var(--ui-muted) !important;
   }
 
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-filter-chip {

--- a/app/pages/dashboard/jobs/[id]/application-form.vue
+++ b/app/pages/dashboard/jobs/[id]/application-form.vue
@@ -951,17 +951,17 @@ async function copyTrackingUrl(code: string) {
                 <section>
                   <h4 class="mb-4 text-sm font-semibold text-surface-900 dark:text-surface-100">Contact information</h4>
                   <div class="grid gap-3 sm:grid-cols-2">
-                    <label class="block text-xs font-semibold uppercase tracking-[0.12em] text-surface-500 dark:text-surface-400">
+                    <label class="ui-preview-label">
                       Name <span class="text-brand-600 dark:text-brand-400">*</span>
-                      <input disabled placeholder="First and last name" class="ui-field mt-1 px-3 py-2 text-sm opacity-80" />
+                      <input disabled placeholder="First and last name" class="ui-field ui-preview-field" />
                     </label>
-                    <label class="block text-xs font-semibold uppercase tracking-[0.12em] text-surface-500 dark:text-surface-400">
+                    <label class="ui-preview-label">
                       Email <span class="text-brand-600 dark:text-brand-400">*</span>
-                      <input disabled placeholder="you@example.com" class="ui-field mt-1 px-3 py-2 text-sm opacity-80" />
+                      <input disabled placeholder="you@example.com" class="ui-field ui-preview-field" />
                     </label>
-                    <label class="block text-xs font-semibold uppercase tracking-[0.12em] text-surface-500 dark:text-surface-400">
+                    <label class="ui-preview-label">
                       Phone
-                      <input disabled placeholder="Optional" class="ui-field mt-1 px-3 py-2 text-sm opacity-80" />
+                      <input disabled placeholder="Optional" class="ui-field ui-preview-field" />
                     </label>
                   </div>
                 </section>
@@ -969,15 +969,15 @@ async function copyTrackingUrl(code: string) {
                 <section class="border-t border-surface-200 pt-5 dark:border-surface-800">
                   <h4 class="mb-4 text-sm font-semibold text-surface-900 dark:text-surface-100">Location</h4>
                   <div class="grid gap-3 sm:grid-cols-2">
-                    <label class="block text-xs font-semibold uppercase tracking-[0.12em] text-surface-500 dark:text-surface-400">
+                    <label class="ui-preview-label">
                       Country <span class="text-brand-600 dark:text-brand-400">*</span>
-                      <select disabled class="ui-field mt-1 px-3 py-2 text-sm opacity-80">
+                      <select disabled class="ui-field ui-preview-field">
                         <option>United States</option>
                       </select>
                     </label>
-                    <label class="block text-xs font-semibold uppercase tracking-[0.12em] text-surface-500 dark:text-surface-400">
+                    <label class="ui-preview-label">
                       State <span class="text-brand-600 dark:text-brand-400">*</span>
-                      <select disabled class="ui-field mt-1 px-3 py-2 text-sm opacity-80">
+                      <select disabled class="ui-field ui-preview-field">
                         <option>Select state</option>
                       </select>
                     </label>
@@ -989,19 +989,19 @@ async function copyTrackingUrl(code: string) {
                   class="space-y-4 border-t border-surface-200 pt-5 dark:border-surface-800"
                 >
                   <div v-if="requireResume">
-                    <p class="mb-2 text-xs font-semibold uppercase tracking-[0.12em] text-surface-500 dark:text-surface-400">
+                    <p class="ui-preview-label mb-2">
                       Resume / CV <span class="text-brand-600 dark:text-brand-400">*</span>
                     </p>
-                    <div class="border border-dashed border-surface-300 px-4 py-5 text-center text-sm text-surface-500 dark:border-surface-700 dark:text-surface-400">
+                    <div class="ui-preview-upload-placeholder py-5 text-center">
                       Upload PDF, DOC, or DOCX
                     </div>
                   </div>
                   <label
                     v-if="requireCoverLetter"
-                    class="block text-xs font-semibold uppercase tracking-[0.12em] text-surface-500 dark:text-surface-400"
+                    class="ui-preview-label"
                   >
                     Cover Letter
-                    <textarea disabled rows="5" placeholder="Tell us why this role interests you." class="ui-field mt-1 px-3 py-2 text-sm opacity-80"></textarea>
+                    <textarea disabled rows="5" placeholder="Tell us why this role interests you." class="ui-field ui-preview-field"></textarea>
                   </label>
                 </section>
 
@@ -1025,7 +1025,7 @@ async function copyTrackingUrl(code: string) {
                     <select
                       v-if="q.type === 'single_select' || q.type === 'multi_select'"
                       disabled
-                      class="ui-field px-3 py-2 text-sm opacity-80"
+                      class="ui-field ui-preview-field"
                     >
                       <option>{{ q.options?.[0] ?? 'Select an option' }}</option>
                     </select>
@@ -1034,11 +1034,11 @@ async function copyTrackingUrl(code: string) {
                       disabled
                       rows="4"
                       :placeholder="previewQuestionTypeLabels[q.type]"
-                      class="ui-field px-3 py-2 text-sm opacity-80"
+                      class="ui-field ui-preview-field"
                     ></textarea>
                     <div
                       v-else-if="q.type === 'file_upload'"
-                      class="border border-dashed border-surface-300 px-4 py-4 text-sm text-surface-500 dark:border-surface-700 dark:text-surface-400"
+                      class="ui-preview-upload-placeholder"
                     >
                       Upload file
                     </div>
@@ -1046,7 +1046,7 @@ async function copyTrackingUrl(code: string) {
                       v-else
                       disabled
                       :placeholder="previewQuestionTypeLabels[q.type] ?? 'Answer'"
-                      class="ui-field px-3 py-2 text-sm opacity-80"
+                      class="ui-field ui-preview-field"
                     />
                   </div>
                 </section>
@@ -1062,34 +1062,34 @@ async function copyTrackingUrl(code: string) {
                     </p>
                   </div>
                   <div v-if="includeEeo" class="grid gap-3 sm:grid-cols-2">
-                    <label class="block text-xs font-semibold uppercase tracking-[0.12em] text-surface-500 dark:text-surface-400">
+                    <label class="ui-preview-label">
                       Sex
-                      <select disabled class="ui-field mt-1 px-3 py-2 text-sm opacity-80">
+                      <select disabled class="ui-field ui-preview-field">
                         <option>Prefer not to answer</option>
                       </select>
                     </label>
-                    <label class="block text-xs font-semibold uppercase tracking-[0.12em] text-surface-500 dark:text-surface-400">
+                    <label class="ui-preview-label">
                       Race / ethnicity
-                      <select disabled class="ui-field mt-1 px-3 py-2 text-sm opacity-80">
+                      <select disabled class="ui-field ui-preview-field">
                         <option>Prefer not to answer</option>
                       </select>
                     </label>
                   </div>
                   <label
                     v-if="includeVeteran"
-                    class="block text-xs font-semibold uppercase tracking-[0.12em] text-surface-500 dark:text-surface-400"
+                    class="ui-preview-label"
                   >
                     Veteran status
-                    <select disabled class="ui-field mt-1 px-3 py-2 text-sm opacity-80">
+                    <select disabled class="ui-field ui-preview-field">
                       <option>Prefer not to answer</option>
                     </select>
                   </label>
                   <label
                     v-if="includeDisability"
-                    class="block text-xs font-semibold uppercase tracking-[0.12em] text-surface-500 dark:text-surface-400"
+                    class="ui-preview-label"
                   >
                     Disability status
-                    <select disabled class="ui-field mt-1 px-3 py-2 text-sm opacity-80">
+                    <select disabled class="ui-field ui-preview-field">
                       <option>Prefer not to answer</option>
                     </select>
                   </label>

--- a/app/pages/dashboard/jobs/new.vue
+++ b/app/pages/dashboard/jobs/new.vue
@@ -1383,17 +1383,17 @@ const questionTypeLabels: Record<QuestionType, string> = {
                 <h3 class="text-sm font-semibold text-surface-800 dark:text-surface-200">Add custom criterion</h3>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
-                    <label class="block text-xs font-medium text-surface-700 dark:text-surface-300 mb-1">Name *</label>
+                    <label class="ui-form-label">Name *</label>
                     <input
                       v-model="customCriterionForm.name"
                       @input="customCriterionForm.key = autoGenerateKey(customCriterionForm.name)"
                       type="text"
                       placeholder="e.g. React Expertise"
-                      class="w-full rounded-lg border border-surface-300 dark:border-surface-700 px-3 py-2 text-sm bg-white dark:bg-surface-900 text-surface-900 dark:text-surface-100 focus:outline-none focus:ring-2 focus:ring-brand-500"
+                      class="ui-field"
                     />
                   </div>
                   <div>
-                    <label class="block text-xs font-medium text-surface-700 dark:text-surface-300 mb-1">Category</label>
+                    <label class="ui-form-label">Category</label>
                     <FactorySelect
                       v-model="customCriterionForm.category"
                       :options="Object.entries(categoryLabels).map(([key, label]) => ({ value: key, label }))"
@@ -1401,33 +1401,33 @@ const questionTypeLabels: Record<QuestionType, string> = {
                   </div>
                 </div>
                 <div>
-                  <label class="block text-xs font-medium text-surface-700 dark:text-surface-300 mb-1">Description</label>
+                  <label class="ui-form-label">Description</label>
                   <textarea
                     v-model="customCriterionForm.description"
                     rows="2"
                     placeholder="Describe what the AI should evaluate for this criterion..."
-                    class="w-full rounded-lg border border-surface-300 dark:border-surface-700 px-3 py-2 text-sm bg-white dark:bg-surface-900 text-surface-900 dark:text-surface-100 focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    class="ui-field"
                   />
                 </div>
                 <div class="grid grid-cols-2 gap-4">
                   <div>
-                    <label class="block text-xs font-medium text-surface-700 dark:text-surface-300 mb-1">Max Score</label>
+                    <label class="ui-form-label">Max Score</label>
                     <input
                       v-model.number="customCriterionForm.maxScore"
                       type="number"
                       min="1"
                       max="100"
-                      class="w-full rounded-lg border border-surface-300 dark:border-surface-700 px-3 py-2 text-sm bg-white dark:bg-surface-900 text-surface-900 dark:text-surface-100 focus:outline-none focus:ring-2 focus:ring-brand-500"
+                      class="ui-field"
                     />
                   </div>
                   <div>
-                    <label class="block text-xs font-medium text-surface-700 dark:text-surface-300 mb-1">Initial Weight (0–100)</label>
+                    <label class="ui-form-label">Initial Weight (0–100)</label>
                     <input
                       v-model.number="customCriterionForm.weight"
                       type="number"
                       min="0"
                       max="100"
-                      class="w-full rounded-lg border border-surface-300 dark:border-surface-700 px-3 py-2 text-sm bg-white dark:bg-surface-900 text-surface-900 dark:text-surface-100 focus:outline-none focus:ring-2 focus:ring-brand-500"
+                      class="ui-field"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Closes #93.
- Adds shared `ui-form-label`, `ui-preview-label`, `ui-preview-field`, and preview upload placeholder classes.
- Replaces repeated application preview label/field strings and switches custom scoring criteria inputs to `ui-field`.

## Validation run
- `npm run check:conventions`
- `npm run typecheck` (passes; existing Vue/Volar `vue-router/volar/sfc-route-blocks` warning emitted)
- `npm run test:unit -- tests/unit/application-form-requirements.test.ts`
- Browser pass: local `/dashboard/jobs/new` redirected to `/auth/sign-in`, so authenticated modal visual QA was blocked in this worktree.
- Pre-push hook ran `npm run preflight:pr`, including full unit suite, typecheck, CLI smoke tests, production env contract validation, and `npm run build` (passes; existing Tailwind sourcemap warnings emitted during build).

## Known risks or skipped checks
- Authenticated dashboard visual verification was not completed because the local browser session was not signed in.
- This is CSS/template-only; no route, API, database, or CLI contract behavior changed.

## Release/version notes
- No changeset needed. Internal dashboard refactor only.