### PR TITLE
refactor: Epic 7 pagination and pipeline count helpers (PR1)

### DIFF
--- a/server/api/applications/index.get.ts
+++ b/server/api/applications/index.get.ts
@@ -1,5 +1,6 @@
 import { eq, and, desc, inArray } from 'drizzle-orm'
 import { application, candidate, job } from '../../database/schema'
+import { paginatedListResponse, paginationOffset } from '../../utils/schemas/common'
 import { applicationQuerySchema } from '../../utils/schemas/application'
 import {
   loadPropertyEntriesForEntities,
@@ -17,7 +18,7 @@ export default defineEventHandler(async (event) => {
 
   const query = await getValidatedQuery(event, applicationQuerySchema.parse)
 
-  const offset = (query.page - 1) * query.limit
+  const offset = paginationOffset(query.page, query.limit)
   const conditions = [eq(application.organizationId, orgId)]
 
   if (query.jobId) {
@@ -38,7 +39,7 @@ export default defineEventHandler(async (event) => {
       filters: propertyFilters,
     })
     if (!matching || matching.size === 0) {
-      return { data: [], total: 0, page: query.page, limit: query.limit }
+      return paginatedListResponse([], 0, query.page, query.limit)
     }
     conditions.push(inArray(application.id, [...matching]))
   }
@@ -88,5 +89,5 @@ export default defineEventHandler(async (event) => {
     properties: propertyMap.get(a.id) ?? [],
   }))
 
-  return { data: enriched, total, page: query.page, limit: query.limit }
+  return paginatedListResponse(enriched, total, query.page, query.limit)
 })

--- a/server/api/candidates/index.get.ts
+++ b/server/api/candidates/index.get.ts
@@ -1,5 +1,6 @@
 import { eq, and, or, ilike, desc, sql, gte, lte, inArray } from 'drizzle-orm'
 import { candidate, application } from '../../database/schema'
+import { paginatedListResponse, paginationOffset } from '../../utils/schemas/common'
 import { candidateQuerySchema } from '../../utils/schemas/candidate'
 import {
   loadPropertyEntriesForEntities,
@@ -12,7 +13,7 @@ export default defineEventHandler(async (event) => {
 
   const query = await getValidatedQuery(event, candidateQuerySchema.parse)
 
-  const offset = (query.page - 1) * query.limit
+  const offset = paginationOffset(query.page, query.limit)
   const conditions = [eq(candidate.organizationId, orgId)]
 
   if (query.search) {
@@ -48,7 +49,7 @@ export default defineEventHandler(async (event) => {
       filters: propertyFilters,
     })
     if (!matching || matching.size === 0) {
-      return { data: [], total: 0, page: query.page, limit: query.limit }
+      return paginatedListResponse([], 0, query.page, query.limit)
     }
     conditions.push(inArray(candidate.id, [...matching]))
   }
@@ -90,5 +91,5 @@ export default defineEventHandler(async (event) => {
   })
   const enriched = data.map((c) => ({ ...c, properties: propertyMap.get(c.id) ?? [] }))
 
-  return { data: enriched, total, page: query.page, limit: query.limit }
+  return paginatedListResponse(enriched, total, query.page, query.limit)
 })

--- a/server/api/dashboard/stats.get.ts
+++ b/server/api/dashboard/stats.get.ts
@@ -1,4 +1,5 @@
 import { eq, and, desc, sql, count } from 'drizzle-orm'
+import { emptyPipelineCounts } from '~~/shared/application-status'
 import { application, candidate, job } from '../../database/schema'
 
 /**
@@ -109,14 +110,7 @@ export default defineCachedEventHandler(async (event) => {
   // ─────────────────────────────────────────────
   // Transform grouped rows into keyed objects
   // ─────────────────────────────────────────────
-  const pipeline: Record<string, number> = {
-    new: 0,
-    screening: 0,
-    interview: 0,
-    offer: 0,
-    hired: 0,
-    rejected: 0,
-  }
+  const pipeline: Record<string, number> = { ...emptyPipelineCounts() }
   for (const row of pipelineRows) {
     pipeline[row.status] = row.count
   }

--- a/server/api/dashboard/stats.get.ts
+++ b/server/api/dashboard/stats.get.ts
@@ -110,7 +110,7 @@ export default defineCachedEventHandler(async (event) => {
   // ─────────────────────────────────────────────
   // Transform grouped rows into keyed objects
   // ─────────────────────────────────────────────
-  const pipeline: Record<string, number> = { ...emptyPipelineCounts() }
+  const pipeline: Record<string, number> = emptyPipelineCounts()
   for (const row of pipelineRows) {
     pipeline[row.status] = row.count
   }

--- a/server/api/jobs/index.get.ts
+++ b/server/api/jobs/index.get.ts
@@ -1,15 +1,8 @@
 import { eq, and, desc, count, inArray } from 'drizzle-orm'
 import { job, application } from '../../database/schema'
+import { emptyPipelineCounts, type PipelineCounts } from '~~/shared/application-status'
+import { paginatedListResponse, paginationOffset } from '../../utils/schemas/common'
 import { jobQuerySchema } from '../../utils/schemas/job'
-
-interface PipelineCounts {
-  new: number
-  screening: number
-  interview: number
-  offer: number
-  hired: number
-  rejected: number
-}
 
 export default defineEventHandler(async (event) => {
   const session = await requirePermission(event, { job: ['read'] })
@@ -17,7 +10,7 @@ export default defineEventHandler(async (event) => {
 
   const query = await getValidatedQuery(event, jobQuerySchema.parse)
 
-  const offset = (query.page - 1) * query.limit
+  const offset = paginationOffset(query.page, query.limit)
   const conditions = [eq(job.organizationId, orgId)]
   if (query.status) conditions.push(eq(job.status, query.status))
 
@@ -64,15 +57,15 @@ export default defineEventHandler(async (event) => {
       .groupBy(application.jobId, application.status)
 
     for (const row of pipelineRows) {
-      const entry = (pipelineMap[row.jobId] ??= { new: 0, screening: 0, interview: 0, offer: 0, hired: 0, rejected: 0 })
+      const entry = (pipelineMap[row.jobId] ??= emptyPipelineCounts())
       entry[row.status as keyof PipelineCounts] = row.count
     }
   }
 
   const enrichedData = data.map((j) => ({
     ...j,
-    pipeline: pipelineMap[j.id] ?? { new: 0, screening: 0, interview: 0, offer: 0, hired: 0, rejected: 0 },
+    pipeline: pipelineMap[j.id] ?? emptyPipelineCounts(),
   }))
 
-  return { data: enrichedData, total, page: query.page, limit: query.limit }
+  return paginatedListResponse(enrichedData, total, query.page, query.limit)
 })

--- a/server/api/source-tracking/stats.get.ts
+++ b/server/api/source-tracking/stats.get.ts
@@ -1,4 +1,5 @@
 import { eq, and, sql, count, gte, lte, desc } from 'drizzle-orm'
+import { emptyPipelineCounts } from '~~/shared/application-status'
 import { applicationSource, application, trackingLink, job, candidate } from '../../database/schema'
 import { sourceStatsQuerySchema } from '../../utils/schemas/trackingLink'
 
@@ -165,7 +166,7 @@ export default defineEventHandler(async (event) => {
   const funnel: Record<string, Record<string, number>> = {}
   for (const row of statusByChannel) {
     if (!funnel[row.channel]) {
-      funnel[row.channel] = { new: 0, screening: 0, interview: 0, offer: 0, hired: 0, rejected: 0 }
+      funnel[row.channel] = emptyPipelineCounts()
     }
     funnel[row.channel]![row.status] = row.count
   }

--- a/server/api/tracking-links/[id]/stats.get.ts
+++ b/server/api/tracking-links/[id]/stats.get.ts
@@ -128,7 +128,7 @@ export default defineEventHandler(async (event) => {
   ])
 
   // ─── Build funnel map ─────────────────────
-  const funnel: Record<string, number> = { ...emptyPipelineCounts() }
+  const funnel: Record<string, number> = emptyPipelineCounts()
   for (const row of statusBreakdown) {
     funnel[row.status] = row.count
   }

--- a/server/api/tracking-links/[id]/stats.get.ts
+++ b/server/api/tracking-links/[id]/stats.get.ts
@@ -1,5 +1,6 @@
 import { eq, and, sql, count, gte, lte, desc } from 'drizzle-orm'
 import { applicationSource, application, trackingLink, job, candidate } from '../../../database/schema'
+import { emptyPipelineCounts } from '~~/shared/application-status'
 import { findOrgScopedOr404, orgScopedIdWhere } from '../../../utils/orgScope'
 import { trackingLinkIdSchema, sourceStatsQuerySchema } from '../../../utils/schemas/trackingLink'
 
@@ -127,7 +128,7 @@ export default defineEventHandler(async (event) => {
   ])
 
   // ─── Build funnel map ─────────────────────
-  const funnel: Record<string, number> = { new: 0, screening: 0, interview: 0, offer: 0, hired: 0, rejected: 0 }
+  const funnel: Record<string, number> = { ...emptyPipelineCounts() }
   for (const row of statusBreakdown) {
     funnel[row.status] = row.count
   }

--- a/server/utils/schemas/application.ts
+++ b/server/utils/schemas/application.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod'
+import { APPLICATION_STATUSES } from '~~/shared/application-status'
+import { paginationQuerySchema } from './common'
 
 export { APPLICATION_STATUS_TRANSITIONS } from '~~/shared/status-transitions'
 
@@ -15,18 +17,16 @@ export const createApplicationSchema = z.object({
 
 /** Schema for updating an existing application (status transitions, notes, score) */
 export const updateApplicationSchema = z.object({
-  status: z.enum(['new', 'screening', 'interview', 'offer', 'hired', 'rejected']).optional(),
+  status: z.enum(APPLICATION_STATUSES).optional(),
   notes: z.string().max(5000).nullish(),
   score: z.number().int().min(0).max(100).nullish(),
 })
 
 /** Schema for application list query params */
-export const applicationQuerySchema = z.object({
-  page: z.coerce.number().int().min(1).default(1),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
+export const applicationQuerySchema = paginationQuerySchema().extend({
   jobId: z.string().min(1).optional(),
   candidateId: z.string().min(1).optional(),
-  status: z.enum(['new', 'screening', 'interview', 'offer', 'hired', 'rejected']).optional(),
+  status: z.enum(APPLICATION_STATUSES).optional(),
   /** JSON-encoded array of { propertyDefinitionId, op, value } filters */
   propertyFilters: z.string().optional(),
 })

--- a/server/utils/schemas/candidate.ts
+++ b/server/utils/schemas/candidate.ts
@@ -6,6 +6,7 @@ import {
   candidateGenderValues,
   candidateUpdateFieldsSchema,
 } from '~~/shared/schemas/candidate'
+import { paginationQuerySchema } from './common'
 
 // ─────────────────────────────────────────────
 // Candidate validation schemas — shared across API routes
@@ -22,9 +23,7 @@ export const updateCandidateSchema = candidateUpdateFieldsSchema.extend({
 })
 
 /** Schema for candidate list query params */
-export const candidateQuerySchema = z.object({
-  page: z.coerce.number().int().min(1).default(1),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
+export const candidateQuerySchema = paginationQuerySchema().extend({
   search: z.string().trim().max(200).optional(),
   gender: candidateGenderSchema.optional(),
   dobFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'dobFrom must be YYYY-MM-DD').optional(),

--- a/server/utils/schemas/common.ts
+++ b/server/utils/schemas/common.ts
@@ -1,5 +1,37 @@
 import { z } from 'zod'
 
+type PaginationQueryOptions = {
+  defaultLimit?: number
+  maxLimit?: number
+}
+
+/** Reusable list query params for paginated API routes */
+export function paginationQuerySchema(options: PaginationQueryOptions = {}) {
+  const { defaultLimit = 20, maxLimit = 100 } = options
+
+  return z.object({
+    page: z.coerce.number().int().min(1).default(1),
+    limit: z.coerce.number().int().min(1).max(maxLimit).default(defaultLimit),
+  })
+}
+
+export type PaginationQuery = z.infer<ReturnType<typeof paginationQuerySchema>>
+
+/** Offset for SQL `LIMIT`/`OFFSET` pagination. */
+export function paginationOffset(page: number, limit: number): number {
+  return (page - 1) * limit
+}
+
+/** Standard paginated list response envelope. */
+export function paginatedListResponse<T>(
+  data: T[],
+  total: number,
+  page: number,
+  limit: number,
+) {
+  return { data, total, page, limit }
+}
+
 /** Reusable `:id` route param for org-scoped resources */
 export const resourceIdParamSchema = z.object({
   id: z.string().min(1),

--- a/server/utils/schemas/job.ts
+++ b/server/utils/schemas/job.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { CURRENCY_VALUES } from '~~/shared/currency-options'
 import { SALARY_UNIT_VALUES } from '~~/shared/salary-options'
+import { paginationQuerySchema } from './common'
 import { scoringBandsSchema } from './scoringBands'
 
 export { JOB_STATUS_TRANSITIONS } from '~~/shared/status-transitions'
@@ -80,9 +81,7 @@ export const updateJobSchema = z.object({
 })
 
 /** Schema for job list query params */
-export const jobQuerySchema = z.object({
-  page: z.coerce.number().int().min(1).default(1),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
+export const jobQuerySchema = paginationQuerySchema().extend({
   status: z.enum(['draft', 'open', 'closed', 'archived']).optional(),
 })
 

--- a/shared/application-status.ts
+++ b/shared/application-status.ts
@@ -1,0 +1,29 @@
+/**
+ * Application pipeline status constants — single source of truth for
+ * server analytics, API validation, and dashboard pipeline counts.
+ */
+
+export const APPLICATION_STATUSES = [
+  'new',
+  'screening',
+  'interview',
+  'offer',
+  'hired',
+  'rejected',
+] as const
+
+export type ApplicationStatus = (typeof APPLICATION_STATUSES)[number]
+
+export type PipelineCounts = Record<ApplicationStatus, number>
+
+/** Returns a zeroed pipeline count map for every application status. */
+export function emptyPipelineCounts(): PipelineCounts {
+  return {
+    new: 0,
+    screening: 0,
+    interview: 0,
+    offer: 0,
+    hired: 0,
+    rejected: 0,
+  }
+}

--- a/tests/unit/cli-parity-changed-files.test.ts
+++ b/tests/unit/cli-parity-changed-files.test.ts
@@ -38,6 +38,22 @@ describe('CLI parity changed-file guard', () => {
     })
   })
 
+  it('accepts CLI parity evidence for Epic 7 pagination and pipeline helpers without contract changes', () => {
+    expect(evaluateCliParityEvidence([
+      'server/api/candidates/index.get.ts',
+      'server/api/applications/index.get.ts',
+      'server/api/jobs/index.get.ts',
+      'server/api/dashboard/stats.get.ts',
+      'server/api/tracking-links/[id]/stats.get.ts',
+      'server/api/source-tracking/stats.get.ts',
+      'shared/application-status.ts',
+      'tests/unit/cli-parity-changed-files.test.ts',
+    ])).toMatchObject({
+      ok: true,
+      message: 'CLI parity evidence found.',
+    })
+  })
+
   it('passes when parity-sensitive files include CLI evidence', () => {
     expect(evaluateCliParityEvidence([
       'server/api/jobs/index.post.ts',

--- a/tests/unit/server-helpers-epic7-pr1.test.ts
+++ b/tests/unit/server-helpers-epic7-pr1.test.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  APPLICATION_STATUSES,
+  emptyPipelineCounts,
+} from '../../shared/application-status'
+import {
+  paginatedListResponse,
+  paginationOffset,
+  paginationQuerySchema,
+} from '../../server/utils/schemas/common'
+import { applicationQuerySchema } from '../../server/utils/schemas/application'
+import { candidateQuerySchema } from '../../server/utils/schemas/candidate'
+import { jobQuerySchema } from '../../server/utils/schemas/job'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('paginationQuerySchema', () => {
+  it('applies default page and limit', () => {
+    expect(paginationQuerySchema().parse({})).toEqual({ page: 1, limit: 20 })
+  })
+
+  it('coerces string query params and honors custom limits', () => {
+    const schema = paginationQuerySchema({ defaultLimit: 50, maxLimit: 200 })
+
+    expect(schema.parse({ page: '2', limit: '75' })).toEqual({ page: 2, limit: 75 })
+    expect(() => schema.parse({ limit: '201' })).toThrow()
+  })
+
+  it('is composed into candidate, application, and job list schemas', () => {
+    expect(candidateQuerySchema.parse({})).toMatchObject({ page: 1, limit: 20 })
+    expect(applicationQuerySchema.parse({ status: 'screening' })).toMatchObject({
+      page: 1,
+      limit: 20,
+      status: 'screening',
+    })
+    expect(jobQuerySchema.parse({ status: 'open', page: '3' })).toEqual({
+      page: 3,
+      limit: 20,
+      status: 'open',
+    })
+  })
+})
+
+describe('paginated list helpers', () => {
+  it('computes SQL offsets from page and limit', () => {
+    expect(paginationOffset(1, 20)).toBe(0)
+    expect(paginationOffset(3, 25)).toBe(50)
+  })
+
+  it('builds the standard list response envelope', () => {
+    expect(paginatedListResponse([{ id: 'app_1' }], 42, 2, 20)).toEqual({
+      data: [{ id: 'app_1' }],
+      total: 42,
+      page: 2,
+      limit: 20,
+    })
+  })
+})
+
+describe('emptyPipelineCounts', () => {
+  it('returns a zeroed map for every application status', () => {
+    expect(emptyPipelineCounts()).toEqual({
+      new: 0,
+      screening: 0,
+      interview: 0,
+      offer: 0,
+      hired: 0,
+      rejected: 0,
+    })
+    expect(Object.keys(emptyPipelineCounts()).sort()).toEqual([...APPLICATION_STATUSES].sort())
+  })
+
+  it('returns a fresh object on each call', () => {
+    const first = emptyPipelineCounts()
+    first.new = 5
+
+    expect(emptyPipelineCounts().new).toBe(0)
+  })
+})
+
+describe('epic 7 route migrations', () => {
+  it('routes list handlers through shared pagination helpers', () => {
+    for (const path of [
+      'server/api/candidates/index.get.ts',
+      'server/api/applications/index.get.ts',
+      'server/api/jobs/index.get.ts',
+    ]) {
+      const source = readProjectFile(path)
+      expect(source, path).toContain('paginationOffset')
+      expect(source, path).toContain('paginatedListResponse')
+    }
+  })
+
+  it('routes pipeline analytics through emptyPipelineCounts', () => {
+    for (const path of [
+      'server/api/jobs/index.get.ts',
+      'server/api/dashboard/stats.get.ts',
+      'server/api/tracking-links/[id]/stats.get.ts',
+      'server/api/source-tracking/stats.get.ts',
+    ]) {
+      const source = readProjectFile(path)
+      expect(source, path).toContain('emptyPipelineCounts')
+      expect(source, path).not.toMatch(/\{\s*new:\s*0,\s*screening:\s*0/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Epic 7 PR1 — server domain helpers for pagination and pipeline counts.

### #232 — Pagination schema + list helper
- Add `paginationQuerySchema({ defaultLimit, maxLimit })`, `paginationOffset()`, and `paginatedListResponse()` in `server/utils/schemas/common.ts`
- Migrate `candidateQuerySchema`, `applicationQuerySchema`, and `jobQuerySchema` to compose the shared pagination schema
- Migrate candidates, applications, and jobs list routes to use the shared offset/response helpers

### #233 — emptyPipelineCounts
- Add `APPLICATION_STATUSES` and `emptyPipelineCounts()` in `shared/application-status.ts`
- Migrate pipeline zero maps in:
  - `server/api/jobs/index.get.ts`
  - `server/api/dashboard/stats.get.ts`
  - `server/api/tracking-links/[id]/stats.get.ts`
  - `server/api/source-tracking/stats.get.ts`

## Verification

```bash
npm run test:unit
npm run typecheck
```

- Unit tests: **958 passed** (includes new `tests/unit/server-helpers-epic7-pr1.test.ts`)
- Typecheck: **pass**

## CLI parity

Internal refactor only — response shapes and query contracts are unchanged. CLI parity evidence added in `tests/unit/cli-parity-changed-files.test.ts`.

Closes #232
Closes #233
Part of #252