### PR TITLE
refactor: Epic 8 e2e db and jsonl capture helpers

### DIFF
--- a/e2e/critical-flows/ai-candidate-review.spec.ts
+++ b/e2e/critical-flows/ai-candidate-review.spec.ts
@@ -1,7 +1,10 @@
-import { randomUUID } from 'node:crypto'
-import { readFile, rm } from 'node:fs/promises'
-import postgres from 'postgres'
 import { test, expect, selectFactorySelectOption } from '../fixtures'
+import { readJsonlCapture, setupCaptureFile } from '../helpers/captured-jsonl'
+import {
+  lookupApplicationByEmail,
+  seedCrossTenantSentinel,
+  seedParsedResume,
+} from '../helpers/db'
 
 type CapturedAiRequest = {
   schemaName: string
@@ -11,153 +14,10 @@ type CapturedAiRequest = {
   model: string
 }
 
-type ApplicationLookup = {
-  applicationId: string
-  candidateId: string
-  organizationId: string
-}
-
-async function readCapturedAiRequests(capturePath: string): Promise<CapturedAiRequest[]> {
-  try {
-    const contents = await readFile(capturePath, 'utf8')
-    return contents
-      .split('\n')
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as CapturedAiRequest)
-  }
-  catch (error) {
-    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return []
-    throw error
-  }
-}
-
-async function lookupApplicationByEmail(email: string): Promise<ApplicationLookup> {
-  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for AI candidate review E2E').toBeTruthy()
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-
-  try {
-    const [row] = await sql<ApplicationLookup[]>`
-      select
-        a.id as "applicationId",
-        c.id as "candidateId",
-        a.organization_id as "organizationId"
-      from application a
-      inner join candidate c on c.id = a.candidate_id
-      where c.email = ${email}
-      order by a.created_at desc
-      limit 1
-    `
-
-    expect(row, `expected application for ${email}`).toBeTruthy()
-    return row!
-  }
-  finally {
-    await sql.end()
-  }
-}
-
-async function seedParsedResume(params: {
-  organizationId: string
-  candidateId: string
-  resumeText: string
-}) {
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-  const documentId = randomUUID()
-
-  try {
-    await sql`
-      insert into document (
-        id,
-        organization_id,
-        candidate_id,
-        type,
-        storage_key,
-        original_filename,
-        mime_type,
-        size_bytes,
-        parsed_content
-      )
-      values (
-        ${documentId},
-        ${params.organizationId},
-        ${params.candidateId},
-        'resume',
-        ${`${params.organizationId}/${params.candidateId}/${documentId}.txt`},
-        'deterministic-resume.txt',
-        'text/plain',
-        ${params.resumeText.length},
-        ${sql.json({ text: params.resumeText })}
-      )
-    `
-  }
-  finally {
-    await sql.end()
-  }
-}
-
-async function seedCrossTenantSentinel(sentinel: string) {
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-  const orgId = randomUUID()
-  const candidateId = randomUUID()
-  const jobId = randomUUID()
-  const applicationId = randomUUID()
-  const documentId = randomUUID()
-
-  try {
-    await sql.begin(async (tx) => {
-      await tx`
-        insert into organization (id, name, slug)
-        values (${orgId}, ${`Sentinel Org ${orgId.slice(0, 8)}`}, ${`sentinel-${orgId.slice(0, 8)}`})
-      `
-      await tx`
-        insert into job (id, organization_id, title, slug, description, status, active_from)
-        values (${jobId}, ${orgId}, 'Sentinel Role', ${`sentinel-role-${jobId.slice(0, 8)}`}, ${sentinel}, 'open', now())
-      `
-      await tx`
-        insert into candidate (id, organization_id, first_name, last_name, email)
-        values (${candidateId}, ${orgId}, 'Cross', 'Tenant', ${`cross-tenant-${candidateId}@example.com`})
-      `
-      await tx`
-        insert into application (id, organization_id, candidate_id, job_id, cover_letter_text)
-        values (${applicationId}, ${orgId}, ${candidateId}, ${jobId}, ${sentinel})
-      `
-      await tx`
-        insert into document (
-          id,
-          organization_id,
-          candidate_id,
-          type,
-          storage_key,
-          original_filename,
-          mime_type,
-          size_bytes,
-          parsed_content
-        )
-        values (
-          ${documentId},
-          ${orgId},
-          ${candidateId},
-          'resume',
-          ${`${orgId}/${candidateId}/${documentId}.txt`},
-          'sentinel-resume.txt',
-          'text/plain',
-          ${sentinel.length},
-          ${tx.json({ text: sentinel })}
-        )
-      `
-    })
-  }
-  finally {
-    await sql.end()
-  }
-}
-
 test.describe('AI candidate review', () => {
   test('scores a submitted candidate through the dashboard using deterministic local AI', async ({ authenticatedPage, browser }, testInfo) => {
-    const capturePath = process.env.FACTORY_AI_CAPTURE_PATH
     expect(process.env.FACTORY_AI_TEST_MODE, 'AI E2E must use mock mode, not a real provider').toBe('mock')
-    expect(capturePath, 'FACTORY_AI_CAPTURE_PATH must be set for AI E2E').toBeTruthy()
-    await rm(capturePath!, { force: true })
+    const capturePath = await setupCaptureFile('FACTORY_AI_CAPTURE_PATH', 'AI E2E')
 
     const page = authenticatedPage
     const runId = `${Date.now()}-${testInfo.workerIndex}-${testInfo.retry}`
@@ -288,12 +148,13 @@ test.describe('AI candidate review', () => {
       evidence: expect.stringContaining('athletes, entertainers, founders, media, and investments'),
     }))
 
-    await expect.poll(async () => (await readCapturedAiRequests(capturePath!)).length, {
+    await expect.poll(async () => (await readJsonlCapture<CapturedAiRequest>(capturePath)).length, {
       message: 'AI mock provider should capture the scoring request',
       timeout: 10_000,
     }).toBeGreaterThanOrEqual(1)
 
-    const captured = (await readCapturedAiRequests(capturePath!)).find(request => request.schemaName === 'CandidateScoring')
+    const captured = (await readJsonlCapture<CapturedAiRequest>(capturePath))
+      .find(request => request.schemaName === 'CandidateScoring')
     expect(captured, 'candidate scoring request should be captured').toBeTruthy()
     expect(captured?.provider).toBe('openai')
     expect(captured?.model).toBe('factory-e2e-candidate-review')

--- a/e2e/critical-flows/ai-config-lifecycle.spec.ts
+++ b/e2e/critical-flows/ai-config-lifecycle.spec.ts
@@ -1,5 +1,5 @@
-import { readFile, rm } from 'node:fs/promises'
 import { test, expect } from '../fixtures'
+import { readJsonlCapture, setupCaptureFile } from '../helpers/captured-jsonl'
 
 type CapturedAiRequest = {
   schemaName: string
@@ -17,26 +17,10 @@ type AiConfigRow = {
   isDefaultAnalysis: boolean
 }
 
-async function readCapturedAiRequests(capturePath: string): Promise<CapturedAiRequest[]> {
-  try {
-    const contents = await readFile(capturePath, 'utf8')
-    return contents
-      .split('\n')
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as CapturedAiRequest)
-  }
-  catch (error) {
-    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return []
-    throw error
-  }
-}
-
 test.describe('AI configuration lifecycle', () => {
   test('creates, edits, tests, defaults, and uses local AI config for generated job criteria', async ({ authenticatedPage }, testInfo) => {
-    const capturePath = process.env.FACTORY_AI_CAPTURE_PATH
     expect(process.env.FACTORY_AI_TEST_MODE, 'AI E2E must use mock mode, not a real provider').toBe('mock')
-    expect(capturePath, 'FACTORY_AI_CAPTURE_PATH must be set for AI E2E').toBeTruthy()
-    await rm(capturePath!, { force: true })
+    const capturePath = await setupCaptureFile('FACTORY_AI_CAPTURE_PATH', 'AI E2E')
 
     const page = authenticatedPage
     const runId = `${Date.now()}-${testInfo.workerIndex}-${testInfo.retry}`
@@ -170,12 +154,12 @@ test.describe('AI configuration lifecycle', () => {
       jobId: job.id,
     }))
 
-    await expect.poll(async () => (await readCapturedAiRequests(capturePath!)).length, {
+    await expect.poll(async () => (await readJsonlCapture<CapturedAiRequest>(capturePath)).length, {
       message: 'AI mock provider should capture connection checks and generated criteria',
       timeout: 10_000,
     }).toBeGreaterThanOrEqual(3)
 
-    const captured = await readCapturedAiRequests(capturePath!)
+    const captured = await readJsonlCapture<CapturedAiRequest>(capturePath)
     const generatedCriteriaRequest = captured.find(request => request.schemaName === 'GeneratedCriteria')
     expect(generatedCriteriaRequest, 'generated criteria request should be captured').toBeTruthy()
     expect(generatedCriteriaRequest?.provider).toBe('openai')

--- a/e2e/critical-flows/chatbot-conversations.spec.ts
+++ b/e2e/critical-flows/chatbot-conversations.spec.ts
@@ -1,5 +1,5 @@
-import { readFile, rm } from 'node:fs/promises'
 import { test, expect } from '../fixtures'
+import { readJsonlCapture, setupCaptureFile } from '../helpers/captured-jsonl'
 import { assertMutatingE2ESafety } from '../safety'
 
 type CapturedChatbotRequest = {
@@ -20,26 +20,17 @@ type CapturedChatbotRequest = {
   toolNames: string[]
 }
 
-async function readCapturedChatbotRequests(capturePath: string): Promise<CapturedChatbotRequest[]> {
-  try {
-    const contents = await readFile(capturePath, 'utf8')
-    return contents
-      .split('\n')
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as CapturedChatbotRequest)
-      .filter((request) => request.schemaName === 'ChatbotChat')
-  }
-  catch (error) {
-    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return []
-    throw error
-  }
+function readCapturedChatbotRequests(capturePath: string) {
+  return readJsonlCapture<CapturedChatbotRequest>(
+    capturePath,
+    request => request.schemaName === 'ChatbotChat',
+  )
 }
 
 test.describe('Chatbot agents and conversations', () => {
   test('creates an agent, sends a mocked conversation turn, and persists it after reload', async ({ authenticatedPage }, testInfo) => {
     const page = authenticatedPage
     const baseURL = String(testInfo.project.use.baseURL ?? '')
-    const capturePath = process.env.FACTORY_AI_CAPTURE_PATH
 
     assertMutatingE2ESafety({
       env: {
@@ -48,8 +39,7 @@ test.describe('Chatbot agents and conversations', () => {
       },
     })
     expect(process.env.FACTORY_AI_TEST_MODE, 'Chatbot E2E must use mock mode, not a real provider').toBe('mock')
-    expect(capturePath, 'FACTORY_AI_CAPTURE_PATH must be set for chatbot E2E').toBeTruthy()
-    await rm(capturePath!, { force: true })
+    const capturePath = await setupCaptureFile('FACTORY_AI_CAPTURE_PATH', 'chatbot E2E')
 
     const runId = `${Date.now()}-${testInfo.workerIndex}-${testInfo.retry}`
     const modelName = 'factory-e2e-chatbot-response'
@@ -126,12 +116,12 @@ test.describe('Chatbot agents and conversations', () => {
     })
     expect(missingConversationResponse.status(), `Missing conversation returned ${missingConversationResponse.status()}`).toBe(404)
 
-    await expect.poll(async () => (await readCapturedChatbotRequests(capturePath!)).length, {
+    await expect.poll(async () => (await readCapturedChatbotRequests(capturePath)).length, {
       message: 'chatbot mock stream should capture the prompt context',
       timeout: 10_000,
     }).toBeGreaterThanOrEqual(1)
 
-    const captured = await readCapturedChatbotRequests(capturePath!)
+    const captured = await readCapturedChatbotRequests(capturePath)
     const chatRequest = captured.find(request => request.model === modelName)
     expect(chatRequest, 'chatbot request should be captured').toBeTruthy()
     expect(chatRequest?.provider).toBe('openai')
@@ -149,7 +139,6 @@ test.describe('Chatbot agents and conversations', () => {
   test('uploads a knowledge file and includes it in mocked chatbot context', async ({ authenticatedPage }, testInfo) => {
     const page = authenticatedPage
     const baseURL = String(testInfo.project.use.baseURL ?? '')
-    const capturePath = process.env.FACTORY_AI_CAPTURE_PATH
 
     assertMutatingE2ESafety({
       env: {
@@ -158,8 +147,7 @@ test.describe('Chatbot agents and conversations', () => {
       },
     })
     expect(process.env.FACTORY_AI_TEST_MODE, 'Chatbot knowledge E2E must use mock mode, not a real provider').toBe('mock')
-    expect(capturePath, 'FACTORY_AI_CAPTURE_PATH must be set for chatbot E2E').toBeTruthy()
-    await rm(capturePath!, { force: true })
+    const capturePath = await setupCaptureFile('FACTORY_AI_CAPTURE_PATH', 'chatbot E2E')
 
     const runId = `${Date.now()}-${testInfo.workerIndex}-${testInfo.retry}`
     const modelName = 'factory-e2e-chatbot-knowledge-response'
@@ -224,12 +212,12 @@ test.describe('Chatbot agents and conversations', () => {
     })
     expect(invalidAttachmentResponse.status(), `Invalid attachment returned ${invalidAttachmentResponse.status()}`).toBe(410)
 
-    await expect.poll(async () => (await readCapturedChatbotRequests(capturePath!)).length, {
+    await expect.poll(async () => (await readCapturedChatbotRequests(capturePath)).length, {
       message: 'chatbot mock stream should capture uploaded knowledge context',
       timeout: 10_000,
     }).toBeGreaterThanOrEqual(1)
 
-    const captured = await readCapturedChatbotRequests(capturePath!)
+    const captured = await readCapturedChatbotRequests(capturePath)
     const chatRequest = captured.find(request => request.model === modelName)
     expect(chatRequest, 'chatbot knowledge request should be captured').toBeTruthy()
     expect(chatRequest?.provider).toBe('openai')

--- a/e2e/critical-flows/org-admin-membership.spec.ts
+++ b/e2e/critical-flows/org-admin-membership.spec.ts
@@ -1,81 +1,17 @@
 import type { Browser, Page } from '@playwright/test'
-import postgres from 'postgres'
 import { assertMutatingE2ESafety } from '../safety'
 import { expect, expectFloatingMenuNotClipped, selectFactorySelectOption, test } from '../fixtures'
+import {
+  lookupJoinRequestStatus,
+  lookupMemberByEmail,
+  lookupMembership,
+} from '../helpers/db'
 
 interface SignedInApplicant {
   email: string
   name: string
   page: Page
   close: () => Promise<void>
-}
-
-interface MembershipLookup {
-  userId: string
-  memberId: string
-  organizationId: string
-}
-
-async function lookupMembership(email: string, organizationName: string): Promise<MembershipLookup> {
-  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for org admin e2e membership lookup').toBeTruthy()
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-
-  try {
-    const [membership] = await sql<MembershipLookup[]>`
-      select
-        u.id as "userId",
-        m.id as "memberId",
-        o.id as "organizationId"
-      from "user" u
-      inner join "member" m on m."user_id" = u.id
-      inner join "organization" o on o.id = m."organization_id"
-      where u.email = ${email} and o.name = ${organizationName}
-      limit 1
-    `
-
-    expect(membership, `expected ${email} to belong to ${organizationName}`).toBeTruthy()
-    return membership
-  }
-  finally {
-    await sql.end()
-  }
-}
-
-async function lookupMemberByEmail(email: string, organizationId: string) {
-  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for org admin e2e member lookup').toBeTruthy()
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-
-  try {
-    const [member] = await sql<Array<{ id: string, role: string }>>`
-      select m.id, m.role
-      from "member" m
-      inner join "user" u on u.id = m."user_id"
-      where u.email = ${email} and m."organization_id" = ${organizationId}
-      limit 1
-    `
-    return member
-  }
-  finally {
-    await sql.end()
-  }
-}
-
-async function lookupJoinRequestStatus(requestId: string) {
-  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for org admin e2e join-request lookup').toBeTruthy()
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-
-  try {
-    const [request] = await sql<Array<{ status: string, reviewedAt: Date | null }>>`
-      select status, "reviewed_at" as "reviewedAt"
-      from "join_request"
-      where id = ${requestId}
-      limit 1
-    `
-    return request
-  }
-  finally {
-    await sql.end()
-  }
 }
 
 async function signUpWithoutOrganization(browser: Browser, baseURL: string, label: string): Promise<SignedInApplicant> {

--- a/e2e/critical-flows/privacy-request-fake-mail.spec.ts
+++ b/e2e/critical-flows/privacy-request-fake-mail.spec.ts
@@ -1,100 +1,15 @@
-import { rm } from 'node:fs/promises'
 import type { Page } from '@playwright/test'
 import { test, expect, selectFactorySelectOption } from '../fixtures'
-import postgres from 'postgres'
-import type { Sql } from 'postgres'
+import { setupCaptureFile } from '../helpers/captured-jsonl'
 import { type CapturedEmail, readCapturedEmails } from '../helpers/captured-emails'
-
-type PrivacyRequestRecord = {
-  id: string
-  organizationId: string | null
-  status: string
-  requesterName: string
-  requesterEmail: string
-  stateOfResidence: string
-  applicationId: string | null
-  details: string | null
-  verificationTokenHash: string
-  verifiedAt: Date | null
-  completedAt: Date | null
-  resolutionNotes: string | null
-}
-
-type CandidateApplicationRecord = {
-  candidateId: string
-  applicationId: string
-  organizationId: string
-}
-
-async function lookupPrivacyRequest(sql: Sql, requesterEmail: string) {
-  const [request] = await sql<PrivacyRequestRecord[]>`
-    select
-      id,
-      organization_id as "organizationId",
-      status,
-      requester_name as "requesterName",
-      requester_email as "requesterEmail",
-      state_of_residence as "stateOfResidence",
-      application_id as "applicationId",
-      details,
-      verification_token_hash as "verificationTokenHash",
-      verified_at as "verifiedAt",
-      completed_at as "completedAt",
-      resolution_notes as "resolutionNotes"
-    from privacy_request
-    where requester_email = ${requesterEmail}
-    order by created_at desc
-    limit 1
-  `
-
-  return request ?? null
-}
-
-async function lookupCandidateApplication(sql: Sql, requesterEmail: string) {
-  const [record] = await sql<CandidateApplicationRecord[]>`
-    select
-      c.id as "candidateId",
-      a.id as "applicationId",
-      c.organization_id as "organizationId"
-    from candidate c
-    join application a on a.candidate_id = c.id and a.organization_id = c.organization_id
-    where c.email = ${requesterEmail}
-    order by a.created_at desc
-    limit 1
-  `
-
-  return record ?? null
-}
-
-async function countCandidateRows(sql: Sql, candidateId: string) {
-  const [row] = await sql<{ count: number }[]>`
-    select count(*)::int as count
-    from candidate
-    where id = ${candidateId}
-  `
-  return row?.count ?? 0
-}
-
-async function countApplicationRows(sql: Sql, applicationId: string) {
-  const [row] = await sql<{ count: number }[]>`
-    select count(*)::int as count
-    from application
-    where id = ${applicationId}
-  `
-  return row?.count ?? 0
-}
-
-async function countPrivacyAuditRows(sql: Sql, organizationId: string, requestId: string) {
-  const [row] = await sql<{ count: number }[]>`
-    select count(*)::int as count
-    from activity_log
-    where organization_id = ${organizationId}
-      and resource_type = 'privacy_request'
-      and resource_id = ${requestId}
-      and action = 'deleted'
-  `
-  return row?.count ?? 0
-}
+import {
+  assertE2eDatabaseUrl,
+  countApplicationRows,
+  countCandidateRows,
+  countPrivacyAuditRows,
+  lookupCandidateApplication,
+  lookupPrivacyRequest,
+} from '../helpers/db'
 
 function extractVerifyUrl(email: CapturedEmail) {
   const content = `${email.text}\n${email.html}`
@@ -146,16 +61,11 @@ async function signUpAndCreateOrganization(page: Page, id: string) {
 
 test.describe('Privacy request fake mail', () => {
   test('verifies deletion request persistence, fake-mail verification, and confirmation', async ({ page }, testInfo) => {
-    const capturePath = process.env.FACTORY_EMAIL_CAPTURE_PATH
-    expect(capturePath, 'FACTORY_EMAIL_CAPTURE_PATH must be set for privacy request E2E').toBeTruthy()
     expect(process.env.FACTORY_EMAIL_TEST_MODE, 'E2E mail must use capture mode, not a real provider').toBe('capture')
-    expect(process.env.DATABASE_URL, 'DATABASE_URL is required for privacy request e2e coverage').toBeTruthy()
+    assertE2eDatabaseUrl('privacy request e2e coverage')
+    const capturePath = await setupCaptureFile('FACTORY_EMAIL_CAPTURE_PATH', 'privacy request E2E')
 
-    await rm(capturePath!, { force: true })
-    const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-
-    try {
-      const id = `${Date.now()}-${testInfo.workerIndex}-${Math.random().toString(36).slice(2)}`
+    const id = `${Date.now()}-${testInfo.workerIndex}-${Math.random().toString(36).slice(2)}`
       const requester = {
         name: `Privacy Requester ${id}`,
         email: `privacy.requester.${id}@example.com`,
@@ -184,80 +94,72 @@ test.describe('Privacy request fake mail', () => {
       expect(submitResponse.status()).toBe(202)
       await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible()
 
-      await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
-        message: 'privacy request should capture requester verification and internal alert emails',
-        timeout: 10_000,
-      }).toBeGreaterThanOrEqual(2)
+    await expect.poll(async () => (await readCapturedEmails(capturePath)).length, {
+      message: 'privacy request should capture requester verification and internal alert emails',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(2)
 
-      const request = await lookupPrivacyRequest(sql, requester.email)
-      expect(request, 'privacy request should be persisted').toBeTruthy()
-      expect(request).toMatchObject({
-        status: 'submitted',
-        requesterName: requester.name,
-        requesterEmail: requester.email,
-        stateOfResidence: requester.state,
-        verifiedAt: null,
-      })
-      expect(request?.details).toContain(requester.context)
-      expect(request?.details).toContain(requester.details)
-      expect(request?.verificationTokenHash).toMatch(/^[a-f0-9]{64}$/)
+    const request = await lookupPrivacyRequest(requester.email)
+    expect(request, 'privacy request should be persisted').toBeTruthy()
+    expect(request).toMatchObject({
+      status: 'submitted',
+      requesterName: requester.name,
+      requesterEmail: requester.email,
+      stateOfResidence: requester.state,
+      verifiedAt: null,
+    })
+    expect(request?.details).toContain(requester.context)
+    expect(request?.details).toContain(requester.details)
+    expect(request?.verificationTokenHash).toMatch(/^[a-f0-9]{64}$/)
 
-      const capturedEmails = await readCapturedEmails(capturePath!)
-      const verificationEmail = capturedEmails.find((email) => email.subject === 'Verify your deletion request — Factory Careers')
-      expect(verificationEmail, 'requester verification email should be captured').toBeTruthy()
-      expect(verificationEmail?.renderError, 'requester verification email should render successfully').toBeUndefined()
-      expect(verificationEmail?.to).toContain(requester.email)
-      expect(verificationEmail?.text).toContain(requester.name)
-      expect(verificationEmail?.text).toContain('Verify your deletion request')
+    const capturedEmails = await readCapturedEmails(capturePath)
+    const verificationEmail = capturedEmails.find((email) => email.subject === 'Verify your deletion request — Factory Careers')
+    expect(verificationEmail, 'requester verification email should be captured').toBeTruthy()
+    expect(verificationEmail?.renderError, 'requester verification email should render successfully').toBeUndefined()
+    expect(verificationEmail?.to).toContain(requester.email)
+    expect(verificationEmail?.text).toContain(requester.name)
+    expect(verificationEmail?.text).toContain('Verify your deletion request')
 
-      const verifyUrl = extractVerifyUrl(verificationEmail!)
-      expect(verifyUrl, 'verification email should contain a local verification URL').toContain('/api/privacy-requests/verify?token=')
-      expect(verifyUrl).not.toContain(request.verificationTokenHash)
-      expect(verifyUrl).not.toContain('thefactoryhq.com')
+    const verifyUrl = extractVerifyUrl(verificationEmail!)
+    expect(verifyUrl, 'verification email should contain a local verification URL').toContain('/api/privacy-requests/verify?token=')
+    expect(verifyUrl).not.toContain(request!.verificationTokenHash)
+    expect(verifyUrl).not.toContain('thefactoryhq.com')
 
-      const internalAlert = capturedEmails.find((email) => email.subject === `Privacy deletion request: ${requester.email}`)
-      expect(internalAlert, 'privacy-team alert email should be captured').toBeTruthy()
-      expect(internalAlert?.renderError, 'privacy-team alert email should render successfully').toBeUndefined()
-      expect(internalAlert?.to).toContain(privacyInbox)
-      expect(internalAlert?.text).toContain(requester.name)
-      expect(internalAlert?.text).toContain(requester.email)
-      expect(internalAlert?.text).toContain(requester.state)
+    const internalAlert = capturedEmails.find((email) => email.subject === `Privacy deletion request: ${requester.email}`)
+    expect(internalAlert, 'privacy-team alert email should be captured').toBeTruthy()
+    expect(internalAlert?.renderError, 'privacy-team alert email should render successfully').toBeUndefined()
+    expect(internalAlert?.to).toContain(privacyInbox)
+    expect(internalAlert?.text).toContain(requester.name)
+    expect(internalAlert?.text).toContain(requester.email)
+    expect(internalAlert?.text).toContain(requester.state)
 
-      const verifyResponse = await page.request.get(verifyUrl)
-      expect(verifyResponse.status()).toBe(200)
-      await expect.poll(async () => (await lookupPrivacyRequest(sql, requester.email))?.status, {
-        message: 'privacy request should move to verified after opening the verification URL',
-        timeout: 10_000,
-      }).toBe('verified')
+    const verifyResponse = await page.request.get(verifyUrl)
+    expect(verifyResponse.status()).toBe(200)
+    await expect.poll(async () => (await lookupPrivacyRequest(requester.email))?.status, {
+      message: 'privacy request should move to verified after opening the verification URL',
+      timeout: 10_000,
+    }).toBe('verified')
 
-      const verifiedRequest = await lookupPrivacyRequest(sql, requester.email)
-      expect(verifiedRequest?.verifiedAt).toBeTruthy()
+    const verifiedRequest = await lookupPrivacyRequest(requester.email)
+    expect(verifiedRequest?.verifiedAt).toBeTruthy()
 
-      await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
-        message: 'privacy verification should capture confirmation email',
-        timeout: 10_000,
-      }).toBeGreaterThanOrEqual(3)
+    await expect.poll(async () => (await readCapturedEmails(capturePath)).length, {
+      message: 'privacy verification should capture confirmation email',
+      timeout: 10_000,
+    }).toBeGreaterThanOrEqual(3)
 
-      const confirmationEmail = (await readCapturedEmails(capturePath!))
-        .find((email) => email.subject === 'Deletion request verified — Factory Careers')
-      expect(confirmationEmail, 'requester confirmation email should be captured').toBeTruthy()
-      expect(confirmationEmail?.renderError, 'requester confirmation email should render successfully').toBeUndefined()
-      expect(confirmationEmail?.to).toContain(requester.email)
-      expect(confirmationEmail?.text).toContain('Request verified')
-    }
-    finally {
-      await sql.end()
-    }
+    const confirmationEmail = (await readCapturedEmails(capturePath))
+      .find((email) => email.subject === 'Deletion request verified — Factory Careers')
+    expect(confirmationEmail, 'requester confirmation email should be captured').toBeTruthy()
+    expect(confirmationEmail?.renderError, 'requester confirmation email should render successfully').toBeUndefined()
+    expect(confirmationEmail?.to).toContain(requester.email)
+    expect(confirmationEmail?.text).toContain('Request verified')
   })
 
   test('fulfills a verified deletion request from the dashboard and removes matched applicant data', async ({ authenticatedPage, browser }, testInfo) => {
-    const capturePath = process.env.FACTORY_EMAIL_CAPTURE_PATH
-    expect(capturePath, 'FACTORY_EMAIL_CAPTURE_PATH must be set for privacy request E2E').toBeTruthy()
     expect(process.env.FACTORY_EMAIL_TEST_MODE, 'E2E mail must use capture mode, not a real provider').toBe('capture')
-    expect(process.env.DATABASE_URL, 'DATABASE_URL is required for privacy request e2e coverage').toBeTruthy()
-
-    await rm(capturePath!, { force: true })
-    const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
+    assertE2eDatabaseUrl('privacy request e2e coverage')
+    const capturePath = await setupCaptureFile('FACTORY_EMAIL_CAPTURE_PATH', 'privacy request E2E')
     const page = authenticatedPage
     const id = `${Date.now()}-${testInfo.workerIndex}-${Math.random().toString(36).slice(2)}`
     const requester = {
@@ -269,8 +171,7 @@ test.describe('Privacy request fake mail', () => {
       applicationState: 'CA',
     }
 
-    try {
-      const createJobResponse = await page.request.post('/api/jobs', {
+    const createJobResponse = await page.request.post('/api/jobs', {
         data: {
           title: `Privacy Fulfillment Role ${id}`,
           description: 'Role used to verify privacy request fulfillment removes applicant data.',
@@ -304,7 +205,7 @@ test.describe('Privacy request fake mail', () => {
       })
       expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
 
-      const candidateApplication = await lookupCandidateApplication(sql, requester.email)
+    const candidateApplication = await lookupCandidateApplication(requester.email)
       expect(candidateApplication, 'candidate/application fixture should be persisted').toBeTruthy()
 
       const privacyResponse = await page.request.post('/api/privacy-requests', {
@@ -319,12 +220,12 @@ test.describe('Privacy request fake mail', () => {
       })
       expect(privacyResponse.status(), `Privacy request API returned ${privacyResponse.status()}`).toBe(202)
 
-      await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+    await expect.poll(async () => (await readCapturedEmails(capturePath)).length, {
         message: 'privacy request should capture verification email',
         timeout: 10_000,
       }).toBeGreaterThanOrEqual(1)
 
-      const verificationEmail = (await readCapturedEmails(capturePath!))
+    const verificationEmail = (await readCapturedEmails(capturePath))
         .find((email) => email.subject === 'Verify your deletion request — Factory Careers')
       expect(verificationEmail, 'requester verification email should be captured').toBeTruthy()
       const verifyUrl = extractVerifyUrl(verificationEmail!)
@@ -333,12 +234,12 @@ test.describe('Privacy request fake mail', () => {
 
       const verifyResponse = await page.request.get(verifyUrl)
       expect(verifyResponse.status()).toBe(200)
-      await expect.poll(async () => (await lookupPrivacyRequest(sql, requester.email))?.status, {
+    await expect.poll(async () => (await lookupPrivacyRequest(requester.email))?.status, {
         message: 'privacy request should move to verified before dashboard fulfillment',
         timeout: 10_000,
       }).toBe('verified')
 
-      const verifiedRequest = await lookupPrivacyRequest(sql, requester.email)
+    const verifiedRequest = await lookupPrivacyRequest(requester.email)
       expect(verifiedRequest).toMatchObject({
         organizationId: candidateApplication!.organizationId,
         applicationId: candidateApplication!.applicationId,
@@ -385,16 +286,16 @@ test.describe('Privacy request fake mail', () => {
       await expect(page.getByText('completed').first()).toBeVisible()
       await expect(page.getByText('No candidates match this verified email in the active organization.')).toBeVisible()
 
-      await expect.poll(() => countCandidateRows(sql, candidateApplication!.candidateId), {
+    await expect.poll(() => countCandidateRows(candidateApplication!.candidateId), {
         message: 'fulfillment should delete matched candidate personal data',
         timeout: 10_000,
       }).toBe(0)
-      await expect.poll(() => countApplicationRows(sql, candidateApplication!.applicationId), {
+    await expect.poll(() => countApplicationRows(candidateApplication!.applicationId), {
         message: 'fulfillment should cascade-delete matched application data',
         timeout: 10_000,
       }).toBe(0)
 
-      const completedRequest = await lookupPrivacyRequest(sql, requester.email)
+    const completedRequest = await lookupPrivacyRequest(requester.email)
       expect(completedRequest).toMatchObject({
         id: verifiedRequest!.id,
         status: 'completed',
@@ -402,13 +303,9 @@ test.describe('Privacy request fake mail', () => {
       })
       expect(completedRequest?.completedAt).toBeTruthy()
       expect(completedRequest?.resolutionNotes).toContain(requester.email)
-      await expect.poll(() => countPrivacyAuditRows(sql, candidateApplication!.organizationId, verifiedRequest!.id), {
+    await expect.poll(() => countPrivacyAuditRows(candidateApplication!.organizationId, verifiedRequest!.id), {
         message: 'privacy fulfillment should preserve an audit trail',
         timeout: 10_000,
       }).toBeGreaterThanOrEqual(1)
-    }
-    finally {
-      await sql.end()
-    }
   })
 })

--- a/e2e/critical-flows/rbac-role-permissions.spec.ts
+++ b/e2e/critical-flows/rbac-role-permissions.spec.ts
@@ -1,35 +1,12 @@
-import { randomUUID } from 'node:crypto'
 import { type Browser, type Page } from '@playwright/test'
-import postgres from 'postgres'
 import { test, expect } from '../fixtures'
+import { grantOrganizationRole, lookupMembership } from '../helpers/db'
 
 interface SignedInOrg {
   page: Page
   userId: string
   organizationId: string
   close: () => Promise<void>
-}
-
-async function lookupMembership(email: string, organizationName: string) {
-  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for RBAC e2e membership lookup').toBeTruthy()
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-
-  try {
-    const [membership] = await sql<{ userId: string, organizationId: string }[]>`
-      select u.id as "userId", o.id as "organizationId"
-      from "user" u
-      inner join "member" m on m."user_id" = u.id
-      inner join "organization" o on o.id = m."organization_id"
-      where u.email = ${email} and o.name = ${organizationName}
-      limit 1
-    `
-
-    expect(membership, `expected ${email} to belong to ${organizationName}`).toBeTruthy()
-    return membership
-  }
-  finally {
-    await sql.end()
-  }
 }
 
 async function signUpWithOrg(browser: Browser, label: string): Promise<SignedInOrg> {
@@ -91,35 +68,6 @@ async function signUpWithOrg(browser: Browser, label: string): Promise<SignedInO
     userId: membership.userId,
     organizationId: membership.organizationId,
     close: () => context.close(),
-  }
-}
-
-async function grantOrganizationRole(userId: string, organizationId: string, role: 'admin' | 'member') {
-  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for RBAC role grant').toBeTruthy()
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-
-  try {
-    await sql.begin(async (tx) => {
-      const [membership] = await tx<{ id: string }[]>`
-        insert into "member" ("id", "user_id", "organization_id", "role")
-        values (${randomUUID()}, ${userId}, ${organizationId}, ${role})
-        on conflict ("user_id", "organization_id")
-        do update set "role" = ${role}
-        returning "id"
-      `
-      expect(membership?.id, `expected ${role} membership to exist after grant`).toBeTruthy()
-
-      const updatedSessions = await tx<{ id: string }[]>`
-        update "session"
-        set "active_organization_id" = ${organizationId}, "updated_at" = now()
-        where "user_id" = ${userId}
-        returning "id"
-      `
-      expect(updatedSessions.length, 'expected role grant to update an active session').toBeGreaterThan(0)
-    })
-  }
-  finally {
-    await sql.end()
   }
 }
 

--- a/e2e/helpers/captured-emails.ts
+++ b/e2e/helpers/captured-emails.ts
@@ -1,37 +1,14 @@
-import { readFile } from "node:fs/promises";
+import { readJsonlCapture } from './captured-jsonl'
 
 export type CapturedEmail = {
-  from?: string;
-  to: string[];
-  subject: string;
-  html: string;
-  text: string;
-  renderError?: string;
-};
+  from?: string
+  to: string[]
+  subject: string
+  html: string
+  text: string
+  renderError?: string
+}
 
 export async function readCapturedEmails(capturePath: string): Promise<CapturedEmail[]> {
-  try {
-    const contents = await readFile(capturePath, "utf8");
-    const lines = contents
-      .split("\n")
-      .filter(Boolean);
-
-    return lines.flatMap((line, index) => {
-      try {
-        return [JSON.parse(line) as CapturedEmail];
-      } catch {
-        if (index === lines.length - 1) {
-          return [];
-        }
-
-        throw error;
-      }
-    });
-  } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      return [];
-    }
-
-    throw error;
-  }
+  return readJsonlCapture<CapturedEmail>(capturePath)
 }

--- a/e2e/helpers/captured-jsonl.ts
+++ b/e2e/helpers/captured-jsonl.ts
@@ -1,0 +1,43 @@
+import { readFile, rm } from 'node:fs/promises'
+
+export async function readJsonlCapture<T>(
+  path: string,
+  filter?: (entry: T) => boolean,
+): Promise<T[]> {
+  try {
+    const contents = await readFile(path, 'utf8')
+    const lines = contents.split('\n').filter(Boolean)
+    const entries = lines.flatMap((line, index) => {
+      try {
+        return [JSON.parse(line) as T]
+      }
+      catch (error) {
+        if (index === lines.length - 1) {
+          return []
+        }
+
+        throw error
+      }
+    })
+
+    return filter ? entries.filter(filter) : entries
+  }
+  catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return []
+    }
+
+    throw error
+  }
+}
+
+export async function setupCaptureFile(envVar: string, label?: string): Promise<string> {
+  const { expect } = await import('@playwright/test')
+  const capturePath = process.env[envVar]
+  expect(
+    capturePath,
+    `${envVar} must be set${label ? ` for ${label}` : ''}`,
+  ).toBeTruthy()
+  await rm(capturePath!, { force: true })
+  return capturePath!
+}

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -1,0 +1,424 @@
+import { randomUUID } from 'node:crypto'
+import { expect } from '@playwright/test'
+import postgres, { type Sql } from 'postgres'
+
+export type MembershipLookup = {
+  userId: string
+  memberId: string
+  organizationId: string
+}
+
+export type MemberRoleLookup = {
+  id: string
+  role: string
+}
+
+export type JoinRequestStatusLookup = {
+  status: string
+  reviewedAt: Date | null
+}
+
+export type ApplicationLookup = {
+  applicationId: string
+  candidateId: string
+  organizationId: string
+}
+
+export type PrivacyRequestRecord = {
+  id: string
+  organizationId: string | null
+  status: string
+  requesterName: string
+  requesterEmail: string
+  stateOfResidence: string
+  applicationId: string | null
+  details: string | null
+  verificationTokenHash: string
+  verifiedAt: Date | null
+  completedAt: Date | null
+  resolutionNotes: string | null
+}
+
+export type CandidateApplicationRecord = {
+  candidateId: string
+  applicationId: string
+  organizationId: string
+}
+
+export function assertE2eDatabaseUrl(label: string): string {
+  const databaseUrl = process.env.DATABASE_URL
+  expect(databaseUrl, `DATABASE_URL is required for ${label}`).toBeTruthy()
+  return databaseUrl!
+}
+
+export function createE2eDb(label: string): Sql {
+  return postgres(assertE2eDatabaseUrl(label), { max: 1 })
+}
+
+export async function closeE2eDb(sql: Sql): Promise<void> {
+  await sql.end()
+}
+
+export async function withE2eDb<T>(label: string, fn: (sql: Sql) => Promise<T>): Promise<T> {
+  const sql = createE2eDb(label)
+  try {
+    return await fn(sql)
+  }
+  finally {
+    await closeE2eDb(sql)
+  }
+}
+
+export async function lookupMembership(email: string, organizationName: string): Promise<MembershipLookup> {
+  return withE2eDb('membership lookup e2e coverage', async (sql) => {
+    const [membership] = await sql<MembershipLookup[]>`
+      select
+        u.id as "userId",
+        m.id as "memberId",
+        o.id as "organizationId"
+      from "user" u
+      inner join "member" m on m."user_id" = u.id
+      inner join "organization" o on o.id = m."organization_id"
+      where u.email = ${email} and o.name = ${organizationName}
+      limit 1
+    `
+
+    expect(membership, `expected ${email} to belong to ${organizationName}`).toBeTruthy()
+    return membership!
+  })
+}
+
+export async function lookupMemberByEmail(
+  email: string,
+  organizationId: string,
+): Promise<MemberRoleLookup | undefined> {
+  return withE2eDb('member lookup e2e coverage', async (sql) => {
+    const [member] = await sql<MemberRoleLookup[]>`
+      select m.id, m.role
+      from "member" m
+      inner join "user" u on u.id = m."user_id"
+      where u.email = ${email} and m."organization_id" = ${organizationId}
+      limit 1
+    `
+    return member
+  })
+}
+
+export async function lookupJoinRequestStatus(requestId: string): Promise<JoinRequestStatusLookup | undefined> {
+  return withE2eDb('join-request lookup e2e coverage', async (sql) => {
+    const [request] = await sql<JoinRequestStatusLookup[]>`
+      select status, "reviewed_at" as "reviewedAt"
+      from "join_request"
+      where id = ${requestId}
+      limit 1
+    `
+    return request
+  })
+}
+
+export async function lookupApplicationByEmail(email: string): Promise<ApplicationLookup> {
+  return withE2eDb('application lookup e2e coverage', async (sql) => {
+    const [row] = await sql<ApplicationLookup[]>`
+      select
+        a.id as "applicationId",
+        c.id as "candidateId",
+        a.organization_id as "organizationId"
+      from application a
+      inner join candidate c on c.id = a.candidate_id
+      where c.email = ${email}
+      order by a.created_at desc
+      limit 1
+    `
+
+    expect(row, `expected application for ${email}`).toBeTruthy()
+    return row!
+  })
+}
+
+export async function seedParsedResume(params: {
+  organizationId: string
+  candidateId: string
+  resumeText: string
+}) {
+  return withE2eDb('parsed resume seed e2e coverage', async (sql) => {
+    const documentId = randomUUID()
+
+    await sql`
+      insert into document (
+        id,
+        organization_id,
+        candidate_id,
+        type,
+        storage_key,
+        original_filename,
+        mime_type,
+        size_bytes,
+        parsed_content
+      )
+      values (
+        ${documentId},
+        ${params.organizationId},
+        ${params.candidateId},
+        'resume',
+        ${`${params.organizationId}/${params.candidateId}/${documentId}.txt`},
+        'deterministic-resume.txt',
+        'text/plain',
+        ${params.resumeText.length},
+        ${sql.json({ text: params.resumeText })}
+      )
+    `
+  })
+}
+
+export async function seedCrossTenantSentinel(sentinel: string) {
+  return withE2eDb('cross-tenant sentinel seed e2e coverage', async (sql) => {
+    const orgId = randomUUID()
+    const candidateId = randomUUID()
+    const jobId = randomUUID()
+    const applicationId = randomUUID()
+    const documentId = randomUUID()
+
+    await sql.begin(async (tx) => {
+      await tx`
+        insert into organization (id, name, slug)
+        values (${orgId}, ${`Sentinel Org ${orgId.slice(0, 8)}`}, ${`sentinel-${orgId.slice(0, 8)}`})
+      `
+      await tx`
+        insert into job (id, organization_id, title, slug, description, status, active_from)
+        values (${jobId}, ${orgId}, 'Sentinel Role', ${`sentinel-role-${jobId.slice(0, 8)}`}, ${sentinel}, 'open', now())
+      `
+      await tx`
+        insert into candidate (id, organization_id, first_name, last_name, email)
+        values (${candidateId}, ${orgId}, 'Cross', 'Tenant', ${`cross-tenant-${candidateId}@example.com`})
+      `
+      await tx`
+        insert into application (id, organization_id, candidate_id, job_id, cover_letter_text)
+        values (${applicationId}, ${orgId}, ${candidateId}, ${jobId}, ${sentinel})
+      `
+      await tx`
+        insert into document (
+          id,
+          organization_id,
+          candidate_id,
+          type,
+          storage_key,
+          original_filename,
+          mime_type,
+          size_bytes,
+          parsed_content
+        )
+        values (
+          ${documentId},
+          ${orgId},
+          ${candidateId},
+          'resume',
+          ${`${orgId}/${candidateId}/${documentId}.txt`},
+          'sentinel-resume.txt',
+          'text/plain',
+          ${sentinel.length},
+          ${tx.json({ text: sentinel })}
+        )
+      `
+    })
+  })
+}
+
+export async function grantOrganizationRole(
+  userId: string,
+  organizationId: string,
+  role: 'admin' | 'member',
+): Promise<string> {
+  return withE2eDb('organization role grant e2e coverage', async (sql) => {
+    const result = await sql.begin(async (tx) => {
+      const [membership] = await tx<{ id: string }[]>`
+        insert into "member" ("id", "user_id", "organization_id", "role")
+        values (${randomUUID()}, ${userId}, ${organizationId}, ${role})
+        on conflict ("user_id", "organization_id")
+        do update set "role" = ${role}
+        returning "id"
+      `
+
+      const updatedSessions = await tx<{ id: string }[]>`
+        update "session"
+        set "active_organization_id" = ${organizationId}, "updated_at" = now()
+        where "user_id" = ${userId}
+        returning "id"
+      `
+
+      return { membership, updatedSessions }
+    })
+
+    expect(result.updatedSessions.length, `expected an active session for ${userId}`).toBeGreaterThan(0)
+    expect(result.membership?.id, `expected ${role} membership to exist after grant`).toBeTruthy()
+    return result.membership!.id
+  })
+}
+
+export async function deleteMembership(userId: string, organizationId: string) {
+  return withE2eDb('stale-membership e2e coverage', async (sql) => {
+    await sql`delete from "member" where "user_id" = ${userId} and "organization_id" = ${organizationId}`
+  })
+}
+
+export async function expireInviteLink(linkId: string) {
+  return withE2eDb('invite-link e2e coverage', async (sql) => {
+    await sql`
+      update "invite_link"
+      set "expires_at" = now() - interval '1 hour'
+      where "id" = ${linkId}
+    `
+  })
+}
+
+export async function attributeApplicationSource(
+  organizationId: string,
+  applicationId: string,
+  trackingLinkId: string,
+) {
+  return withE2eDb('source-tracking e2e coverage', async (sql) => {
+    await sql.begin(async (tx) => {
+      await tx`
+        insert into "application_source" (
+          "id",
+          "organization_id",
+          "application_id",
+          "channel",
+          "tracking_link_id",
+          "utm_source",
+          "utm_medium",
+          "utm_campaign",
+          "referrer_domain"
+        )
+        values (
+          ${randomUUID()},
+          ${organizationId},
+          ${applicationId},
+          'linkedin',
+          ${trackingLinkId},
+          'linkedin',
+          'social',
+          'tenant-isolation',
+          'linkedin.com'
+        )
+      `
+
+      await tx`
+        update "tracking_link"
+        set "application_count" = "application_count" + 1
+        where "id" = ${trackingLinkId}
+      `
+    })
+  })
+}
+
+export async function insertSsoProvider(
+  organizationId: string,
+  userId: string,
+  providerId: string,
+): Promise<string> {
+  return withE2eDb('SSO provider e2e coverage', async (sql) => {
+    const id = randomUUID()
+
+    await sql`
+      insert into "sso_provider" (
+        "id",
+        "issuer",
+        "domain",
+        "oidc_config",
+        "user_id",
+        "provider_id",
+        "organization_id"
+      )
+      values (
+        ${id},
+        ${`https://idp-${providerId}.example.com`},
+        ${`${providerId}.example.com`},
+        '{}',
+        ${userId},
+        ${providerId},
+        ${organizationId}
+      )
+    `
+    return id
+  })
+}
+
+export async function lookupPrivacyRequest(requesterEmail: string): Promise<PrivacyRequestRecord | null> {
+  return withE2eDb('privacy request lookup e2e coverage', async (sql) => {
+    const [request] = await sql<PrivacyRequestRecord[]>`
+      select
+        id,
+        organization_id as "organizationId",
+        status,
+        requester_name as "requesterName",
+        requester_email as "requesterEmail",
+        state_of_residence as "stateOfResidence",
+        application_id as "applicationId",
+        details,
+        verification_token_hash as "verificationTokenHash",
+        verified_at as "verifiedAt",
+        completed_at as "completedAt",
+        resolution_notes as "resolutionNotes"
+      from privacy_request
+      where requester_email = ${requesterEmail}
+      order by created_at desc
+      limit 1
+    `
+
+    return request ?? null
+  })
+}
+
+export async function lookupCandidateApplication(requesterEmail: string): Promise<CandidateApplicationRecord | null> {
+  return withE2eDb('candidate application lookup e2e coverage', async (sql) => {
+    const [record] = await sql<CandidateApplicationRecord[]>`
+      select
+        c.id as "candidateId",
+        a.id as "applicationId",
+        c.organization_id as "organizationId"
+      from candidate c
+      join application a on a.candidate_id = c.id and a.organization_id = c.organization_id
+      where c.email = ${requesterEmail}
+      order by a.created_at desc
+      limit 1
+    `
+
+    return record ?? null
+  })
+}
+
+export async function countCandidateRows(candidateId: string): Promise<number> {
+  return withE2eDb('candidate row count e2e coverage', async (sql) => {
+    const [row] = await sql<{ count: number }[]>`
+      select count(*)::int as count
+      from candidate
+      where id = ${candidateId}
+    `
+    return row?.count ?? 0
+  })
+}
+
+export async function countApplicationRows(applicationId: string): Promise<number> {
+  return withE2eDb('application row count e2e coverage', async (sql) => {
+    const [row] = await sql<{ count: number }[]>`
+      select count(*)::int as count
+      from application
+      where id = ${applicationId}
+    `
+    return row?.count ?? 0
+  })
+}
+
+export async function countPrivacyAuditRows(organizationId: string, requestId: string): Promise<number> {
+  return withE2eDb('privacy audit row count e2e coverage', async (sql) => {
+    const [row] = await sql<{ count: number }[]>`
+      select count(*)::int as count
+      from activity_log
+      where organization_id = ${organizationId}
+        and resource_type = 'privacy_request'
+        and resource_id = ${requestId}
+        and action = 'deleted'
+    `
+    return row?.count ?? 0
+  })
+}

--- a/e2e/security/tenant-isolation.spec.ts
+++ b/e2e/security/tenant-isolation.spec.ts
@@ -1,8 +1,14 @@
-import { randomUUID } from 'node:crypto'
 import { type Browser, type Page } from '@playwright/test'
-import postgres from 'postgres'
 import { test, expect } from '../fixtures'
 import { VALID_FILE_CONFIGS } from '../fixtures/test-buffers'
+import {
+  attributeApplicationSource,
+  deleteMembership,
+  expireInviteLink,
+  grantOrganizationRole,
+  insertSsoProvider,
+  lookupMembership,
+} from '../helpers/db'
 
 interface SignedInOrg {
   page: Page
@@ -72,28 +78,6 @@ async function signUpWithOrg(browser: Browser, label: string): Promise<SignedInO
     memberId: membership.memberId,
     organizationId: membership.organizationId,
     close: () => context.close(),
-  }
-}
-
-async function lookupMembership(email: string, organizationName: string) {
-  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for membership lookup e2e coverage').toBeTruthy()
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-
-  try {
-    const [membership] = await sql<{ userId: string, memberId: string, organizationId: string }[]>`
-      select u.id as "userId", m.id as "memberId", o.id as "organizationId"
-      from "user" u
-      inner join "member" m on m."user_id" = u.id
-      inner join "organization" o on o.id = m."organization_id"
-      where u.email = ${email} and o.name = ${organizationName}
-      limit 1
-    `
-
-    expect(membership, `expected ${email} to belong to ${organizationName}`).toBeTruthy()
-    return membership
-  }
-  finally {
-    await sql.end()
   }
 }
 
@@ -246,147 +230,7 @@ async function expectStatus(response: { status: () => number }, allowedStatuses:
   expect(allowedStatuses, `unexpected response status ${response.status()}`).toContain(response.status())
 }
 
-async function deleteMembership(userId: string, organizationId: string) {
-  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for stale-membership e2e coverage').toBeTruthy()
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
 
-  try {
-    await sql`delete from "member" where "user_id" = ${userId} and "organization_id" = ${organizationId}`
-  }
-  finally {
-    await sql.end()
-  }
-}
-
-async function grantOrganizationRole(userId: string, organizationId: string, role: 'admin' | 'member'): Promise<string> {
-  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for member RBAC e2e coverage').toBeTruthy()
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-
-  try {
-    const result = await sql.begin(async (tx) => {
-      const [membership] = await tx<{ id: string }[]>`
-        insert into "member" ("id", "user_id", "organization_id", "role")
-        values (${randomUUID()}, ${userId}, ${organizationId}, ${role})
-        on conflict ("user_id", "organization_id")
-        do update set "role" = ${role}
-        returning "id"
-      `
-
-      const updatedSessions = await tx`
-        update "session"
-        set "active_organization_id" = ${organizationId}, "updated_at" = now()
-        where "user_id" = ${userId}
-        returning "id"
-      `
-
-      return { membership, updatedSessions }
-    })
-
-    const membershipId = result.membership?.id
-    expect(result.updatedSessions.length, `expected an active session for ${userId}`).toBeGreaterThan(0)
-    expect(membershipId, `expected membership for ${userId}`).toBeTruthy()
-    return membershipId!
-  }
-  finally {
-    await sql.end()
-  }
-}
-
-async function expireInviteLink(linkId: string) {
-  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for invite-link e2e coverage').toBeTruthy()
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-
-  try {
-    await sql`
-      update "invite_link"
-      set "expires_at" = now() - interval '1 hour'
-      where "id" = ${linkId}
-    `
-  }
-  finally {
-    await sql.end()
-  }
-}
-
-async function attributeApplicationSource(
-  organizationId: string,
-  applicationId: string,
-  trackingLinkId: string,
-) {
-  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for source-tracking e2e coverage').toBeTruthy()
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-
-  try {
-    await sql.begin(async (tx) => {
-      await tx`
-        insert into "application_source" (
-          "id",
-          "organization_id",
-          "application_id",
-          "channel",
-          "tracking_link_id",
-          "utm_source",
-          "utm_medium",
-          "utm_campaign",
-          "referrer_domain"
-        )
-        values (
-          ${randomUUID()},
-          ${organizationId},
-          ${applicationId},
-          'linkedin',
-          ${trackingLinkId},
-          'linkedin',
-          'social',
-          'tenant-isolation',
-          'linkedin.com'
-        )
-      `
-
-      await tx`
-        update "tracking_link"
-        set "application_count" = "application_count" + 1
-        where "id" = ${trackingLinkId}
-      `
-    })
-  }
-  finally {
-    await sql.end()
-  }
-}
-
-async function insertSsoProvider(organizationId: string, userId: string, providerId: string) {
-  expect(process.env.DATABASE_URL, 'DATABASE_URL is required for SSO provider e2e coverage').toBeTruthy()
-  const sql = postgres(process.env.DATABASE_URL!, { max: 1 })
-  const id = randomUUID()
-
-  try {
-    await sql`
-      insert into "sso_provider" (
-        "id",
-        "issuer",
-        "domain",
-        "oidc_config",
-        "user_id",
-        "provider_id",
-        "organization_id"
-      )
-      values (
-        ${id},
-        ${`https://idp-${providerId}.example.com`},
-        ${`${providerId}.example.com`},
-        '{}',
-        ${userId},
-        ${providerId},
-        ${organizationId}
-      )
-    `
-    return id
-  }
-  finally {
-    await sql.end()
-  }
-}
 
 test.describe('Security — tenant isolation and document access', () => {
   test('denies cross-organization direct resource and document access @security-core', async ({ browser }) => {

--- a/tests/unit/e2e-captured-jsonl.test.ts
+++ b/tests/unit/e2e-captured-jsonl.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { readJsonlCapture } from '../../e2e/helpers/captured-jsonl'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('E2E captured JSONL helpers', () => {
+  it('exports shared JSONL capture helpers', () => {
+    const source = readProjectFile('e2e/helpers/captured-jsonl.ts')
+
+    for (const exportName of ['readJsonlCapture', 'setupCaptureFile']) {
+      expect(source, exportName).toContain(exportName)
+    }
+  })
+
+  it('reads typed JSONL entries and tolerates a trailing partial line', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'factory-careers-jsonl-'))
+    const capturePath = join(dir, 'capture.jsonl')
+
+    try {
+      await writeFile(capturePath, [
+        JSON.stringify({ schemaName: 'CandidateScoring', model: 'factory-e2e' }),
+        '{"schemaName":"ChatbotChat","model":"factory-e2e-chatbot"',
+      ].join('\n'), 'utf8')
+
+      const entries = await readJsonlCapture<{ schemaName: string, model: string }>(
+        capturePath,
+        entry => entry.schemaName === 'CandidateScoring',
+      )
+
+      expect(entries).toEqual([{ schemaName: 'CandidateScoring', model: 'factory-e2e' }])
+    }
+    finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns an empty array when the capture file does not exist', async () => {
+    const entries = await readJsonlCapture(join(tmpdir(), 'missing-capture.jsonl'))
+    expect(entries).toEqual([])
+  })
+
+  it('is adopted by email, AI, and chatbot specs', () => {
+    const migratedSpecs = [
+      'e2e/helpers/captured-emails.ts',
+      'e2e/critical-flows/ai-candidate-review.spec.ts',
+      'e2e/critical-flows/chatbot-conversations.spec.ts',
+    ]
+
+    for (const spec of migratedSpecs) {
+      const source = readProjectFile(spec)
+      expect(source, spec).toContain('captured-jsonl')
+      expect(source, spec).not.toContain('readFile(capturePath')
+    }
+
+    const capturedEmails = readProjectFile('e2e/helpers/captured-emails.ts')
+    expect(capturedEmails).toContain('readJsonlCapture<CapturedEmail>')
+  })
+})

--- a/tests/unit/e2e-db-helpers.test.ts
+++ b/tests/unit/e2e-db-helpers.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('E2E database helpers', () => {
+  it('exports shared Postgres lifecycle and lookup helpers', () => {
+    const source = readProjectFile('e2e/helpers/db.ts')
+
+    for (const exportName of [
+      'assertE2eDatabaseUrl',
+      'createE2eDb',
+      'closeE2eDb',
+      'withE2eDb',
+      'lookupMembership',
+      'lookupMemberByEmail',
+      'lookupJoinRequestStatus',
+      'lookupApplicationByEmail',
+      'seedParsedResume',
+      'seedCrossTenantSentinel',
+      'grantOrganizationRole',
+      'deleteMembership',
+      'expireInviteLink',
+      'attributeApplicationSource',
+      'insertSsoProvider',
+      'lookupPrivacyRequest',
+      'lookupCandidateApplication',
+      'countCandidateRows',
+      'countApplicationRows',
+      'countPrivacyAuditRows',
+    ]) {
+      expect(source, exportName).toContain(exportName)
+    }
+  })
+
+  it('is adopted by migrated specs with local postgres helpers removed', () => {
+    const migratedSpecs = [
+      'e2e/critical-flows/org-admin-membership.spec.ts',
+      'e2e/critical-flows/rbac-role-permissions.spec.ts',
+      'e2e/critical-flows/ai-candidate-review.spec.ts',
+      'e2e/security/tenant-isolation.spec.ts',
+      'e2e/critical-flows/privacy-request-fake-mail.spec.ts',
+    ]
+
+    for (const spec of migratedSpecs) {
+      const source = readProjectFile(spec)
+      expect(source, spec).toContain('../helpers/db')
+      expect(source, spec).not.toContain("import postgres from 'postgres'")
+      expect(source, spec).not.toContain('async function lookupMembership(')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Epic 8 PR1: consolidate duplicated E2E JSONL capture readers and direct Postgres lookups into shared helpers.

### Added
- `e2e/helpers/captured-jsonl.ts`
  - `readJsonlCapture<T>(path, filter?)` — shared read/split/parse/ENOENT handling (tolerates trailing partial lines)
  - `setupCaptureFile(envVar, label?)` — asserts env var is set and clears the capture file
- `e2e/helpers/db.ts`
  - Shared connection lifecycle: `assertE2eDatabaseUrl`, `createE2eDb`, `closeE2eDb`, `withE2eDb`
  - Typed lookup/seed helpers for membership, applications, privacy requests, RBAC grants, tenant-isolation fixtures

### Migrated
- **JSONL:** `captured-emails.ts`, `ai-candidate-review.spec.ts`, `chatbot-conversations.spec.ts`, `ai-config-lifecycle.spec.ts`
- **DB:** `org-admin-membership.spec.ts`, `rbac-role-permissions.spec.ts`, `ai-candidate-review.spec.ts`, `tenant-isolation.spec.ts`, `privacy-request-fake-mail.spec.ts`

### Tests
- `tests/unit/e2e-captured-jsonl.test.ts`
- `tests/unit/e2e-db-helpers.test.ts`

## Verification
```bash
npx vitest run tests/unit/e2e-captured-jsonl.test.ts tests/unit/e2e-db-helpers.test.ts tests/unit/e2e-harness-contract.test.ts
npm run test:unit   # 954 passed (full suite after nuxt prepare)
```

`npm run test:e2e:smoke` was not run locally in this worktree (missing `DATABASE_URL` / local `.env`).

Closes #240
Closes #241
Part of #253