### PR TITLE
refactor: Epic 3 DRY dashboard list pages

### DIFF
--- a/app/components/DashboardListToolbar.vue
+++ b/app/components/DashboardListToolbar.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { SlidersHorizontal, X, Maximize2, Minimize2 } from 'lucide-vue-next'
+import type { SavedView } from '~/composables/useSavedViews'
+
+const props = withDefaults(defineProps<{
+  searchInput: string
+  searchAriaLabel: string
+  searchPlaceholder: string
+  views: SavedView<Record<string, unknown>>[]
+  activeViewId: string | null
+  isDirty?: boolean
+  visibleColumns: Record<string, boolean>
+  columns: { key: string, label: string, required?: boolean }[]
+  filterCount: number
+  showClear?: boolean
+  isFullscreen: boolean
+  clearButtonClass?: string
+}>(), {
+  isDirty: false,
+  showClear: false,
+  clearButtonClass: 'inline-flex items-center gap-1 text-xs text-white/60 hover:text-danger-600 transition-colors',
+})
+
+const emit = defineEmits<{
+  'update:searchInput': [value: string]
+  'update:visibleColumns': [value: Record<string, boolean>]
+  'open-filters': []
+  'clear-filters': []
+  'toggle-fullscreen': []
+  'select-view': [id: string | null]
+  'save-view': [name: string]
+  'update-view': [id: string]
+  'delete-view': [id: string]
+  'set-default-view': [id: string | null]
+}>()
+</script>
+
+<template>
+  <div class="flex items-center gap-2 mb-4">
+    <GooeySearchInput
+      :model-value="searchInput"
+      :aria-label="searchAriaLabel"
+      class="min-w-0 flex-1 sm:max-w-sm"
+      :placeholder="searchPlaceholder"
+      reserve-expanded-space
+      @update:model-value="emit('update:searchInput', $event)"
+    />
+    <SavedViewsMenu
+      :views="views"
+      :active-view-id="activeViewId"
+      :is-dirty="isDirty"
+      @select="emit('select-view', $event)"
+      @save="emit('save-view', $event)"
+      @update="emit('update-view', $event)"
+      @delete="emit('delete-view', $event)"
+      @set-default="emit('set-default-view', $event)"
+    />
+    <ColumnsMenu
+      :model-value="visibleColumns"
+      :columns="columns"
+      @update:model-value="emit('update:visibleColumns', $event)"
+    />
+    <button
+      type="button"
+      class="factory-toolbar-button inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
+      :class="{ 'is-active': filterCount > 0 }"
+      @click="emit('open-filters')"
+    >
+      <SlidersHorizontal class="size-4" />
+      <span>Filters</span>
+      <span
+        v-if="filterCount > 0"
+        class="inline-flex items-center justify-center min-w-[1rem] h-4 px-1 rounded-full bg-brand-500 text-white text-[10px] font-semibold"
+      >{{ filterCount }}</span>
+    </button>
+    <button
+      v-if="showClear"
+      type="button"
+      :class="clearButtonClass"
+      @click="emit('clear-filters')"
+    >
+      <X class="size-3" />
+      Clear
+    </button>
+    <button
+      type="button"
+      class="factory-toolbar-button inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors"
+      :title="isFullscreen ? 'Exit fullscreen' : 'Fullscreen table'"
+      @click="emit('toggle-fullscreen')"
+    >
+      <Maximize2 v-if="!isFullscreen" class="size-4" />
+      <Minimize2 v-else class="size-4" />
+    </button>
+  </div>
+</template>

--- a/app/components/DashboardListToolbar.vue
+++ b/app/components/DashboardListToolbar.vue
@@ -86,6 +86,7 @@ const emit = defineEmits<{
       type="button"
       class="factory-toolbar-button inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors"
       :title="isFullscreen ? 'Exit fullscreen' : 'Fullscreen table'"
+      :aria-label="isFullscreen ? 'Exit fullscreen' : 'Fullscreen table'"
       @click="emit('toggle-fullscreen')"
     >
       <Maximize2 v-if="!isFullscreen" class="size-4" />

--- a/app/composables/useDashboardListPage.ts
+++ b/app/composables/useDashboardListPage.ts
@@ -1,0 +1,42 @@
+type UseDashboardListPageOptions<TSearch> = {
+  debounceMs?: number
+  normalizeSearch?: (value: string) => TSearch
+  initialSearch?: TSearch
+}
+
+/**
+ * Shared orchestration for dashboard list pages: debounced search, filter drawer,
+ * and fullscreen table mode with Escape-to-exit behavior.
+ */
+export function useDashboardListPage<TSearch = string | undefined>(
+  options: UseDashboardListPageOptions<TSearch> = {},
+) {
+  const normalizeSearch = options.normalizeSearch
+    ?? ((value: string) => (value.trim() || undefined) as TSearch)
+
+  const searchInput = ref('')
+  const debouncedSearch = useDebouncedRef(searchInput, {
+    delay: options.debounceMs ?? 300,
+    transform: normalizeSearch,
+    initial: options.initialSearch ?? normalizeSearch(''),
+  })
+
+  const drawerOpen = ref(false)
+  const isFullscreen = ref(false)
+
+  function handleFullscreenKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape' && isFullscreen.value) {
+      isFullscreen.value = false
+    }
+  }
+
+  onMounted(() => window.addEventListener('keydown', handleFullscreenKeydown))
+  onUnmounted(() => window.removeEventListener('keydown', handleFullscreenKeydown))
+
+  return {
+    searchInput,
+    debouncedSearch,
+    drawerOpen,
+    isFullscreen,
+  }
+}

--- a/app/composables/useDebouncedRef.ts
+++ b/app/composables/useDebouncedRef.ts
@@ -1,0 +1,34 @@
+import type { Ref } from 'vue'
+
+type DebouncedRefOptions<T> = {
+  delay?: number
+  transform?: (value: string) => T
+  initial?: T
+}
+
+/**
+ * Debounce a string ref into a derived value. Used by dashboard search bars.
+ */
+export function useDebouncedRef<T>(
+  source: Ref<string>,
+  options: DebouncedRefOptions<T> = {},
+) {
+  const delay = options.delay ?? 300
+  const transform = options.transform ?? ((value: string) => value as unknown as T)
+  const debounced = ref(options.initial ?? transform(source.value)) as Ref<T>
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  watch(source, (value) => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      debounced.value = transform(value)
+    }, delay)
+  })
+
+  onScopeDispose(() => {
+    if (timer) clearTimeout(timer)
+  })
+
+  return debounced
+}

--- a/app/composables/useTableSort.ts
+++ b/app/composables/useTableSort.ts
@@ -1,0 +1,45 @@
+export type SortDir = 'asc' | 'desc'
+
+type UseTableSortOptions<SortKey extends string> = {
+  initialKey: SortKey
+  initialDir?: SortDir
+  /** Default direction when switching to a new sort column. */
+  defaultDirForKey?: (key: SortKey) => SortDir
+}
+
+/**
+ * Shared table sort state and accessible sort-button helpers for dashboard lists.
+ */
+export function useTableSort<SortKey extends string>(options: UseTableSortOptions<SortKey>) {
+  const sortKey = ref(options.initialKey)
+  const sortDir = ref(options.initialDir ?? 'desc')
+
+  function toggleSort(key: SortKey) {
+    if (sortKey.value === key) {
+      sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc'
+      return
+    }
+
+    sortKey.value = key
+    sortDir.value = options.defaultDirForKey?.(key) ?? 'asc'
+  }
+
+  function getSortAria(key: SortKey): 'none' | 'ascending' | 'descending' {
+    if (sortKey.value !== key) return 'none'
+    return sortDir.value === 'asc' ? 'ascending' : 'descending'
+  }
+
+  function getSortButtonLabel(key: SortKey, label: string) {
+    if (sortKey.value !== key) return `Sort by ${label}`
+    const nextDirection = sortDir.value === 'asc' ? 'descending' : 'ascending'
+    return `Sort by ${label} ${nextDirection}`
+  }
+
+  return {
+    sortKey,
+    sortDir,
+    toggleSort,
+    getSortAria,
+    getSortButtonLabel,
+  }
+}

--- a/app/pages/dashboard/applications/index.vue
+++ b/app/pages/dashboard/applications/index.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { FileText, Search, X, Briefcase, Clock, ArrowUp, ArrowDown, ArrowUpDown, SlidersHorizontal, Maximize2, Minimize2, Check } from 'lucide-vue-next'
+import { FileText, Search, Briefcase, Clock, ArrowUp, ArrowDown, ArrowUpDown, Minimize2 } from 'lucide-vue-next'
+import type { SortDir } from '~/composables/useTableSort'
 import {
   formatRelativeTime,
   getApplicationStatusLabel,
   getScoreBadgeClass,
 } from '~/utils/status-display'
+import { getPropertyValue } from '~/utils/property-display'
 
 definePageMeta({
   layout: 'dashboard',
@@ -45,15 +47,15 @@ const router = useRouter()
 
 // ── Search ────────────────────────────────────────────────────────────────────
 
-const searchInput = ref('')
-const debouncedSearch = ref('')
-
-let debounceTimer: ReturnType<typeof setTimeout>
-watch(searchInput, (val) => {
-  clearTimeout(debounceTimer)
-  debounceTimer = setTimeout(() => {
-    debouncedSearch.value = val.trim().toLowerCase()
-  }, 250)
+const {
+  searchInput,
+  debouncedSearch,
+  drawerOpen,
+  isFullscreen,
+} = useDashboardListPage<string>({
+  debounceMs: 250,
+  normalizeSearch: (value) => value.trim().toLowerCase(),
+  initialSearch: '',
 })
 
 // ── Status filter ─────────────────────────────────────────────────────────────
@@ -108,19 +110,12 @@ const uniqueJobs = computed(() => {
 // ── Sorting ───────────────────────────────────────────────────────────────────
 
 type SortKey = 'name' | 'email' | 'job' | 'status' | 'score' | 'created'
-type SortDir = 'asc' | 'desc'
 
-const sortKey = ref<SortKey>('created')
-const sortDir = ref<SortDir>('desc')
-
-function toggleSort(key: SortKey) {
-  if (sortKey.value === key) {
-    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc'
-  } else {
-    sortKey.value = key
-    sortDir.value = key === 'created' || key === 'score' ? 'desc' : 'asc'
-  }
-}
+const { sortKey, sortDir, toggleSort } = useTableSort<SortKey>({
+  initialKey: 'created',
+  initialDir: 'desc',
+  defaultDirForKey: (key) => (key === 'created' || key === 'score' ? 'desc' : 'asc'),
+})
 
 // ── Filtered + sorted list ────────────────────────────────────────────────────
 
@@ -201,8 +196,6 @@ const defaultSettings: ApplicationsViewSettings = {
   visibleColumns: undefined,
 }
 
-const drawerOpen = ref(false)
-const isFullscreen = ref(false)
 const currentSettings = computed<ApplicationsViewSettings>(() => ({
   status: activeStatus.value,
   jobId: activeJobId.value,
@@ -211,15 +204,6 @@ const currentSettings = computed<ApplicationsViewSettings>(() => ({
   sortDir: sortDir.value,
   visibleColumns: { ...visibleColumns.value },
 }))
-
-function handleFullscreenKeydown(event: KeyboardEvent) {
-  if (event.key === 'Escape' && isFullscreen.value) {
-    isFullscreen.value = false
-  }
-}
-
-onMounted(() => window.addEventListener('keydown', handleFullscreenKeydown))
-onUnmounted(() => window.removeEventListener('keydown', handleFullscreenKeydown))
 
 function applySettings(s: ApplicationsViewSettings) {
   activeStatus.value = s.status
@@ -245,11 +229,6 @@ const drawerActiveCount = computed(() =>
   [activeStatus.value, activeJobId.value].filter(Boolean).length + propertyFilters.value.length,
 )
 
-// ── Property value lookup helper ──────────────────────────────────────────────
-function getPropertyValue(entity: { properties?: import('~~/shared/properties').PropertyEntry[] | null }, definitionId: string): unknown {
-  return entity.properties?.find((p) => p.definition.id === definitionId)?.value ?? null
-}
-
 // ── Application detail drawer ─────────────────────────────────────────────────
 const selectedApplicationId = ref<string | null>(null)
 </script>
@@ -266,60 +245,28 @@ const selectedApplicationId = ref<string | null>(null)
       </div>
     </div>
 
-    <!-- Search + Views + Filters -->
-    <div class="flex items-center gap-2 mb-4">
-      <GooeySearchInput
-        v-model="searchInput"
-        aria-label="Search applications"
-        class="min-w-0 flex-1 sm:max-w-sm"
-        placeholder="Search by candidate name, email, or job title…"
-        reserve-expanded-space
-      />
-      <SavedViewsMenu
-        :views="views"
-        :active-view-id="activeViewId"
-        :is-dirty="isDirty"
-        @select="onSelectView"
-        @save="onSaveView"
-        @update="onUpdateView"
-        @delete="deleteView"
-        @set-default="setDefault"
-      />
-      <ColumnsMenu
-        v-model="visibleColumns"
-        :columns="applicationColumns"
-      />
-      <button
-        type="button"
-        class="factory-toolbar-button inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
-        :class="{ 'is-active': drawerActiveCount > 0 }"
-        @click="drawerOpen = true"
-      >
-        <SlidersHorizontal class="size-4" />
-        <span>Filters</span>
-        <span
-          v-if="drawerActiveCount > 0"
-          class="inline-flex items-center justify-center min-w-[1rem] h-4 px-1 rounded-full bg-brand-500 text-white text-[10px] font-semibold"
-        >{{ drawerActiveCount }}</span>
-      </button>
-      <button
-        v-if="hasActiveFilters"
-        class="inline-flex items-center gap-1 text-xs text-surface-400 hover:text-danger-600 transition-colors"
-        @click="clearAllFilters"
-      >
-        <X class="size-3" />
-        Clear
-      </button>
-      <button
-        type="button"
-        class="factory-toolbar-button inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors"
-        :title="isFullscreen ? 'Exit fullscreen' : 'Fullscreen table'"
-        @click="isFullscreen = !isFullscreen"
-      >
-        <Maximize2 v-if="!isFullscreen" class="size-4" />
-        <Minimize2 v-else class="size-4" />
-      </button>
-    </div>
+    <DashboardListToolbar
+      v-model:search-input="searchInput"
+      v-model:visible-columns="visibleColumns"
+      search-aria-label="Search applications"
+      search-placeholder="Search by candidate name, email, or job title…"
+      :views="views"
+      :active-view-id="activeViewId"
+      :is-dirty="isDirty"
+      :columns="applicationColumns"
+      :filter-count="drawerActiveCount"
+      :show-clear="hasActiveFilters"
+      :is-fullscreen="isFullscreen"
+      clear-button-class="inline-flex items-center gap-1 text-xs text-surface-400 hover:text-danger-600 transition-colors"
+      @open-filters="drawerOpen = true"
+      @clear-filters="clearAllFilters"
+      @toggle-fullscreen="isFullscreen = !isFullscreen"
+      @select-view="onSelectView"
+      @save-view="onSaveView"
+      @update-view="onUpdateView"
+      @delete-view="deleteView"
+      @set-default-view="setDefault"
+    />
 
     <!-- Filter drawer -->
     <FilterDrawer

--- a/app/pages/dashboard/candidates/index.vue
+++ b/app/pages/dashboard/candidates/index.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { Users, Plus, Phone, ArrowUp, ArrowDown, ArrowUpDown, SlidersHorizontal, X, StickyNote, Maximize2, Minimize2, Check } from 'lucide-vue-next'
+import { Users, Plus, Phone, ArrowUp, ArrowDown, ArrowUpDown, StickyNote, Minimize2 } from 'lucide-vue-next'
 import { formatPhoneNumber } from '~/utils/phone-format'
+import type { SortDir } from '~/composables/useTableSort'
+import { getPropertyValue } from '~/utils/property-display'
 
 definePageMeta({
   layout: 'dashboard',
@@ -36,34 +38,23 @@ const candidateColumns = computed(() => [
   ...propertyDefs.value.map((d) => ({ key: `prop_${d.id}`, label: d.name })),
 ])
 
-const searchInput = ref('')
-const debouncedSearch = ref<string | undefined>(undefined)
-
-let debounceTimer: ReturnType<typeof setTimeout>
-watch(searchInput, (val) => {
-  clearTimeout(debounceTimer)
-  debounceTimer = setTimeout(() => {
-    debouncedSearch.value = val.trim() || undefined
-  }, 300)
+const {
+  searchInput,
+  debouncedSearch,
+  drawerOpen,
+  isFullscreen,
+} = useDashboardListPage<string | undefined>({
+  debounceMs: 300,
+  normalizeSearch: (value) => value.trim() || undefined,
+  initialSearch: undefined,
 })
 
 // ── Filters ───────────────────────────────────────────────────────────────────
 
-const drawerOpen = ref(false)
-const isFullscreen = ref(false)
 const filterGender = ref<string | undefined>(undefined)
 const filterDobFrom = ref<string | undefined>(undefined)
 const filterDobTo = ref<string | undefined>(undefined)
 const propertyFilters = ref<import('~~/shared/properties').PropertyFilter[]>([])
-
-function handleFullscreenKeydown(event: KeyboardEvent) {
-  if (event.key === 'Escape' && isFullscreen.value) {
-    isFullscreen.value = false
-  }
-}
-
-onMounted(() => window.addEventListener('keydown', handleFullscreenKeydown))
-onUnmounted(() => window.removeEventListener('keydown', handleFullscreenKeydown))
 
 const activeFilterCount = computed(() =>
   [filterGender.value, filterDobFrom.value, filterDobTo.value].filter(Boolean).length
@@ -91,30 +82,18 @@ const { formatCandidateName, formatDateTime } = useOrgSettings()
 // ── Sorting ───────────────────────────────────────────────────────────────────
 
 type SortKey = 'name' | 'email' | 'phone' | 'applications' | 'created'
-type SortDir = 'asc' | 'desc'
 
-const sortKey = ref<SortKey>('created')
-const sortDir = ref<SortDir>('desc')
-
-function toggleSort(key: SortKey) {
-  if (sortKey.value === key) {
-    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc'
-  } else {
-    sortKey.value = key
-    sortDir.value = key === 'created' || key === 'applications' ? 'desc' : 'asc'
-  }
-}
-
-function getSortAria(key: SortKey) {
-  if (sortKey.value !== key) return 'none'
-  return sortDir.value === 'asc' ? 'ascending' : 'descending'
-}
-
-function getSortButtonLabel(key: SortKey, label: string) {
-  if (sortKey.value !== key) return `Sort by ${label}`
-  const nextDirection = sortDir.value === 'asc' ? 'descending' : 'ascending'
-  return `Sort by ${label} ${nextDirection}`
-}
+const {
+  sortKey,
+  sortDir,
+  toggleSort,
+  getSortAria,
+  getSortButtonLabel,
+} = useTableSort<SortKey>({
+  initialKey: 'created',
+  initialDir: 'desc',
+  defaultDirForKey: (key) => (key === 'created' || key === 'applications' ? 'desc' : 'asc'),
+})
 
 const sortedCandidates = computed(() => {
   const list = [...candidates.value]
@@ -167,12 +146,6 @@ async function saveNotes(candidateId: string) {
 
 function cancelEditNotes() {
   editingNotesId.value = null
-}
-
-// ── Property value lookup helper ──────────────────────────────────────────────
-// Avoids `as any` in the template and is null-safe.
-function getPropertyValue(entity: { properties?: import('~~/shared/properties').PropertyEntry[] | null }, definitionId: string): unknown {
-  return entity.properties?.find((p) => p.definition.id === definitionId)?.value ?? null
 }
 
 // ── Saved Views ──────────────────────────────────────────────────────────────────
@@ -251,60 +224,27 @@ const selectedCandidateId = ref<string | null>(null)
       </NuxtLink>
     </div>
 
-    <!-- Search + Views + Filters -->
-    <div class="flex items-center gap-2 mb-4">
-      <GooeySearchInput
-        v-model="searchInput"
-        aria-label="Search candidates"
-        class="min-w-0 flex-1 sm:max-w-sm"
-        placeholder="Search by name or email…"
-        reserve-expanded-space
-      />
-      <SavedViewsMenu
-        :views="views"
-        :active-view-id="activeViewId"
-        :is-dirty="isDirty"
-        @select="onSelectView"
-        @save="onSaveView"
-        @update="onUpdateView"
-        @delete="deleteView"
-        @set-default="setDefault"
-      />
-      <ColumnsMenu
-        v-model="visibleColumns"
-        :columns="candidateColumns"
-      />
-      <button
-        type="button"
-        class="factory-toolbar-button inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
-        :class="{ 'is-active': activeFilterCount > 0 }"
-        @click="drawerOpen = true"
-      >
-        <SlidersHorizontal class="size-4" />
-        <span>Filters</span>
-        <span
-          v-if="activeFilterCount > 0"
-          class="inline-flex items-center justify-center min-w-[1rem] h-4 px-1 rounded-full bg-brand-500 text-white text-[10px] font-semibold"
-        >{{ activeFilterCount }}</span>
-      </button>
-      <button
-        v-if="activeFilterCount > 0"
-        class="inline-flex items-center gap-1 text-xs text-white/60 hover:text-danger-600 transition-colors"
-        @click="clearFilters"
-      >
-        <X class="size-3" />
-        Clear
-      </button>
-      <button
-        type="button"
-        class="factory-toolbar-button inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors"
-        :title="isFullscreen ? 'Exit fullscreen' : 'Fullscreen table'"
-        @click="isFullscreen = !isFullscreen"
-      >
-        <Maximize2 v-if="!isFullscreen" class="size-4" />
-        <Minimize2 v-else class="size-4" />
-      </button>
-    </div>
+    <DashboardListToolbar
+      v-model:search-input="searchInput"
+      v-model:visible-columns="visibleColumns"
+      search-aria-label="Search candidates"
+      search-placeholder="Search by name or email…"
+      :views="views"
+      :active-view-id="activeViewId"
+      :is-dirty="isDirty"
+      :columns="candidateColumns"
+      :filter-count="activeFilterCount"
+      :show-clear="activeFilterCount > 0"
+      :is-fullscreen="isFullscreen"
+      @open-filters="drawerOpen = true"
+      @clear-filters="clearFilters"
+      @toggle-fullscreen="isFullscreen = !isFullscreen"
+      @select-view="onSelectView"
+      @save-view="onSaveView"
+      @update-view="onUpdateView"
+      @delete-view="deleteView"
+      @set-default-view="setDefault"
+    />
 
     <!-- Filter drawer -->
     <FilterDrawer

--- a/app/utils/property-display.ts
+++ b/app/utils/property-display.ts
@@ -1,0 +1,13 @@
+import type { PropertyEntry } from '~~/shared/properties'
+
+type EntityWithProperties = {
+  properties?: PropertyEntry[] | null
+}
+
+/** Read a custom property value from a list/detail entity payload. */
+export function getPropertyValue(
+  entity: EntityWithProperties,
+  definitionId: string,
+): unknown {
+  return entity.properties?.find((p) => p.definition.id === definitionId)?.value ?? null
+}

--- a/tests/unit/dashboard-list-epic3.test.ts
+++ b/tests/unit/dashboard-list-epic3.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { getPropertyValue } from '../../app/utils/property-display'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('dashboard list epic 3 helpers', () => {
+  it('reads property values from entity payloads', () => {
+    expect(getPropertyValue({
+      properties: [
+        { definition: { id: 'prop_1' } as never, value: 'Senior' },
+      ],
+    }, 'prop_1')).toBe('Senior')
+
+    expect(getPropertyValue({ properties: [] }, 'prop_1')).toBeNull()
+  })
+
+  it('keeps table sort helpers accessible and aria-aware', () => {
+    const sortHelper = readProjectFile('app/composables/useTableSort.ts')
+
+    for (const snippet of [
+      'export function useTableSort',
+      'toggleSort',
+      'getSortAria',
+      'getSortButtonLabel',
+      "? 'ascending' : 'descending'",
+    ]) {
+      expect(sortHelper, snippet).toContain(snippet)
+    }
+  })
+
+  it('routes candidates and applications list pages through shared epic 3 primitives', () => {
+    const candidates = readProjectFile('app/pages/dashboard/candidates/index.vue')
+    const applications = readProjectFile('app/pages/dashboard/applications/index.vue')
+
+    for (const source of [candidates, applications]) {
+      expect(source).toContain('<DashboardListToolbar')
+      expect(source).toContain('useDashboardListPage')
+      expect(source).toContain('useTableSort')
+      expect(source).toContain("from '~/utils/property-display'")
+      expect(source).not.toContain('let debounceTimer')
+      expect(source).not.toContain('function getPropertyValue(')
+    }
+  })
+
+  it('keeps shared toolbar and composable implementations grounded in repo files', () => {
+    const toolbar = readProjectFile('app/components/DashboardListToolbar.vue')
+    const listPage = readProjectFile('app/composables/useDashboardListPage.ts')
+    const debounced = readProjectFile('app/composables/useDebouncedRef.ts')
+
+    expect(toolbar).toContain('<GooeySearchInput')
+    expect(toolbar).toContain('<SavedViewsMenu')
+    expect(toolbar).toContain('<ColumnsMenu')
+    expect(listPage).toContain('useDebouncedRef')
+    expect(listPage).toContain("event.key === 'Escape'")
+    expect(debounced).toContain('onScopeDispose')
+  })
+})

--- a/tests/unit/gooey-search-input.test.ts
+++ b/tests/unit/gooey-search-input.test.ts
@@ -86,8 +86,6 @@ describe('search bar call sites', () => {
     'app/pages/jobs/index.vue',
     'app/pages/dashboard/jobs/index.vue',
     'app/pages/dashboard/jobs/[id]/index.vue',
-    'app/pages/dashboard/candidates/index.vue',
-    'app/pages/dashboard/applications/index.vue',
     'app/pages/dashboard/interviews/index.vue',
     'app/pages/dashboard/timeline.vue',
     'app/pages/dashboard/settings/members.vue',
@@ -108,8 +106,6 @@ describe('search bar call sites', () => {
   it('keeps dashboard toolbar search inputs bounded so sibling controls stay visible', () => {
     const dashboardToolbarSearches = [
       'app/pages/dashboard/jobs/index.vue',
-      'app/pages/dashboard/candidates/index.vue',
-      'app/pages/dashboard/applications/index.vue',
       'app/pages/dashboard/interviews/index.vue',
       'app/pages/dashboard/timeline.vue',
     ]
@@ -117,6 +113,17 @@ describe('search bar call sites', () => {
     for (const relativePath of dashboardToolbarSearches) {
       const source = readFileSync(join(process.cwd(), relativePath), 'utf8')
       expect(source, relativePath).toMatch(/<GooeySearchInput[\s\S]*class="[^"]*min-w-0[^"]*flex-1[^"]*sm:max-w-sm/)
+    }
+
+    const sharedToolbar = readFileSync(join(process.cwd(), 'app/components/DashboardListToolbar.vue'), 'utf8')
+    expect(sharedToolbar).toMatch(/<GooeySearchInput[\s\S]*class="[^"]*min-w-0[^"]*flex-1[^"]*sm:max-w-sm/)
+
+    for (const relativePath of [
+      'app/pages/dashboard/candidates/index.vue',
+      'app/pages/dashboard/applications/index.vue',
+    ]) {
+      const source = readFileSync(join(process.cwd(), relativePath), 'utf8')
+      expect(source, relativePath).toContain('<DashboardListToolbar')
     }
   })
 

--- a/tests/unit/job-subnav-actions.test.ts
+++ b/tests/unit/job-subnav-actions.test.ts
@@ -22,6 +22,8 @@ describe('job subnav actions', () => {
     const jobDetail = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
 
     expect(toolbar).toContain('factory-toolbar-button inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors')
+    expect(toolbar).toContain(":title=\"isFullscreen ? 'Exit fullscreen' : 'Fullscreen table'\"")
+    expect(toolbar).toContain(":aria-label=\"isFullscreen ? 'Exit fullscreen' : 'Fullscreen table'\"")
     expect(jobDetail).toContain('factory-pipeline-fullscreen-button factory-toolbar-button ml-auto inline-flex h-8 min-h-8 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg border px-2 py-0 text-sm font-medium transition-colors')
     expect(jobDetail).toContain(":title=\"isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'\"")
     expect(jobDetail).toContain(":aria-label=\"isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'\"")

--- a/tests/unit/job-subnav-actions.test.ts
+++ b/tests/unit/job-subnav-actions.test.ts
@@ -18,10 +18,10 @@ describe('job subnav actions', () => {
   })
 
   it('uses the applications toolbar button recipe for the pipeline fullscreen control', () => {
-    const applications = readProjectFile('app/pages/dashboard/applications/index.vue')
+    const toolbar = readProjectFile('app/components/DashboardListToolbar.vue')
     const jobDetail = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
 
-    expect(applications).toContain('factory-toolbar-button inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors')
+    expect(toolbar).toContain('factory-toolbar-button inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors')
     expect(jobDetail).toContain('factory-pipeline-fullscreen-button factory-toolbar-button ml-auto inline-flex h-8 min-h-8 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg border px-2 py-0 text-sm font-medium transition-colors')
     expect(jobDetail).toContain(":title=\"isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'\"")
     expect(jobDetail).toContain(":aria-label=\"isFullscreen ? 'Exit fullscreen' : 'Fullscreen pipeline'\"")

--- a/tests/unit/table-fullscreen-mode.test.ts
+++ b/tests/unit/table-fullscreen-mode.test.ts
@@ -7,17 +7,24 @@ function readProjectFile(path: string) {
 }
 
 describe('table fullscreen mode', () => {
+  it('useDashboardListPage exits fullscreen on Escape', () => {
+    const helper = readProjectFile('app/composables/useDashboardListPage.ts')
+
+    expect(helper).toContain("event.key === 'Escape' && isFullscreen.value")
+    expect(helper).toContain('window.addEventListener')
+    expect(helper).toContain('window.removeEventListener')
+  })
+
   for (const path of [
     'app/pages/dashboard/candidates/index.vue',
     'app/pages/dashboard/applications/index.vue',
   ]) {
-    it(`${path} uses an opaque fullscreen surface and exits on Escape`, () => {
+    it(`${path} uses an opaque fullscreen surface and shared list page state`, () => {
       const source = readProjectFile(path)
 
       expect(source).toContain('factory-fullscreen-surface')
-      expect(source).toContain("event.key === 'Escape' && isFullscreen.value")
-      expect(source).toContain('window.addEventListener')
-      expect(source).toContain('window.removeEventListener')
+      expect(source).toContain('useDashboardListPage')
+      expect(source).toContain('isFullscreen')
     })
   }
 


### PR DESCRIPTION
## Summary

Epic 3 (#248) from the DRY cleanup plan (#255).

**New shared primitives:**
- `useDebouncedRef` — debounced string-to-value search normalization
- `useTableSort` — sort state + accessible aria helpers
- `useDashboardListPage` — search, filter drawer, fullscreen + Escape exit
- `getPropertyValue` in `app/utils/property-display.ts`
- `DashboardListToolbar` — search, saved views, columns, filters, clear, fullscreen

**Migrations:**
- `app/pages/dashboard/candidates/index.vue`
- `app/pages/dashboard/applications/index.vue`

Preserves page-specific search normalization (candidates: trim/undefined @ 300ms; applications: lowercase @ 250ms), sort defaults, and toolbar styling.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:unit` (945 tests)
- [x] `npm run build` (via pre-push preflight)
- [ ] Browser QA: candidates + applications list search, sort, filters, saved views, fullscreen

Closes #221, #222, #223. Closes #248.