### PR TITLE
refactor: Epic 9 CLI factory — email-templates

### DIFF
--- a/packages/careers-cli/src/commands/email-templates.ts
+++ b/packages/careers-cli/src/commands/email-templates.ts
@@ -1,0 +1,47 @@
+import type { Command } from 'commander'
+import { registerJsonCommand } from '../commandFactories'
+import type { CliRuntime } from '../cliRuntime'
+
+export function registerEmailTemplatesCommands(program: Command, runtime: CliRuntime): Command {
+  const emailTemplates = program
+    .command('email-templates')
+    .description('Manage email templates')
+
+  registerJsonCommand(runtime, emailTemplates, {
+    name: 'list',
+    description: 'List email templates',
+    method: 'GET',
+    path: '/api/email-templates',
+  })
+
+  registerJsonCommand(runtime, emailTemplates, {
+    name: 'create',
+    description: 'Create an email template',
+    method: 'POST',
+    path: '/api/email-templates',
+    mutation: true,
+    stdin: true,
+  })
+
+  registerJsonCommand(runtime, emailTemplates, {
+    name: 'update',
+    description: 'Update an email template',
+    method: 'PATCH',
+    path: (id) => `/api/email-templates/${encodeURIComponent(id)}`,
+    args: [{ name: 'id', description: 'Email template ID' }],
+    mutation: true,
+    stdin: true,
+  })
+
+  registerJsonCommand(runtime, emailTemplates, {
+    name: 'delete',
+    description: 'Delete an email template',
+    method: 'DELETE',
+    path: (id) => `/api/email-templates/${encodeURIComponent(id)}`,
+    args: [{ name: 'id', description: 'Email template ID' }],
+    mutation: true,
+    deleteAck: true,
+  })
+
+  return emailTemplates
+}

--- a/packages/careers-cli/src/program.ts
+++ b/packages/careers-cli/src/program.ts
@@ -21,6 +21,7 @@ import {
   type StdinOptions,
 } from './cliRuntime'
 import { registerCommentsCommands } from './commands/comments'
+import { registerEmailTemplatesCommands } from './commands/email-templates'
 import { removeProfileToken, saveProfile } from './config'
 import { normalizeCliError } from './errors'
 import {
@@ -964,6 +965,7 @@ export function createProgram(io: CliIo = {}): Command {
   })
 
   registerCommentsCommands(program, runtime)
+  registerEmailTemplatesCommands(program, runtime)
 
   const feedback = program
     .command('feedback')
@@ -1208,89 +1210,6 @@ export function createProgram(io: CliIo = {}): Command {
     })
 
     outputResult(io, globals, result)
-  })
-
-  const emailTemplates = program
-    .command('email-templates')
-    .description('Manage email templates')
-
-  addGlobalOptions(
-    emailTemplates
-      .command('list')
-      .description('List email templates'),
-  ).action(async (options: GlobalOptions, command: Command) => {
-    const { globals, profile } = getContext(command, options)
-    const token = requireAuthenticatedProfile(profile)
-    const result = await requestJson<unknown>({
-      fetch: getFetch(io),
-      url: `${profile.baseUrl}/api/email-templates`,
-      method: 'GET',
-      token,
-    })
-
-    outputResult(io, globals, result)
-  })
-
-  addGlobalOptions(
-    emailTemplates
-      .command('create')
-      .description('Create an email template')
-      .option('--stdin', 'Read request body as JSON from stdin'),
-  ).action(async (options: StdinOptions, command: Command) => {
-    const { globals, profile } = getContext(command, options)
-    requireMutationConfirmation(globals)
-    const token = requireAuthenticatedProfile(profile)
-    const body = await readStdinJson(io, options.stdin)
-    const result = await requestJson<unknown>({
-      fetch: getFetch(io),
-      url: `${profile.baseUrl}/api/email-templates`,
-      method: 'POST',
-      token,
-      body,
-    })
-
-    outputResult(io, globals, result)
-  })
-
-  addGlobalOptions(
-    emailTemplates
-      .command('update')
-      .description('Update an email template')
-      .argument('<id>', 'Email template ID')
-      .option('--stdin', 'Read request body as JSON from stdin'),
-  ).action(async (id: string, options: StdinOptions, command: Command) => {
-    const { globals, profile } = getContext(command, options)
-    requireMutationConfirmation(globals)
-    const token = requireAuthenticatedProfile(profile)
-    const body = await readStdinJson(io, options.stdin)
-    const result = await requestJson<unknown>({
-      fetch: getFetch(io),
-      url: `${profile.baseUrl}/api/email-templates/${encodeURIComponent(id)}`,
-      method: 'PATCH',
-      token,
-      body,
-    })
-
-    outputResult(io, globals, result)
-  })
-
-  addGlobalOptions(
-    emailTemplates
-      .command('delete')
-      .description('Delete an email template')
-      .argument('<id>', 'Email template ID'),
-  ).action(async (id: string, options: GlobalOptions, command: Command) => {
-    const { globals, profile } = getContext(command, options)
-    requireMutationConfirmation(globals)
-    const token = requireAuthenticatedProfile(profile)
-    await requestJson<unknown>({
-      fetch: getFetch(io),
-      url: `${profile.baseUrl}/api/email-templates/${encodeURIComponent(id)}`,
-      method: 'DELETE',
-      token,
-    })
-
-    outputResult(io, globals, { deleted: true, id })
   })
 
   const interviews = program

--- a/tests/unit/cli-command-factories.test.ts
+++ b/tests/unit/cli-command-factories.test.ts
@@ -71,4 +71,22 @@ describe('CLI command factories', () => {
       code: 'CONFIRMATION_REQUIRED',
     })
   })
+
+  it('preserves email-templates delete confirmation behavior through migrated commands', async () => {
+    const dir = tempDir()
+    const configPath = join(dir, 'config.json')
+    writeAuthedConfig(configPath)
+    const stdout: string[] = []
+
+    const exitCode = await runCli(
+      ['email-templates', 'delete', 'tmpl_1', '--config', configPath, '--json'],
+      { stdout: (value) => stdout.push(value), stderr: () => {} },
+    )
+
+    expect(exitCode).toBe(1)
+    expect(JSON.parse(stdout[0])).toMatchObject({
+      status: 400,
+      code: 'CONFIRMATION_REQUIRED',
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Migrates `email-templates` list/create/update/delete to `registerJsonCommand`, following the `comments` factory pattern from Epic 9 PR1.
- Extracts handlers into `packages/careers-cli/src/commands/email-templates.ts` and wires registration from `program.ts`.
- Removes ~80 lines of duplicated inline handlers from `program.ts`.

## Type of change

- [x] Refactor

## Behavior preserved

- `--json`, `--stdin`, `--yes`, and mutation confirmation for create/update/delete
- Delete ack payload: `{ deleted: true, id }`
- API paths unchanged: `/api/email-templates` CRUD

## Validation

- [x] `npm run test:unit` — 166 files, 971 tests passed
- [x] `npm run preflight:cli-parity` — no CLI parity-sensitive surface changes
- [x] Added factory confirmation test for `email-templates delete`

## CLI parity

- [x] No portal/API workflow payload or route coverage changes
- [x] `docs/CLI.md` unchanged (surface unchanged)

## Epic 9 incremental PR

Follow-up to Epic 9 PR1 (#268 comments factory). Next CRUD families can migrate using the same pattern.