### PR TITLE
refactor: Epic 9 CLI command registration factory (comments)

### DIFF
--- a/packages/careers-cli/src/cliRuntime.ts
+++ b/packages/careers-cli/src/cliRuntime.ts
@@ -1,0 +1,185 @@
+import type { Command } from 'commander'
+import type { FetchLike } from './api'
+import { resolveActiveProfile, resolveConfigPath } from './config'
+
+export type CliIo = {
+  stdout?: (value: string) => void
+  stderr?: (value: string) => void
+  fetch?: FetchLike
+  sleep?: (ms: number) => Promise<void>
+  stdin?: () => Promise<string>
+}
+
+export type GlobalOptions = {
+  config?: string
+  profile?: string
+  baseUrl?: string
+  json?: boolean
+  yes?: boolean
+  noInput?: boolean
+}
+
+export type StdinOptions = GlobalOptions & {
+  stdin?: boolean
+}
+
+export type CliPayloadSchema = {
+  parse: (value: unknown) => unknown
+}
+
+export function writeJson(io: CliIo, value: unknown): void {
+  io.stdout?.(JSON.stringify(value))
+}
+
+export function getFetch(io: CliIo): FetchLike {
+  return io.fetch ?? fetch
+}
+
+export function getSleep(io: CliIo): (ms: number) => Promise<void> {
+  return io.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
+}
+
+function getGlobalOptions(command: Command): GlobalOptions {
+  return command.optsWithGlobals<GlobalOptions>()
+}
+
+export function getContext(command: Command, options: GlobalOptions) {
+  const globals = { ...getGlobalOptions(command), ...options }
+  const configPath = resolveConfigPath({ explicitConfig: globals.config })
+  const profile = resolveActiveProfile({
+    configPath,
+    profile: globals.profile,
+    baseUrl: globals.baseUrl,
+  })
+
+  return { globals, configPath, profile }
+}
+
+export function requireAuthenticatedProfile(profile: { token?: string }): string {
+  if (!profile.token) {
+    throw {
+      status: 401,
+      code: 'NOT_AUTHENTICATED',
+      message: 'Run factory-careers auth login first.',
+    }
+  }
+
+  return profile.token
+}
+
+export function requireMutationConfirmation(options: GlobalOptions): void {
+  if (options.yes) return
+  if ((options as GlobalOptions & { stdin?: boolean }).stdin) return
+
+  throw {
+    status: 400,
+    code: 'CONFIRMATION_REQUIRED',
+    message: 'Pass --yes to confirm this mutating command.',
+  }
+}
+
+export async function readStdinJson(io: CliIo, enabled?: boolean): Promise<unknown> {
+  if (!enabled) return undefined
+  const input = io.stdin ? await io.stdin() : await new Promise<string>((resolve, reject) => {
+    let data = ''
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', (chunk) => {
+      data += chunk
+    })
+    process.stdin.on('end', () => resolve(data))
+    process.stdin.on('error', reject)
+  })
+
+  try {
+    return JSON.parse(input)
+  } catch {
+    throw {
+      status: 400,
+      code: 'INVALID_STDIN_JSON',
+      message: 'Expected valid JSON on stdin.',
+    }
+  }
+}
+
+export function validateStdinPayload(schema: CliPayloadSchema, body: unknown): unknown {
+  if (body === undefined) {
+    throw {
+      status: 400,
+      code: 'MISSING_STDIN_PAYLOAD',
+      message: 'Pass --stdin and pipe a JSON request body for this command.',
+    }
+  }
+
+  try {
+    return schema.parse(body)
+  } catch (error) {
+    const details = error && typeof error === 'object' && 'issues' in error
+      ? (error as { issues: unknown }).issues
+      : undefined
+    throw {
+      status: 400,
+      code: 'INVALID_STDIN_PAYLOAD',
+      message: 'Stdin JSON did not match the CLI command schema.',
+      details,
+    }
+  }
+}
+
+export function outputResult(io: CliIo, globals: GlobalOptions, value: unknown): void {
+  if (globals.json) {
+    writeJson(io, value)
+  } else if (typeof value === 'string') {
+    io.stdout?.(value)
+  } else {
+    io.stdout?.(JSON.stringify(value, null, 2))
+  }
+}
+
+export function appendQuery(baseUrl: string, query: Record<string, string | boolean | undefined>): string {
+  const url = new URL(baseUrl)
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === false) continue
+    url.searchParams.set(key, value === true ? '1' : value)
+  }
+  return url.toString()
+}
+
+export function requireOption(value: string | undefined, name: string): string {
+  if (value) return value
+
+  throw {
+    status: 400,
+    code: 'MISSING_REQUIRED_OPTION',
+    message: `Missing required option ${name}.`,
+  }
+}
+
+export function addGlobalOptions(command: Command): Command {
+  return command
+    .option('--config <path>', 'Path to Factory Careers CLI config file')
+    .option('--profile <name>', 'Config profile to use')
+    .option('--base-url <url>', 'Factory Careers base URL')
+    .option('--json', 'Emit machine-readable JSON')
+    .option('--yes', 'Confirm mutating operations without prompting')
+    .option('--no-input', 'Disable interactive prompts')
+}
+
+export type CliRuntime = ReturnType<typeof createCliRuntime>
+
+export function createCliRuntime(io: CliIo) {
+  return {
+    io,
+    writeJson,
+    getFetch,
+    getSleep,
+    getContext,
+    requireAuthenticatedProfile,
+    requireMutationConfirmation,
+    readStdinJson,
+    validateStdinPayload,
+    outputResult,
+    appendQuery,
+    requireOption,
+    addGlobalOptions,
+  }
+}

--- a/packages/careers-cli/src/commandFactories.ts
+++ b/packages/careers-cli/src/commandFactories.ts
@@ -1,0 +1,187 @@
+import type { Command } from 'commander'
+import { writeFileSync } from 'node:fs'
+import { requestBinary, requestJson } from './api'
+import type { CliRuntime, GlobalOptions } from './cliRuntime'
+
+type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
+
+type JsonCommandArg = {
+  name: string
+  description: string
+}
+
+type JsonCommandOption = {
+  flags: string
+  description: string
+  required?: boolean
+}
+
+type RequiredOptionSpec = {
+  key: string
+  flagName: string
+}
+
+type JsonCommandContext = {
+  args: string[]
+  options: Record<string, unknown>
+  globals: GlobalOptions
+}
+
+export type RegisterJsonCommandConfig = {
+  name: string
+  description: string
+  method: HttpMethod
+  path: string | ((...args: string[]) => string)
+  args?: JsonCommandArg[]
+  options?: JsonCommandOption[]
+  mutation?: boolean
+  stdin?: boolean
+  schema?: { parse: (value: unknown) => unknown }
+  requireAuth?: boolean
+  requireOptions?: RequiredOptionSpec[]
+  query?: (options: Record<string, unknown>) => Record<string, string | boolean | undefined>
+  deleteAck?: boolean
+  formatResult?: (context: JsonCommandContext & { result: unknown }) => unknown
+}
+
+export type RegisterBinaryDownloadConfig = {
+  name: string
+  description: string
+  arg: JsonCommandArg
+  outputOption: {
+    flags: string
+    description: string
+  }
+  path: string | ((id: string) => string)
+  formatResult?: (context: {
+    id: string
+    outputPath: string
+    bytes: number
+    contentType?: string
+  }) => unknown
+}
+
+function resolvePath(path: string | ((...args: string[]) => string), args: string[]): string {
+  return typeof path === 'function' ? path(...args) : path
+}
+
+export function registerJsonCommand(
+  runtime: CliRuntime,
+  parent: Command,
+  config: RegisterJsonCommandConfig,
+): Command {
+  let command = parent.command(config.name).description(config.description)
+
+  for (const arg of config.args ?? []) {
+    command = command.argument(`<${arg.name}>`, arg.description)
+  }
+
+  for (const option of config.options ?? []) {
+    command = option.required
+      ? command.requiredOption(option.flags, option.description)
+      : command.option(option.flags, option.description)
+  }
+
+  if (config.stdin) {
+    command = command.option('--stdin', 'Read request body as JSON from stdin')
+  }
+
+  return runtime.addGlobalOptions(command).action(async (...params: unknown[]) => {
+    const commandInstance = params.at(-1) as Command
+    const options = params.at(-2) as Record<string, unknown>
+    const args = params.slice(0, -2) as string[]
+    const { globals, profile } = runtime.getContext(commandInstance, options as GlobalOptions)
+
+    if (config.mutation) {
+      runtime.requireMutationConfirmation(globals)
+    }
+
+    const token = config.requireAuth === false
+      ? undefined
+      : runtime.requireAuthenticatedProfile(profile)
+
+    for (const requiredOption of config.requireOptions ?? []) {
+      runtime.requireOption(options[requiredOption.key] as string | undefined, requiredOption.flagName)
+    }
+
+    const apiPath = resolvePath(config.path, args)
+    let url = `${profile.baseUrl}${apiPath}`
+    if (config.query) {
+      url = runtime.appendQuery(url, config.query(options))
+    }
+
+    let body: unknown
+    if (config.stdin) {
+      body = await runtime.readStdinJson(runtime.io, options.stdin as boolean | undefined)
+      if (config.schema) {
+        body = runtime.validateStdinPayload(config.schema, body)
+      }
+    }
+
+    const apiResult = await requestJson<unknown>({
+      fetch: runtime.getFetch(runtime.io),
+      url,
+      method: config.method,
+      token,
+      body,
+    })
+
+    const context: JsonCommandContext & { result: unknown } = {
+      args,
+      options,
+      globals,
+      result: apiResult,
+    }
+
+    let result: unknown = apiResult
+    if (config.formatResult) {
+      result = config.formatResult(context)
+    } else if (config.deleteAck && config.method === 'DELETE') {
+      result = { deleted: true, id: args[0] }
+    }
+
+    runtime.outputResult(runtime.io, globals, result)
+  })
+}
+
+export function registerBinaryDownload(
+  runtime: CliRuntime,
+  parent: Command,
+  config: RegisterBinaryDownloadConfig,
+): Command {
+  const command = parent
+    .command(config.name)
+    .description(config.description)
+    .argument(`<${config.arg.name}>`, config.arg.description)
+    .requiredOption(config.outputOption.flags, config.outputOption.description)
+
+  return runtime.addGlobalOptions(command).action(async (id: string, options: Record<string, unknown>, commandInstance: Command) => {
+    const { globals, profile } = runtime.getContext(commandInstance, options as GlobalOptions)
+    const token = runtime.requireAuthenticatedProfile(profile)
+    const outputPath = runtime.requireOption(options.output as string | undefined, config.outputOption.flags.split(' ')[0] ?? '--output')
+    const apiPath = resolvePath(config.path, [id])
+    const result = await requestBinary({
+      fetch: runtime.getFetch(runtime.io),
+      url: `${profile.baseUrl}${apiPath}`,
+      token,
+    })
+
+    writeFileSync(outputPath, result.bytes)
+
+    const payload = config.formatResult
+      ? config.formatResult({
+          id,
+          outputPath,
+          bytes: result.bytes.byteLength,
+          contentType: result.contentType,
+        })
+      : {
+          id,
+          output: outputPath,
+          bytes: result.bytes.byteLength,
+          contentType: result.contentType,
+        }
+
+    runtime.outputResult(runtime.io, globals, payload)
+  })
+}

--- a/packages/careers-cli/src/commands/comments.ts
+++ b/packages/careers-cli/src/commands/comments.ts
@@ -1,0 +1,63 @@
+import type { Command } from 'commander'
+import { registerJsonCommand } from '../commandFactories'
+import type { CliRuntime } from '../cliRuntime'
+
+export function registerCommentsCommands(program: Command, runtime: CliRuntime): Command {
+  const comments = program
+    .command('comments')
+    .description('Manage comments')
+
+  registerJsonCommand(runtime, comments, {
+    name: 'list',
+    description: 'List comments for a target',
+    method: 'GET',
+    path: '/api/comments',
+    options: [
+      { flags: '--target-type <type>', description: 'Target type: candidate, application, or job', required: true },
+      { flags: '--target-id <id>', description: 'Target ID', required: true },
+      { flags: '--page <number>', description: 'Page number' },
+      { flags: '--limit <number>', description: 'Page size' },
+    ],
+    requireOptions: [
+      { key: 'targetType', flagName: '--target-type' },
+      { key: 'targetId', flagName: '--target-id' },
+    ],
+    query: (options) => ({
+      targetType: options.targetType as string,
+      targetId: options.targetId as string,
+      page: options.page as string | undefined,
+      limit: options.limit as string | undefined,
+    }),
+  })
+
+  registerJsonCommand(runtime, comments, {
+    name: 'create',
+    description: 'Create a comment',
+    method: 'POST',
+    path: '/api/comments',
+    mutation: true,
+    stdin: true,
+  })
+
+  registerJsonCommand(runtime, comments, {
+    name: 'update',
+    description: 'Update a comment',
+    method: 'PATCH',
+    path: (id) => `/api/comments/${encodeURIComponent(id)}`,
+    args: [{ name: 'id', description: 'Comment ID' }],
+    mutation: true,
+    stdin: true,
+  })
+
+  registerJsonCommand(runtime, comments, {
+    name: 'delete',
+    description: 'Delete a comment',
+    method: 'DELETE',
+    path: (id) => `/api/comments/${encodeURIComponent(id)}`,
+    args: [{ name: 'id', description: 'Comment ID' }],
+    mutation: true,
+    deleteAck: true,
+  })
+
+  return comments
+}

--- a/packages/careers-cli/src/program.ts
+++ b/packages/careers-cli/src/program.ts
@@ -1,8 +1,27 @@
 import { Command } from 'commander'
 import { basename } from 'node:path'
 import { readFileSync, writeFileSync } from 'node:fs'
-import { requestBinary, requestFormJson, requestJson, requestText, type FetchLike } from './api'
-import { removeProfileToken, resolveActiveProfile, resolveConfigPath, saveProfile } from './config'
+import { requestBinary, requestFormJson, requestJson, requestText } from './api'
+import {
+  addGlobalOptions,
+  appendQuery,
+  createCliRuntime,
+  getContext,
+  getFetch,
+  getSleep,
+  outputResult,
+  readStdinJson,
+  requireAuthenticatedProfile,
+  requireMutationConfirmation,
+  requireOption,
+  validateStdinPayload,
+  writeJson,
+  type CliIo,
+  type GlobalOptions,
+  type StdinOptions,
+} from './cliRuntime'
+import { registerCommentsCommands } from './commands/comments'
+import { removeProfileToken, saveProfile } from './config'
 import { normalizeCliError } from './errors'
 import {
   cliApplicationCreateSchema,
@@ -10,27 +29,6 @@ import {
   cliInterviewScheduleSchema,
   cliJobCreateSchema,
 } from './schemas'
-
-type CliIo = {
-  stdout?: (value: string) => void
-  stderr?: (value: string) => void
-  fetch?: FetchLike
-  sleep?: (ms: number) => Promise<void>
-  stdin?: () => Promise<string>
-}
-
-type GlobalOptions = {
-  config?: string
-  profile?: string
-  baseUrl?: string
-  json?: boolean
-  yes?: boolean
-  noInput?: boolean
-}
-
-type StdinOptions = GlobalOptions & {
-  stdin?: boolean
-}
 
 type PropertyListOptions = GlobalOptions & {
   entityType?: string
@@ -45,13 +43,6 @@ type DocumentUploadOptions = GlobalOptions & {
 
 type DocumentDownloadOptions = GlobalOptions & {
   output?: string
-}
-
-type CommentListOptions = GlobalOptions & {
-  targetType?: string
-  targetId?: string
-  page?: string
-  limit?: string
 }
 
 type SourceTrackingListOptions = GlobalOptions & {
@@ -142,133 +133,6 @@ type CandidateDocumentsResponse = {
   documents?: unknown[]
 }
 
-type CliPayloadSchema = {
-  parse: (value: unknown) => unknown
-}
-
-function writeJson(io: CliIo, value: unknown): void {
-  io.stdout?.(JSON.stringify(value))
-}
-
-function getFetch(io: CliIo): FetchLike {
-  return io.fetch ?? fetch
-}
-
-function getSleep(io: CliIo): (ms: number) => Promise<void> {
-  return io.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
-}
-
-function getContext(command: Command, options: GlobalOptions) {
-  const globals = { ...getGlobalOptions(command), ...options }
-  const configPath = resolveConfigPath({ explicitConfig: globals.config })
-  const profile = resolveActiveProfile({
-    configPath,
-    profile: globals.profile,
-    baseUrl: globals.baseUrl,
-  })
-
-  return { globals, configPath, profile }
-}
-
-function requireAuthenticatedProfile(profile: { token?: string }): string {
-  if (!profile.token) {
-    throw {
-      status: 401,
-      code: 'NOT_AUTHENTICATED',
-      message: 'Run factory-careers auth login first.',
-    }
-  }
-
-  return profile.token
-}
-
-function requireMutationConfirmation(options: GlobalOptions): void {
-  if (options.yes) return
-  if ((options as GlobalOptions & { stdin?: boolean }).stdin) return
-
-  throw {
-    status: 400,
-    code: 'CONFIRMATION_REQUIRED',
-    message: 'Pass --yes to confirm this mutating command.',
-  }
-}
-
-async function readStdinJson(io: CliIo, enabled?: boolean): Promise<unknown> {
-  if (!enabled) return undefined
-  const input = io.stdin ? await io.stdin() : await new Promise<string>((resolve, reject) => {
-    let data = ''
-    process.stdin.setEncoding('utf8')
-    process.stdin.on('data', (chunk) => {
-      data += chunk
-    })
-    process.stdin.on('end', () => resolve(data))
-    process.stdin.on('error', reject)
-  })
-
-  try {
-    return JSON.parse(input)
-  } catch {
-    throw {
-      status: 400,
-      code: 'INVALID_STDIN_JSON',
-      message: 'Expected valid JSON on stdin.',
-    }
-  }
-}
-
-function validateStdinPayload(schema: CliPayloadSchema, body: unknown): unknown {
-  if (body === undefined) {
-    throw {
-      status: 400,
-      code: 'MISSING_STDIN_PAYLOAD',
-      message: 'Pass --stdin and pipe a JSON request body for this command.',
-    }
-  }
-
-  try {
-    return schema.parse(body)
-  } catch (error) {
-    const details = error && typeof error === 'object' && 'issues' in error
-      ? (error as { issues: unknown }).issues
-      : undefined
-    throw {
-      status: 400,
-      code: 'INVALID_STDIN_PAYLOAD',
-      message: 'Stdin JSON did not match the CLI command schema.',
-      details,
-    }
-  }
-}
-
-function outputResult(io: CliIo, globals: GlobalOptions, value: unknown): void {
-  if (globals.json) {
-    writeJson(io, value)
-  } else if (typeof value === 'string') {
-    io.stdout?.(value)
-  } else {
-    io.stdout?.(JSON.stringify(value, null, 2))
-  }
-}
-
-function appendQuery(baseUrl: string, query: Record<string, string | boolean | undefined>): string {
-  const url = new URL(baseUrl)
-  for (const [key, value] of Object.entries(query)) {
-    if (value === undefined || value === false) continue
-    url.searchParams.set(key, value === true ? '1' : value)
-  }
-  return url.toString()
-}
-
-function requireOption(value: string | undefined, name: string): string {
-  if (value) return value
-
-  throw {
-    status: 400,
-    code: 'MISSING_REQUIRED_OPTION',
-    message: `Missing required option ${name}.`,
-  }
-}
-
 function parseChatbotStream(value: string): { events: unknown[], text: string } {
   const events: unknown[] = []
   let text = ''
@@ -297,21 +161,8 @@ function parseChatbotStream(value: string): { events: unknown[], text: string } 
   return { events, text }
 }
 
-function getGlobalOptions(command: Command): GlobalOptions {
-  return command.optsWithGlobals<GlobalOptions>()
-}
-
-function addGlobalOptions(command: Command): Command {
-  return command
-    .option('--config <path>', 'Path to Factory Careers CLI config file')
-    .option('--profile <name>', 'Config profile to use')
-    .option('--base-url <url>', 'Factory Careers base URL')
-    .option('--json', 'Emit machine-readable JSON')
-    .option('--yes', 'Confirm mutating operations without prompting')
-    .option('--no-input', 'Disable interactive prompts')
-}
-
 export function createProgram(io: CliIo = {}): Command {
+  const runtime = createCliRuntime(io)
   const program = addGlobalOptions(new Command())
     .name('factory-careers')
     .description('Authenticated CLI for Factory Careers')
@@ -1112,99 +963,7 @@ export function createProgram(io: CliIo = {}): Command {
     outputResult(io, globals, result)
   })
 
-  const comments = program
-    .command('comments')
-    .description('Manage comments')
-
-  addGlobalOptions(
-    comments
-      .command('list')
-      .description('List comments for a target')
-      .requiredOption('--target-type <type>', 'Target type: candidate, application, or job')
-      .requiredOption('--target-id <id>', 'Target ID')
-      .option('--page <number>', 'Page number')
-      .option('--limit <number>', 'Page size'),
-  ).action(async (options: CommentListOptions, command: Command) => {
-    const { globals, profile } = getContext(command, options)
-    const token = requireAuthenticatedProfile(profile)
-    const targetType = requireOption(options.targetType, '--target-type')
-    const targetId = requireOption(options.targetId, '--target-id')
-    const result = await requestJson<unknown>({
-      fetch: getFetch(io),
-      url: appendQuery(`${profile.baseUrl}/api/comments`, {
-        targetType,
-        targetId,
-        page: options.page,
-        limit: options.limit,
-      }),
-      method: 'GET',
-      token,
-    })
-
-    outputResult(io, globals, result)
-  })
-
-  addGlobalOptions(
-    comments
-      .command('create')
-      .description('Create a comment')
-      .option('--stdin', 'Read request body as JSON from stdin'),
-  ).action(async (options: StdinOptions, command: Command) => {
-    const { globals, profile } = getContext(command, options)
-    requireMutationConfirmation(globals)
-    const token = requireAuthenticatedProfile(profile)
-    const body = await readStdinJson(io, options.stdin)
-    const result = await requestJson<unknown>({
-      fetch: getFetch(io),
-      url: `${profile.baseUrl}/api/comments`,
-      method: 'POST',
-      token,
-      body,
-    })
-
-    outputResult(io, globals, result)
-  })
-
-  addGlobalOptions(
-    comments
-      .command('update')
-      .description('Update a comment')
-      .argument('<id>', 'Comment ID')
-      .option('--stdin', 'Read request body as JSON from stdin'),
-  ).action(async (id: string, options: StdinOptions, command: Command) => {
-    const { globals, profile } = getContext(command, options)
-    requireMutationConfirmation(globals)
-    const token = requireAuthenticatedProfile(profile)
-    const body = await readStdinJson(io, options.stdin)
-    const result = await requestJson<unknown>({
-      fetch: getFetch(io),
-      url: `${profile.baseUrl}/api/comments/${encodeURIComponent(id)}`,
-      method: 'PATCH',
-      token,
-      body,
-    })
-
-    outputResult(io, globals, result)
-  })
-
-  addGlobalOptions(
-    comments
-      .command('delete')
-      .description('Delete a comment')
-      .argument('<id>', 'Comment ID'),
-  ).action(async (id: string, options: GlobalOptions, command: Command) => {
-    const { globals, profile } = getContext(command, options)
-    requireMutationConfirmation(globals)
-    const token = requireAuthenticatedProfile(profile)
-    await requestJson<unknown>({
-      fetch: getFetch(io),
-      url: `${profile.baseUrl}/api/comments/${encodeURIComponent(id)}`,
-      method: 'DELETE',
-      token,
-    })
-
-    outputResult(io, globals, { deleted: true, id })
-  })
+  registerCommentsCommands(program, runtime)
 
   const feedback = program
     .command('feedback')

--- a/tests/unit/cli-command-factories.test.ts
+++ b/tests/unit/cli-command-factories.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Command } from 'commander'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { registerJsonCommand } from '../../packages/careers-cli/src/commandFactories'
+import { createCliRuntime } from '../../packages/careers-cli/src/cliRuntime'
+import { runCli } from '../../packages/careers-cli/src/program'
+
+const tempDirs: string[] = []
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'factory-careers-cli-factories-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function writeAuthedConfig(configPath: string) {
+  writeFileSync(configPath, JSON.stringify({
+    activeProfile: 'prod',
+    profiles: {
+      prod: { baseUrl: 'https://careers.example.com', token: 'secret-token' },
+    },
+  }))
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('CLI command factories', () => {
+  it('registerJsonCommand requires confirmation for mutating commands', async () => {
+    const program = new Command()
+    const runtime = createCliRuntime({})
+    registerJsonCommand(runtime, program, {
+      name: 'delete-item',
+      description: 'Delete an item',
+      method: 'DELETE',
+      path: (id) => `/api/items/${encodeURIComponent(id)}`,
+      args: [{ name: 'id', description: 'Item ID' }],
+      mutation: true,
+      deleteAck: true,
+    })
+
+    await expect(program.parseAsync(
+      ['delete-item', 'item_1', '--json'],
+      { from: 'user' },
+    )).rejects.toMatchObject({
+      status: 400,
+      code: 'CONFIRMATION_REQUIRED',
+    })
+  })
+
+  it('preserves comments delete confirmation behavior through migrated commands', async () => {
+    const dir = tempDir()
+    const configPath = join(dir, 'config.json')
+    writeAuthedConfig(configPath)
+    const stdout: string[] = []
+
+    const exitCode = await runCli(
+      ['comments', 'delete', 'comment_1', '--config', configPath, '--json'],
+      { stdout: (value) => stdout.push(value), stderr: () => {} },
+    )
+
+    expect(exitCode).toBe(1)
+    expect(JSON.parse(stdout[0])).toMatchObject({
+      status: 400,
+      code: 'CONFIRMATION_REQUIRED',
+    })
+  })
+})

--- a/tests/unit/cli-command-route-contracts.test.ts
+++ b/tests/unit/cli-command-route-contracts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { Command } from 'commander'
 import { createProgram } from '../../packages/careers-cli/src/program'
@@ -116,6 +116,26 @@ function dynamicRouteEvidence(source: string, route: string): string[] {
   return []
 }
 
+function factoryRegisteredRouteExists(source: string, route: string): boolean {
+  if (!source.includes('registerJsonCommand')) return false
+
+  const method = expectedMethod(route)
+  const parts = staticApiParts(route)
+  const basePath = `/${parts.join('/')}`
+  const isIdRoute = route.includes('/[id]')
+
+  return source
+    .split('registerJsonCommand')
+    .some((chunk) => {
+      if (!chunk.includes(`method: '${method}'`)) return false
+      if (isIdRoute) {
+        const resourcePath = parts.slice(1).join('/')
+        return chunk.includes(`/api/${resourcePath}/\${encodeURIComponent(id)}`)
+      }
+      return chunk.includes(`path: '${basePath}'`)
+    })
+}
+
 function routeSpecificRequestExists(source: string, route: string): boolean {
   const method = expectedMethod(route)
   const dynamicEvidence = dynamicRouteEvidence(source, route)
@@ -132,9 +152,29 @@ function routeSpecificRequestExists(source: string, route: string): boolean {
     .filter((part) => !(/^server\/api\/chatbot\/(agents|folders)\//.test(route) && ['agents', 'folders'].includes(part)))
     .filter((part) => !(/^server\/api\/updates\/(changelog|system|version)\.get\.ts$/.test(route) && ['changelog', 'system', 'version'].includes(part)))
 
-  return requestBlocks(source).some((block) =>
+  if (requestBlocks(source).some((block) =>
     blockUsesMethod(block, method) && blockContainsParts(block, parts),
-  )
+  )) {
+    return true
+  }
+
+  return factoryRegisteredRouteExists(source, route)
+}
+
+function readCliSources(): string {
+  const srcDir = join(root, 'packages/careers-cli/src')
+  const files: string[] = []
+
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = join(dir, entry.name)
+      if (entry.isDirectory()) walk(fullPath)
+      else if (entry.name.endsWith('.ts')) files.push(fullPath)
+    }
+  }
+
+  walk(srcDir)
+  return files.map((file) => readFileSync(file, 'utf8')).join('\n')
 }
 
 describe('CLI command route contracts', () => {
@@ -150,10 +190,10 @@ describe('CLI command route contracts', () => {
   })
 
   it('keeps supported route methods and paths represented by the CLI implementation', () => {
-    const programSource = readFileSync(join(root, 'packages/careers-cli/src/program.ts'), 'utf8')
+    const cliSource = readCliSources()
     const missing = cliRouteCoverage
       .filter((entry) => entry.status === 'supported')
-      .filter((entry) => !routeSpecificRequestExists(programSource, entry.route))
+      .filter((entry) => !routeSpecificRequestExists(cliSource, entry.route))
       .map((entry) => `${entry.route} missing route-specific ${expectedMethod(entry.route)} request`)
 
     expect(missing).toEqual([])


### PR DESCRIPTION
## Summary

Epic 9 PR1 introduces shared CLI command registration factories and migrates the **comments** CRUD family as proof-of-concept.

Part of #254 (incremental DRY epic). Closes #245.

### Changes
- Add `cliRuntime.ts` with shared CLI primitives (`--json`, `--stdin`, `--yes`, mutation confirmation, auth, output formatting)
- Add `commandFactories.ts` with:
  - `registerJsonCommand` — JSON API command registration
  - `registerBinaryDownload` — binary download registration (ready for documents migration)
- Migrate `comments list/create/update/delete` to `commands/comments.ts` via the factory
- Extend route-contract tests to scan all CLI source files, including factory-registered commands
- Add factory-focused unit tests for mutation confirmation behavior

### Incremental approach
This PR intentionally migrates only one CRUD family to validate the factory pattern before rolling it out to email-templates, properties, source-tracking, and other duplicated handlers in follow-up PRs.

### Behavior preserved
- `--json`, `--stdin`, `--yes`, and `CONFIRMATION_REQUIRED` semantics unchanged
- Existing comments CLI parity tests pass without modification

## Test results
- `npm run test:unit` — **950/950 passed**
- `npm run preflight:cli-parity` — pass (no parity-sensitive manifest changes)
- `./packages/careers-cli/bin/factory-careers.mjs --help` — pass