### PR TITLE
refactor: Epic 5 PR1 — extract application detail sub-panels (#227 / #250)

### DIFF
--- a/app/components/ApplicationDetailDrawer.vue
+++ b/app/components/ApplicationDetailDrawer.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
-import { User, Briefcase, Calendar, FileText, MessageSquare, Brain, Loader2 } from 'lucide-vue-next'
+import { User, Briefcase, Calendar } from 'lucide-vue-next'
 import {
   getApplicationTransitionActionLabel,
   getApplicationTransitionButtonClass,
 } from '~/utils/status-display'
 import { formatPhoneNumber } from '~/utils/phone-format'
-import { formatResponseValue } from '~/utils/application-response-format'
-import type { ScoringBand } from '~~/shared/scoring-bands'
 
 const props = defineProps<{
   applicationId: string
@@ -19,38 +17,21 @@ const emit = defineEmits<{
 const localePath = useLocalePath()
 
 const { application, status: fetchStatus, error, refresh, updateApplication } = useApplication(() => props.applicationId)
-const { isScoringApplication, scoreApplicationCandidate } = useApplicationScoring()
 const { formatCandidateName } = useOrgSettings()
 
-type ApplicationScoresResponse = {
-  scoreBand: ScoringBand | null
-  latestRun: {
-    id: string
-    summary: string | null
-  } | null
-}
-
-const { data: scoringData, refresh: refreshScoring } = useFetch<ApplicationScoresResponse>(
-  () => `/api/applications/${props.applicationId}/scores`,
-  {
-    key: `application-scores-${props.applicationId}`,
-    headers: useRequestHeaders(['cookie']),
-    watch: [() => props.applicationId],
-  }
-)
-
-const scoringSummary = computed(() => {
-  const summary = scoringData.value?.latestRun?.summary
-  return typeof summary === 'string' ? summary.trim() : ''
+const {
+  scoringData,
+  scoringSummary,
+  scoringSummaryFallback,
+  scoreBand,
+  isScoringApplication,
+  scoreCurrentApplication,
+} = useApplicationScoringPanel({
+  applicationId: () => props.applicationId,
+  application,
+  source: 'application_detail_drawer',
+  refreshApplication: false,
 })
-
-const scoringSummaryFallback = computed(() => {
-  if (application.value?.score != null) {
-    return 'No AI summary was stored for this score. Re-score to generate one.'
-  }
-  return 'Run analysis to generate an AI scoring summary.'
-})
-const scoreBand = computed(() => scoringData.value?.scoreBand ?? null)
 
 const showInterviewSidebar = ref(false)
 
@@ -59,25 +40,20 @@ const { allowedTransitions, isTransitioning, transitionToStatus } = useApplicati
   updateStatus: status => updateApplication({ status: status as any }),
 })
 
-const { isEditingNotes, notesInput, isSavingNotes, notesSaveStatus, notesTextarea, startEditNotes, saveNotes, autosaveNotes, finishEditNotes } = useEditableApplicationNotes({
+const {
+  isEditingNotes,
+  notesInput,
+  isSavingNotes,
+  notesSaveStatus,
+  startEditNotes,
+  saveNotes,
+  autosaveNotes,
+  finishEditNotes,
+} = useEditableApplicationNotes({
   application,
   focusOnEdit: true,
   save: notes => updateApplication({ notes }),
 })
-
-async function scoreCurrentApplication() {
-  if (!application.value) return
-  const result = await scoreApplicationCandidate(props.applicationId, {
-    refreshApplication: false,
-    jobId: application.value.job.id,
-    source: 'application_detail_drawer',
-  })
-  if (result && application.value) {
-    application.value.score = result.compositeScore
-  }
-  await refreshScoring()
-}
-
 </script>
 
 <template>
@@ -216,119 +192,33 @@ async function scoreCurrentApplication() {
               </div>
             </div>
 
-            <!-- Application scoring (matches full page layout) -->
-            <div class="border border-white/12 bg-white/[0.025] p-5">
-              <div class="mb-5 flex items-center justify-between">
-                <div class="flex items-center gap-2">
-                  <Brain class="size-4 text-surface-500 dark:text-surface-400" />
-                  <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-200">Scoring</h3>
-                </div>
-                <div class="flex items-center gap-2">
-                  <ScoringFeedbackControl
-                    :application-id="applicationId"
-                    :analysis-run-id="scoringData?.latestRun?.id ?? null"
-                  />
-                  <button
-                    type="button"
-                    :disabled="isScoringApplication"
-                    class="factory-button-cta factory-button-premium inline-flex h-8 min-h-8 cursor-pointer items-center justify-center gap-1.5 px-2.5 py-0 text-[11px] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                    @click="scoreCurrentApplication"
-                  >
-                    <Loader2 v-if="isScoringApplication" class="size-3 animate-spin" />
-                    <Brain v-else class="size-3" />
-                    {{ isScoringApplication ? 'Scoring...' : (application.score != null ? 'Re-score' : 'Run Analysis') }}
-                  </button>
-                </div>
-              </div>
+            <ApplicationScoringPanel
+              surface="drawer"
+              :application-id="applicationId"
+              :score="application.score"
+              :analysis-run-id="scoringData?.latestRun?.id ?? null"
+              :score-band="scoreBand"
+              :scoring-summary="scoringSummary"
+              :scoring-summary-fallback="scoringSummaryFallback"
+              :is-scoring="isScoringApplication"
+              show-score-band
+              @score="scoreCurrentApplication"
+            />
 
-              <dl class="grid gap-5 text-sm md:grid-cols-[8rem_minmax(0,1fr)]">
-                <div>
-                  <dt class="text-xs font-semibold uppercase tracking-[0.18em] text-surface-400">Score</dt>
-                  <dd class="mt-1 flex flex-wrap items-center gap-2">
-                    <span class="text-2xl font-semibold text-surface-900 dark:text-white">
-                      {{ application.score != null ? application.score : '—' }}
-                      <span v-if="application.score != null" class="ml-1 text-sm font-medium text-surface-400">
-                        pts
-                      </span>
-                    </span>
-                    <ScoringBandBadge :band="scoreBand" />
-                  </dd>
-                </div>
-                <div>
-                  <dt class="text-xs font-semibold uppercase tracking-[0.18em] text-surface-400">
-                    AI summary
-                  </dt>
-                  <dd
-                    v-if="scoringSummary"
-                    class="mt-1 max-w-3xl text-sm leading-6 text-surface-700 dark:text-surface-300"
-                  >
-                    {{ scoringSummary }}
-                  </dd>
-                  <dd
-                    v-else
-                    class="mt-1 max-w-3xl text-sm leading-6 text-surface-500 dark:text-surface-400"
-                  >
-                    {{ scoringSummaryFallback }}
-                  </dd>
-                </div>
-              </dl>
-            </div>
-
-            <!-- Notes -->
-            <div class="border border-white/12 bg-white/[0.025] p-5">
-              <div class="flex items-center justify-between mb-3">
-                <div class="flex items-center gap-2">
-                  <MessageSquare class="size-4 text-surface-500 dark:text-surface-400" />
-                  <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-200">Notes</h3>
-                </div>
-                <button
-                  v-if="!isEditingNotes && application.notes"
-                  class="cursor-pointer text-xs text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300 font-medium transition-colors"
-                  @click="startEditNotes"
-                >
-                  Edit
-                </button>
-              </div>
-
-              <div v-if="isEditingNotes">
-                <textarea
-                  ref="notesTextarea"
-                  v-model="notesInput"
-                  rows="4"
-                  placeholder="Add notes about this application…"
-                  class="w-full border border-white/16 bg-black/45 px-3 py-2 text-sm text-white placeholder:text-white/34 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20 transition-colors"
-                  @input="autosaveNotes"
-                  @blur="saveNotes"
-                />
-                <div class="flex items-center gap-2 mt-2">
-                  <p class="min-w-0 flex-1 text-xs text-surface-400" role="status">
-                    {{ notesSaveStatus === 'saving' || isSavingNotes ? 'Saving notes...' : notesSaveStatus === 'saved' ? 'Notes saved' : notesSaveStatus === 'error' ? 'Autosave failed' : 'Automatically saves changes' }}
-                  </p>
-                  <button
-                    class="factory-toolbar-button cursor-pointer border px-3 py-1.5 text-xs font-medium text-white/78 hover:text-white transition-colors"
-                    :disabled="isSavingNotes"
-                    @click="finishEditNotes"
-                  >
-                    Done
-                  </button>
-                </div>
-              </div>
-              <p
-                v-else-if="application.notes"
-                class="text-sm text-surface-600 dark:text-surface-300 whitespace-pre-wrap"
-              >
-                {{ application.notes }}
-              </p>
-              <button
-                v-else
-                type="button"
-                class="group flex w-full cursor-pointer items-center justify-between border border-dashed border-white/12 bg-black px-3 py-3 text-left text-sm text-surface-400 transition-colors hover:border-brand-500/70 hover:bg-brand-500/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-brand-500/40"
-                @click="startEditNotes"
-              >
-                <span class="italic">No notes yet.</span>
-                <span class="text-xs font-semibold uppercase text-brand-400 transition-colors group-hover:text-brand-300">Add Notes</span>
-              </button>
-            </div>
+            <ApplicationNotesPanel
+              surface="drawer"
+              :notes="application.notes"
+              :is-editing-notes="isEditingNotes"
+              :notes-input="notesInput"
+              :is-saving-notes="isSavingNotes"
+              :notes-save-status="notesSaveStatus"
+              focus-on-edit
+              @update:notes-input="notesInput = $event"
+              @start-edit="startEditNotes"
+              @autosave="autosaveNotes"
+              @save="saveNotes"
+              @finish-edit="finishEditNotes"
+            />
 
             <!-- Properties -->
             <div class="border border-white/12 bg-white/[0.025] p-4">
@@ -342,32 +232,11 @@ async function scoreCurrentApplication() {
               />
             </div>
 
-            <!-- Question Responses -->
-            <div
+            <ApplicationResponsesPanel
               v-if="application.responses && application.responses.length > 0"
-              class="border border-white/12 bg-white/[0.025] p-5"
-            >
-              <div class="flex items-center gap-2 mb-3">
-                <FileText class="size-4 text-surface-500 dark:text-surface-400" />
-                <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-200">
-                  Application Responses ({{ application.responses.length }})
-                </h3>
-              </div>
-              <div class="space-y-3">
-                <div
-                  v-for="response in application.responses"
-                  :key="response.id"
-                  class="border-b border-white/10 pb-3 last:border-0 last:pb-0"
-                >
-                  <dt class="text-xs font-medium text-surface-500 dark:text-surface-400 mb-0.5">
-                    {{ response.question?.label ?? 'Unknown question' }}
-                  </dt>
-                  <dd class="text-sm text-surface-700 dark:text-surface-200">
-                    {{ formatResponseValue(response.value) }}
-                  </dd>
-                </div>
-              </div>
-            </div>
+              surface="drawer"
+              :responses="application.responses"
+            />
     </template>
 
     <template #overlays>

--- a/app/components/ApplicationDocumentsPanel.vue
+++ b/app/components/ApplicationDocumentsPanel.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Download,
+  Eye,
+  FileText,
+  RefreshCw,
+  Trash2,
+} from 'lucide-vue-next'
+import type { ApplicationPanelSurface } from '~/composables/useApplicationPanelClass'
+import { DOCUMENT_TYPE_LABELS } from '~/utils/document-display'
+
+const props = withDefaults(defineProps<{
+  documents?: any[]
+  preview: {
+    showPreview: boolean
+    previewUrl: string | null
+    previewFilename: string
+    previewDocId: string | null
+    previewError?: string | null
+    isPdfPreview: boolean
+  }
+  surface?: ApplicationPanelSurface
+  allowDelete?: boolean
+  allowReparse?: boolean
+  reparsingDocId?: string | null
+  emptyDescription?: string
+  previewHeight?: string
+}>(), {
+  documents: () => [],
+  surface: 'sidebar',
+  allowDelete: true,
+  allowReparse: false,
+  reparsingDocId: null,
+  emptyDescription: '',
+  previewHeight: 'calc(100vh - 280px)',
+})
+
+const emit = defineEmits<{
+  preview: [docId: string, mimeType?: string | null]
+  download: [docId: string]
+  delete: [docId: string]
+  reparse: [docId: string]
+  closePreview: []
+}>()
+
+const panelClass = useApplicationPanelClass(() => props.surface)
+
+function isPdfDocument(doc: { mimeType?: string | null }) {
+  return doc.mimeType === 'application/pdf'
+}
+
+function previewDocument(doc: { id: string, mimeType?: string | null }) {
+  if (isPdfDocument(doc)) {
+    emit('preview', doc.id, doc.mimeType)
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <template v-if="preview.showPreview">
+      <div class="flex items-center justify-between">
+        <button
+          class="factory-toolbar-button inline-flex h-10 min-h-10 items-center gap-1.5 border px-3 py-0 text-xs font-medium transition-colors hover:bg-white hover:text-black"
+          @click="emit('closePreview')"
+        >
+          <ArrowLeft class="size-3.5" />
+          Back to documents
+        </button>
+        <div class="flex items-center gap-1">
+          <button
+            v-if="preview.previewDocId"
+            class="ui-button ui-button-ghost p-1.5"
+            title="Download"
+            @click="emit('download', preview.previewDocId)"
+          >
+            <Download class="size-4" />
+          </button>
+        </div>
+      </div>
+
+      <div v-if="preview.previewFilename" class="flex items-center gap-2">
+        <FileText class="size-4 text-surface-400 shrink-0" />
+        <span class="text-sm font-medium text-surface-700 dark:text-surface-200 truncate">
+          {{ preview.previewFilename }}
+        </span>
+      </div>
+
+      <div
+        v-if="preview.previewError"
+        class="ui-alert ui-alert-danger p-6 text-center"
+      >
+        <AlertTriangle class="size-8 text-danger-400 mx-auto mb-2" />
+        <p class="text-sm text-danger-700 dark:text-danger-400">{{ preview.previewError }}</p>
+        <button
+          class="ui-inline-link-brand mt-3 text-sm font-medium"
+          @click="emit('closePreview')"
+        >
+          Go back
+        </button>
+      </div>
+
+      <iframe
+        v-else-if="preview.previewUrl && preview.isPdfPreview"
+        :src="preview.previewUrl"
+        class="w-full rounded-lg border border-surface-200 dark:border-surface-800"
+        :style="{ height: previewHeight }"
+        title="Document preview"
+      />
+    </template>
+
+    <template v-else>
+      <slot name="toolbar" />
+
+      <div
+        v-if="!documents.length"
+        class="ui-empty-panel p-8"
+      >
+        <div class="flex size-14 items-center justify-center rounded-2xl bg-surface-100 dark:bg-surface-800/60 mx-auto mb-3">
+          <FileText class="size-6 text-surface-400 dark:text-surface-500" />
+        </div>
+        <p class="text-sm font-medium text-surface-600 dark:text-surface-300">No documents yet.</p>
+        <p v-if="emptyDescription" class="text-xs text-surface-400 dark:text-surface-500 mt-1">
+          {{ emptyDescription }}
+        </p>
+      </div>
+
+      <div v-else class="space-y-2">
+        <div
+          v-for="doc in documents"
+          :key="doc.id"
+          :class="[panelClass, 'group flex items-center justify-between px-4 py-3 transition-colors', isPdfDocument(doc) ? 'cursor-pointer hover:border-brand-300 dark:hover:border-brand-700 hover:bg-brand-50/50 dark:hover:bg-brand-950/30' : '']"
+          @click="isPdfDocument(doc) ? previewDocument(doc) : undefined"
+        >
+          <div class="flex items-center gap-3 min-w-0">
+            <FileText class="size-4 shrink-0" :class="isPdfDocument(doc) ? 'text-danger-500 dark:text-danger-400' : 'text-surface-400'" />
+            <div class="min-w-0">
+              <p class="text-sm font-medium text-surface-700 dark:text-surface-200 truncate">
+                {{ doc.originalFilename }}
+              </p>
+              <span class="text-xs text-surface-400">
+                {{ DOCUMENT_TYPE_LABELS[doc.type] ?? doc.type }}
+                · {{ new Date(doc.createdAt).toLocaleDateString() }}
+                <template v-if="doc.parsed === false">
+                  · <span class="text-warning-500 dark:text-warning-400">Text extraction failed</span>
+                </template>
+                <template v-else-if="isPdfDocument(doc)"> · <span class="text-brand-500 dark:text-brand-400">Click to preview</span></template>
+              </span>
+            </div>
+          </div>
+          <div class="flex items-center gap-1 shrink-0" @click.stop>
+            <button
+              v-if="allowReparse && doc.parsed === false"
+              :disabled="reparsingDocId === doc.id"
+              class="ui-button ui-button-ghost p-1.5 text-warning-500 disabled:opacity-50"
+              title="Retry text extraction"
+              @click="emit('reparse', doc.id)"
+            >
+              <RefreshCw class="size-4" :class="{ 'animate-spin': reparsingDocId === doc.id }" />
+            </button>
+            <button
+              v-if="isPdfDocument(doc)"
+              class="ui-button ui-button-ghost p-1.5"
+              title="Preview PDF"
+              @click="previewDocument(doc)"
+            >
+              <Eye class="size-4" />
+            </button>
+            <button
+              class="ui-button ui-button-ghost p-1.5"
+              title="Download"
+              @click="emit('download', doc.id)"
+            >
+              <Download class="size-4" />
+            </button>
+            <button
+              v-if="allowDelete"
+              class="ui-button ui-button-ghost ui-button-ghost-danger p-1.5"
+              title="Delete"
+              @click="emit('delete', doc.id)"
+            >
+              <Trash2 class="size-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/app/components/ApplicationInterviewsPanel.vue
+++ b/app/components/ApplicationInterviewsPanel.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { Calendar, ExternalLink } from 'lucide-vue-next'
+import type { Interview } from '~/composables/useInterviews'
+import type { ApplicationPanelSurface } from '~/composables/useApplicationPanelClass'
+import {
+  INTERVIEW_TYPE_LABELS,
+  formatInterviewDate,
+  formatInterviewStatusLabel,
+} from '~/utils/interview-display'
+
+const props = withDefaults(defineProps<{
+  interviews: Interview[]
+  surface?: ApplicationPanelSurface
+}>(), {
+  surface: 'sidebar',
+})
+
+const panelClass = useApplicationPanelClass(() => props.surface)
+</script>
+
+<template>
+  <div v-if="interviews.length > 0" :class="[panelClass, 'p-5']">
+    <div class="flex items-center gap-2.5 mb-4">
+      <div class="ui-icon-state ui-icon-state-success size-7 rounded-lg">
+        <Calendar class="size-3.5" />
+      </div>
+      <h3 class="text-sm font-semibold text-surface-800 dark:text-surface-200">Interviews</h3>
+    </div>
+    <div class="space-y-3">
+      <div
+        v-for="interview in interviews"
+        :key="interview.id"
+        class="rounded-lg border border-surface-200/60 dark:border-surface-800/40 p-3"
+      >
+        <div class="flex items-center justify-between mb-1">
+          <NuxtLink
+            :to="$localePath(`/dashboard/interviews/${interview.id}`)"
+            class="text-sm font-medium text-surface-800 dark:text-surface-200 hover:text-brand-600 dark:hover:text-brand-400 transition-colors truncate"
+          >
+            {{ interview.title }}
+          </NuxtLink>
+          <span
+            class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold capitalize shrink-0 ml-2"
+            :class="{
+              'bg-brand-50 text-brand-700 dark:bg-brand-950/40 dark:text-brand-400': interview.status === 'scheduled',
+              'bg-success-50 text-success-700 dark:bg-success-950/40 dark:text-success-400': interview.status === 'completed',
+              'bg-surface-100 text-surface-500 dark:bg-surface-800 dark:text-surface-400': interview.status === 'cancelled' || interview.status === 'no_show',
+            }"
+          >
+            {{ formatInterviewStatusLabel(interview.status) }}
+          </span>
+        </div>
+        <div class="flex items-center gap-2 text-xs text-surface-400 dark:text-surface-500">
+          <span class="font-medium">{{ formatInterviewDate(interview.scheduledAt) }}</span>
+          <span class="text-surface-200 dark:text-surface-700">&middot;</span>
+          <span>{{ INTERVIEW_TYPE_LABELS[interview.type] ?? interview.type }}</span>
+          <span class="text-surface-200 dark:text-surface-700">&middot;</span>
+          <span>{{ interview.duration }} min</span>
+        </div>
+        <div class="mt-2">
+          <a
+            v-if="interview.googleCalendarEventLink"
+            :href="interview.googleCalendarEventLink"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1 rounded-full bg-emerald-50 dark:bg-emerald-950/30 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-400 hover:bg-emerald-100 dark:hover:bg-emerald-950/50 transition-colors"
+          >
+            <Calendar class="size-2.5" />
+            Open in Calendar
+            <ExternalLink class="size-2" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/components/ApplicationNotesPanel.vue
+++ b/app/components/ApplicationNotesPanel.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { MessageSquare } from 'lucide-vue-next'
+import type { ApplicationPanelSurface } from '~/composables/useApplicationPanelClass'
+
+const props = withDefaults(defineProps<{
+  surface?: ApplicationPanelSurface
+  notes?: string | null
+  isEditingNotes: boolean
+  notesInput: string
+  isSavingNotes: boolean
+  notesSaveStatus: 'idle' | 'saving' | 'saved' | 'error'
+  focusOnEdit?: boolean
+}>(), {
+  surface: 'page',
+  notes: null,
+  focusOnEdit: false,
+})
+
+const emit = defineEmits<{
+  'update:notesInput': [value: string]
+  startEdit: []
+  autosave: []
+  save: []
+  finishEdit: []
+}>()
+
+const panelClass = useApplicationPanelClass(() => props.surface)
+const notesTextareaEl = ref<HTMLTextAreaElement | null>(null)
+
+watch(() => props.isEditingNotes, async (editing) => {
+  if (editing && props.focusOnEdit) {
+    await nextTick()
+    notesTextareaEl.value?.focus()
+  }
+})
+</script>
+
+<template>
+  <div :class="[panelClass, 'p-5', surface === 'page' ? 'mb-4' : '', surface === 'page' && !isEditingNotes ? 'mt-4' : '']">
+    <div class="flex items-center justify-between mb-3" :class="surface === 'sidebar' ? 'mb-4' : ''">
+      <div class="flex items-center gap-2" :class="surface === 'sidebar' ? 'gap-2.5' : ''">
+        <div
+          v-if="surface === 'sidebar'"
+          class="ui-icon-state ui-icon-state-warning size-7 rounded-lg"
+        >
+          <MessageSquare class="size-3.5" />
+        </div>
+        <MessageSquare v-else class="size-4 text-surface-500 dark:text-surface-400" />
+        <h3
+          class="text-sm font-semibold"
+          :class="surface === 'sidebar'
+            ? 'text-surface-800 dark:text-surface-200'
+            : 'text-surface-700 dark:text-surface-200'"
+        >
+          Notes
+        </h3>
+      </div>
+      <button
+        v-if="!isEditingNotes && (surface === 'sidebar' || notes)"
+        class="font-medium transition-colors"
+        :class="surface === 'sidebar'
+          ? 'ui-inline-link-brand text-xs'
+          : 'cursor-pointer text-xs text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300'"
+        @click="emit('startEdit')"
+      >
+        {{ surface === 'sidebar' ? (notes ? 'Edit' : 'Add Notes') : 'Edit' }}
+      </button>
+    </div>
+
+    <div v-if="isEditingNotes">
+      <textarea
+        ref="notesTextareaEl"
+        :value="notesInput"
+        rows="4"
+        placeholder="Add notes about this application…"
+        :class="surface === 'sidebar'
+          ? 'ui-field'
+          : 'w-full border border-white/16 bg-black/45 px-3 py-2 text-sm text-white placeholder:text-white/34 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20 transition-colors'"
+        @input="emit('update:notesInput', ($event.target as HTMLTextAreaElement).value); emit('autosave')"
+        @blur="emit('save')"
+      />
+      <div class="flex items-center gap-2 mt-2">
+        <p class="min-w-0 flex-1 text-xs text-surface-400" role="status">
+          {{ notesSaveStatus === 'saving' || isSavingNotes ? 'Saving notes...' : notesSaveStatus === 'saved' ? 'Notes saved' : notesSaveStatus === 'error' ? 'Autosave failed' : 'Automatically saves changes' }}
+        </p>
+        <button
+          :class="surface === 'sidebar'
+            ? 'ui-button ui-button-secondary px-3 py-1.5 text-sm'
+            : 'factory-toolbar-button cursor-pointer border px-3 py-1.5 text-xs font-medium text-white/78 hover:text-white transition-colors'"
+          :disabled="isSavingNotes"
+          @click="emit('finishEdit')"
+        >
+          Done
+        </button>
+      </div>
+    </div>
+
+    <p
+      v-else-if="notes"
+      class="text-sm whitespace-pre-wrap"
+      :class="surface === 'sidebar'
+        ? 'leading-relaxed text-surface-600 dark:text-surface-300'
+        : 'text-surface-600 dark:text-surface-300'"
+    >
+      {{ notes }}
+    </p>
+    <p
+      v-else-if="surface === 'sidebar'"
+      class="text-sm text-surface-400 italic"
+    >
+      No notes yet.
+    </p>
+    <button
+      v-else
+      type="button"
+      class="group flex w-full cursor-pointer items-center justify-between border border-dashed border-white/12 bg-black px-3 py-3 text-left text-sm text-surface-400 transition-colors hover:border-brand-500/70 hover:bg-brand-500/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-brand-500/40"
+      @click="emit('startEdit')"
+    >
+      <span class="italic">No notes yet.</span>
+      <span class="text-xs font-semibold uppercase text-brand-400 transition-colors group-hover:text-brand-300">Add Notes</span>
+    </button>
+  </div>
+</template>

--- a/app/components/ApplicationResponsesPanel.vue
+++ b/app/components/ApplicationResponsesPanel.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { FileText } from 'lucide-vue-next'
+import type { ApplicationPanelSurface } from '~/composables/useApplicationPanelClass'
+import { formatResponseValue } from '~/utils/application-response-format'
+
+const props = withDefaults(defineProps<{
+  responses?: any[]
+  surface?: ApplicationPanelSurface
+  embedded?: boolean
+}>(), {
+  responses: () => [],
+  surface: 'page',
+  embedded: false,
+})
+
+const panelClass = useApplicationPanelClass(() => props.surface)
+</script>
+
+<template>
+  <div
+    v-if="responses.length > 0 || surface === 'sidebar'"
+    :class="embedded ? '' : [panelClass, 'p-5']"
+  >
+    <template v-if="surface === 'sidebar'">
+      <div
+        v-if="responses.length === 0"
+        class="ui-empty-panel p-8"
+      >
+        <div class="flex size-14 items-center justify-center rounded-2xl bg-surface-100 dark:bg-surface-800/60 mx-auto mb-3">
+          <FileText class="size-6 text-surface-400 dark:text-surface-500" />
+        </div>
+        <p class="text-sm font-medium text-surface-600 dark:text-surface-300">No application responses.</p>
+      </div>
+
+      <div v-else class="space-y-3">
+        <div
+          v-for="response in responses"
+          :key="response.id"
+          class="ui-panel p-4"
+        >
+          <dt class="text-xs font-semibold text-surface-400 dark:text-surface-500 mb-1.5 uppercase tracking-wider">
+            {{ response.question?.label ?? 'Unknown question' }}
+          </dt>
+          <dd class="text-sm text-surface-700 dark:text-surface-200 leading-relaxed">
+            {{ formatResponseValue(response.value) }}
+          </dd>
+        </div>
+      </div>
+    </template>
+
+    <template v-else>
+      <div class="flex items-center gap-2 mb-3">
+        <FileText class="size-4 text-surface-500 dark:text-surface-400" />
+        <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-200">
+          Application Responses ({{ responses.length }})
+        </h3>
+      </div>
+      <div class="space-y-3">
+        <div
+          v-for="response in responses"
+          :key="response.id"
+          class="border-b border-white/10 pb-3 last:border-0 last:pb-0"
+        >
+          <dt class="text-xs font-medium text-surface-500 dark:text-surface-400 mb-0.5">
+            {{ response.question?.label ?? 'Unknown question' }}
+          </dt>
+          <dd class="text-sm text-surface-700 dark:text-surface-200">
+            {{ formatResponseValue(response.value) }}
+          </dd>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/app/components/ApplicationScoringPanel.vue
+++ b/app/components/ApplicationScoringPanel.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { Brain, Loader2 } from 'lucide-vue-next'
+import type { ApplicationPanelSurface } from '~/composables/useApplicationPanelClass'
+import type { ScoringBand } from '~~/shared/scoring-bands'
+
+const props = withDefaults(defineProps<{
+  surface?: ApplicationPanelSurface
+  applicationId: string
+  score?: number | null
+  analysisRunId?: string | null
+  scoreBand?: ScoringBand | null
+  scoringSummary: string
+  scoringSummaryFallback: string
+  isScoring: boolean
+  showScoreBand?: boolean
+  fullWidth?: boolean
+}>(), {
+  surface: 'page',
+  score: null,
+  analysisRunId: null,
+  scoreBand: null,
+  showScoreBand: false,
+  fullWidth: false,
+})
+
+const emit = defineEmits<{
+  score: []
+}>()
+
+const panelClass = useApplicationPanelClass(() => props.surface)
+</script>
+
+<template>
+  <div
+    :class="[
+      panelClass,
+      'p-5',
+      fullWidth ? 'md:col-span-2' : '',
+    ]"
+  >
+    <div
+      class="flex items-center justify-between"
+      :class="surface === 'page' ? 'mb-5 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between' : 'mb-5'"
+    >
+      <div class="flex items-center gap-2">
+        <Brain class="size-4 text-surface-500 dark:text-surface-400" />
+        <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-200">Scoring</h3>
+      </div>
+      <div class="flex items-center gap-2">
+        <ScoringFeedbackControl
+          :application-id="applicationId"
+          :analysis-run-id="analysisRunId"
+        />
+        <button
+          type="button"
+          :disabled="isScoring"
+          class="factory-button-cta factory-button-premium inline-flex h-8 min-h-8 cursor-pointer items-center justify-center gap-1.5 px-2.5 py-0 text-[11px] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+          @click="emit('score')"
+        >
+          <Loader2 v-if="isScoring" class="size-3 animate-spin" />
+          <Brain v-else class="size-3" />
+          {{ isScoring ? 'Scoring...' : (score != null ? 'Re-score' : 'Run Analysis') }}
+        </button>
+      </div>
+    </div>
+
+    <dl
+      class="grid gap-5 text-sm"
+      :class="surface === 'page'
+        ? 'md:grid-cols-[10rem_minmax(0,1fr)]'
+        : 'md:grid-cols-[8rem_minmax(0,1fr)]'"
+    >
+      <div>
+        <dt
+          class="text-xs font-semibold uppercase tracking-[0.18em]"
+          :class="surface === 'page' ? 'text-surface-500 dark:text-surface-500' : 'text-surface-400'"
+        >
+          Score
+        </dt>
+        <dd
+          class="flex flex-wrap items-center gap-2"
+          :class="surface === 'page' ? 'mt-2' : 'mt-1'"
+        >
+          <span
+            class="font-semibold text-surface-900 dark:text-white"
+            :class="surface === 'page' ? 'text-2xl' : 'text-2xl'"
+          >
+            {{ score != null ? score : '—' }}
+            <span
+              v-if="score != null"
+              class="ml-1 text-sm font-medium"
+              :class="surface === 'page' ? 'text-surface-500 dark:text-surface-500' : 'text-surface-400'"
+            >
+              pts
+            </span>
+          </span>
+          <ScoringBandBadge v-if="showScoreBand" :band="scoreBand" />
+        </dd>
+      </div>
+      <div>
+        <dt
+          class="text-xs font-semibold uppercase tracking-[0.18em]"
+          :class="surface === 'page' ? 'text-surface-500 dark:text-surface-500' : 'text-surface-400'"
+        >
+          AI summary
+        </dt>
+        <dd
+          v-if="scoringSummary"
+          class="max-w-3xl text-sm leading-6 text-surface-700 dark:text-surface-300"
+          :class="surface === 'page' ? 'mt-2' : 'mt-1'"
+        >
+          {{ scoringSummary }}
+        </dd>
+        <dd
+          v-else
+          class="max-w-3xl text-sm leading-6"
+          :class="[
+            surface === 'page' ? 'mt-2 text-surface-500 dark:text-surface-500' : 'mt-1 text-surface-500 dark:text-surface-400',
+          ]"
+        >
+          {{ scoringSummaryFallback }}
+        </dd>
+      </div>
+    </dl>
+  </div>
+</template>

--- a/app/components/ApplicationTimelinePanel.vue
+++ b/app/components/ApplicationTimelinePanel.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import { AlertTriangle, History } from 'lucide-vue-next'
+import type { ApplicationTimelineEntry } from '~/composables/useApplicationTimeline'
+import {
+  describeApplicationTimelineItem,
+  formatApplicationTimelineDate,
+  getApplicationTimelineActionColor,
+} from '~/composables/useApplicationTimeline'
+
+const props = defineProps<{
+  items: ApplicationTimelineEntry[]
+  loading: boolean
+  error: string | null
+}>()
+
+const emit = defineEmits<{
+  retry: []
+}>()
+</script>
+
+<template>
+  <div class="space-y-1">
+    <div v-if="loading" class="text-center py-12 text-surface-400">
+      <div class="size-6 rounded-full border-2 border-brand-200 border-t-brand-600 dark:border-brand-800 dark:border-t-brand-400 animate-spin mx-auto mb-3" />
+      Loading timeline…
+    </div>
+
+    <div
+      v-else-if="error"
+      class="ui-alert ui-alert-danger p-5 text-center"
+    >
+      <AlertTriangle class="size-6 text-danger-400 mx-auto mb-2" />
+      <p class="text-sm text-danger-700 dark:text-danger-400">{{ error }}</p>
+      <button
+        class="ui-inline-link-brand mt-3 text-sm font-medium"
+        @click="emit('retry')"
+      >
+        Retry
+      </button>
+    </div>
+
+    <div
+      v-else-if="items.length === 0"
+      class="ui-empty-panel p-8"
+    >
+      <div class="flex size-14 items-center justify-center rounded-2xl bg-surface-100 dark:bg-surface-800/60 mx-auto mb-3">
+        <History class="size-6 text-surface-400 dark:text-surface-500" />
+      </div>
+      <p class="text-sm font-medium text-surface-600 dark:text-surface-300">No activity recorded yet.</p>
+      <p class="text-xs text-surface-400 dark:text-surface-500 mt-1">Activity for this candidate will appear here.</p>
+    </div>
+
+    <div v-else>
+      <div
+        v-for="(item, index) in items"
+        :key="item.id"
+        class="flex gap-3 py-2 group"
+      >
+        <div class="flex flex-col items-center shrink-0 mt-[3px]">
+          <div
+            class="size-[9px] rounded-full ring-2 ring-white dark:ring-surface-950 shrink-0"
+            :class="getApplicationTimelineActionColor(item.action)"
+          />
+          <div
+            v-if="index < items.length - 1"
+            class="w-px flex-1 min-h-[14px] bg-surface-200 dark:bg-surface-700 mt-1"
+          />
+        </div>
+
+        <div class="min-w-0 flex-1">
+          <p class="text-sm text-surface-700 dark:text-surface-200 leading-snug">
+            {{ describeApplicationTimelineItem(item) }}
+          </p>
+          <div class="flex items-center gap-2 mt-0.5">
+            <span class="text-[11px] text-surface-400 dark:text-surface-500 tabular-nums">
+              {{ formatApplicationTimelineDate(item.createdAt) }}
+            </span>
+            <span
+              v-if="item.jobTitle"
+              class="text-[10px] text-surface-400 dark:text-surface-500 bg-surface-100 dark:bg-surface-800 rounded px-1.5 py-0.5 truncate max-w-[140px]"
+            >
+              {{ item.jobTitle }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/components/CandidateDetailSidebar.vue
+++ b/app/components/CandidateDetailSidebar.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import {
-  X, User, Calendar, Clock, Hash, MessageSquare, FileText,
-  ExternalLink, Phone, Upload, Download, Eye, Trash2,
-  ArrowLeft, AlertTriangle, Brain, History, RefreshCw,
+  X, User, Calendar, Hash, FileText,
+  ExternalLink, Phone, Upload, Brain, History,
 } from 'lucide-vue-next'
 import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
 import {
@@ -10,7 +9,7 @@ import {
   getApplicationTransitionLabel,
 } from '~/utils/status-display'
 import { formatPhoneNumber } from '~/utils/phone-format'
-import { formatResponseValue } from '~/utils/application-response-format'
+
 
 const props = defineProps<{
   applicationId: string
@@ -22,8 +21,6 @@ const emit = defineEmits<{
   (e: 'updated'): void
 }>()
 
-const { handlePreviewReadOnlyError } = usePreviewReadOnly()
-const toast = useToast()
 const { track } = useTrack()
 const { formatCandidateName } = useOrgSettings()
 
@@ -123,133 +120,33 @@ const { isEditingNotes, notesInput, isSavingNotes, notesSaveStatus, startEditNot
 // Documents — upload, download, preview, delete
 // ─────────────────────────────────────────────
 
-const { uploadDocument, downloadDocument, getPreviewUrl, deleteDocument } = useDocuments()
-
-const fileInput = ref<HTMLInputElement | null>(null)
-const selectedDocType = ref<'resume' | 'cover_letter' | 'other'>('resume')
-const isUploading = ref(false)
-const showDocDeleteConfirm = ref<string | null>(null)
-const isDeletingDoc = ref(false)
-const reparsingDocId = ref<string | null>(null)
-
-const showPreview = ref(false)
-const previewUrl = ref<string | null>(null)
-const previewFilename = ref('')
-const previewMimeType = ref('')
-const previewDocId = ref<string | null>(null)
-const isLoadingPreview = ref(false)
-const previewError = ref<string | null>(null)
-
-const isPdfPreview = computed(() => previewMimeType.value === 'application/pdf')
-
-const documentTypeLabels: Record<string, string> = {
-  resume: 'Resume',
-  cover_letter: 'Cover Letter',
-  other: 'Other',
-}
-
-function triggerFileSelect() {
-  fileInput.value?.click()
-}
-
-async function handleFileSelected(event: Event) {
-  const input = event.target as HTMLInputElement
-  const file = input.files?.[0]
-  if (!file || !candidateId.value) return
-
-  isUploading.value = true
-
-  try {
-    await uploadDocument(candidateId.value, file, selectedDocType.value)
-    await refreshCandidate()
-  } catch (err: any) {
-    toast.error('Upload failed', { message: err.data?.statusMessage ?? err.statusMessage, statusCode: err.data?.statusCode ?? err.statusCode })
-  } finally {
-    isUploading.value = false
-    input.value = ''
-  }
-}
-
-async function handleReparse(docId: string) {
-  reparsingDocId.value = docId
-  try {
-    await $fetch(`/api/documents/${docId}/parse`, {
-      method: 'POST',
-      headers: useRequestHeaders(['cookie']),
-    })
-    toast.add({ title: 'Resume parsed successfully', type: 'success' })
-    await refreshCandidate()
-  } catch (err: any) {
-    toast.add({
-      title: 'Parse failed',
-      message: err?.data?.statusMessage ?? 'Could not extract text from this document.',
-      type: 'error',
-    })
-  } finally {
-    reparsingDocId.value = null
-  }
-}
-
-async function handlePreview(docId: string, mimeType?: string) {
-  // Only PDFs can be previewed inline — for DOC/DOCX, download directly
-  if (mimeType && mimeType !== 'application/pdf') {
-    await handleDownload(docId)
-    return
-  }
-
-  previewError.value = null
-  showPreview.value = true
-  previewDocId.value = docId
-
-  // Find the document name from the loaded data
-  const doc = documents.value?.find((d: any) => d.id === docId)
-  previewFilename.value = doc?.originalFilename ?? 'Document'
-  previewMimeType.value = doc?.mimeType ?? 'application/pdf'
-
-  // Use the API endpoint URL directly — server streams the PDF (same-origin)
-  previewUrl.value = getPreviewUrl(docId)
-}
-
-function closePreview() {
-  showPreview.value = false
-  previewUrl.value = null
-  previewFilename.value = ''
-  previewMimeType.value = ''
-  previewDocId.value = null
-  previewError.value = null
-}
-
-async function handleDownload(docId: string) {
-  try {
-    track('document_downloaded', { document_id: docId })
-    await downloadDocument(docId)
-  } catch {
-    toast.error('Failed to download document')
-  }
-}
-
-async function handleDeleteDoc(docId: string) {
-  if (!candidateId.value) return
-  isDeletingDoc.value = true
-  try {
-    await deleteDocument(docId, candidateId.value)
-    await refreshCandidate()
-    showDocDeleteConfirm.value = null
-  } catch (err: any) {
-    if (handlePreviewReadOnlyError(err)) return
-    toast.error('Failed to delete document', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
-  } finally {
-    isDeletingDoc.value = false
-  }
-}
+const {
+  fileInput,
+  selectedDocType,
+  isUploading,
+  showDocDeleteConfirm,
+  isDeletingDoc,
+  reparsingDocId,
+  documentPreview,
+  documentPreviewState,
+  triggerFileSelect,
+  handleFileSelected,
+  handleReparse,
+  handleDownload,
+  handleDeleteDoc,
+} = useApplicationDocumentActions({
+  candidateId,
+  documents: () => documents.value,
+  afterMutation: refreshCandidate,
+})
 
 // ─────────────────────────────────────────────
 // Escape key to close (layered: preview → delete → sidebar)
 // ─────────────────────────────────────────────
 
 function closeTopLayer() {
-  if (showPreview.value) {
-    closePreview()
+  if (documentPreview.showPreview.value) {
+    documentPreview.closePreview()
   } else if (showDocDeleteConfirm.value) {
     showDocDeleteConfirm.value = null
   } else {
@@ -267,88 +164,14 @@ useFocusTrap({
 // Timeline data for the candidate
 // ─────────────────────────────────────────────
 
-interface TimelineEntry {
-  id: string
-  action: string
-  resourceType: string
-  resourceId: string
-  metadata: Record<string, unknown> | null
-  createdAt: string
-  actorName: string | null
-  actorEmail: string | null
-  resourceName: string | null
-  jobTitle: string | null
-  candidateName: string | null
-}
-
-const timelineItems = ref<TimelineEntry[]>([])
-const timelineLoading = ref(false)
-const timelineError = ref<string | null>(null)
-const timelineLoaded = ref(false)
-
-const timelineActionLabels: Record<string, string> = {
-  created: 'Created',
-  updated: 'Updated',
-  deleted: 'Deleted',
-  status_changed: 'Status changed',
-  comment_added: 'Comment added',
-  scored: 'Scored',
-  scheduled: 'Scheduled',
-}
-
-function formatTimelineDate(dateStr: string) {
-  const d = new Date(dateStr)
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
-}
-
-function getTimelineActionColor(action: string): string {
-  switch (action) {
-    case 'created': return 'bg-green-500'
-    case 'status_changed': return 'bg-blue-500'
-    case 'updated': return 'bg-amber-500'
-    case 'deleted': return 'bg-danger-500'
-    case 'comment_added': return 'bg-violet-500'
-    case 'scored': return 'bg-teal-500'
-    case 'scheduled': return 'bg-brand-500'
-    default: return 'bg-surface-400'
-  }
-}
-
-function describeTimelineItem(item: TimelineEntry): string {
-  const actor = item.actorName ?? item.actorEmail ?? 'System'
-  const action = timelineActionLabels[item.action] ?? item.action
-  const resource = item.resourceType
-
-  if (item.action === 'status_changed' && item.metadata) {
-    const from = item.metadata.from_status ?? item.metadata.fromStatus
-    const to = item.metadata.to_status ?? item.metadata.toStatus
-    if (from && to) return `${actor} changed ${resource} status from ${from} to ${to}`
-  }
-
-  if (item.action === 'scored' && item.metadata) {
-    const score = item.metadata.score
-    if (score != null) return `${actor} scored ${resource} — ${score} pts`
-  }
-
-  return `${actor} ${action.toLowerCase()} ${resource}`
-}
-
-async function loadTimeline() {
-  if (!candidateId.value) return
-  timelineLoading.value = true
-  timelineError.value = null
-  try {
-    const result = await $fetch<{ items: TimelineEntry[] }>('/api/activity-log/candidate-timeline', {
-      query: { candidateId: candidateId.value },
-    })
-    timelineItems.value = result.items
-    timelineLoaded.value = true
-  } catch (err: any) {
-    timelineError.value = err?.data?.statusMessage ?? 'Failed to load timeline'
-  } finally {
-    timelineLoading.value = false
-  }
-}
+const {
+  timelineItems,
+  timelineLoading,
+  timelineError,
+  timelineLoaded,
+  loadTimeline,
+  resetTimeline,
+} = useApplicationTimeline({ candidateId })
 
 // Load timeline data lazily when tab is selected
 watch(activeTab, (tab) => {
@@ -362,10 +185,8 @@ watch(() => props.applicationId, () => {
   isEditingNotes.value = false
   activeTab.value = 'overview'
   showDocDeleteConfirm.value = null
-  timelineItems.value = []
-  timelineLoaded.value = false
-  timelineError.value = null
-  closePreview()
+  resetTimeline()
+  documentPreview.closePreview()
 })
 
 const responsesCount = computed(() => application.value?.responses?.length ?? 0)
@@ -380,18 +201,7 @@ const { interviews: applicationInterviews } = useInterviews({
   applicationId: computed(() => props.applicationId),
 })
 
-const interviewTypeLabels: Record<string, string> = {
-  phone: 'Phone',
-  video: 'Video',
-  in_person: 'In-person',
-  panel: 'Panel',
-  technical: 'Technical',
-  take_home: 'Take-home',
-}
 
-function formatInterviewDate(dateStr: string) {
-  return new Date(dateStr).toLocaleDateString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
-}
 </script>
 
 <template>
@@ -606,111 +416,24 @@ function formatInterviewDate(dateStr: string) {
               </dl>
             </div>
 
-            <!-- Notes -->
-            <div class="ui-panel p-5">
-              <div class="flex items-center justify-between mb-4">
-                <div class="flex items-center gap-2.5">
-                  <div class="ui-icon-state ui-icon-state-warning size-7 rounded-lg">
-                    <MessageSquare class="size-3.5" />
-                  </div>
-                  <h3 class="text-sm font-semibold text-surface-800 dark:text-surface-200">Notes</h3>
-                </div>
-                <button
-                  v-if="!isEditingNotes"
-                  class="ui-inline-link-brand text-xs font-medium"
-                  @click="startEditNotes"
-                >
-                  {{ application.notes ? 'Edit' : 'Add Notes' }}
-                </button>
-              </div>
+            <ApplicationNotesPanel
+              surface="sidebar"
+              :notes="application.notes"
+              :is-editing-notes="isEditingNotes"
+              :notes-input="notesInput"
+              :is-saving-notes="isSavingNotes"
+              :notes-save-status="notesSaveStatus"
+              @update:notes-input="notesInput = $event"
+              @start-edit="startEditNotes"
+              @autosave="autosaveNotes"
+              @save="saveNotes"
+              @finish-edit="finishEditNotes"
+            />
 
-              <div v-if="isEditingNotes">
-                <textarea
-                  v-model="notesInput"
-                  rows="4"
-                  placeholder="Add notes about this application…"
-                  class="ui-field"
-                  @input="autosaveNotes"
-                  @blur="saveNotes"
-                />
-                <div class="flex items-center gap-2 mt-2">
-                  <p class="min-w-0 flex-1 text-xs text-surface-400" role="status">
-                    {{ notesSaveStatus === 'saving' || isSavingNotes ? 'Saving notes...' : notesSaveStatus === 'saved' ? 'Notes saved' : notesSaveStatus === 'error' ? 'Autosave failed' : 'Automatically saves changes' }}
-                  </p>
-                  <button
-                    class="ui-button ui-button-secondary px-3 py-1.5 text-sm"
-                    :disabled="isSavingNotes"
-                    @click="finishEditNotes"
-                  >
-                    Done
-                  </button>
-                </div>
-              </div>
-
-              <p
-                v-else-if="application.notes"
-                class="text-sm leading-relaxed text-surface-600 dark:text-surface-300 whitespace-pre-wrap"
-              >
-                {{ application.notes }}
-              </p>
-              <p v-else class="text-sm text-surface-400 italic">No notes yet.</p>
-            </div>
-
-            <!-- Scheduled interviews -->
-            <div v-if="applicationInterviews.length > 0" class="ui-panel p-5">
-              <div class="flex items-center gap-2.5 mb-4">
-                <div class="ui-icon-state ui-icon-state-success size-7 rounded-lg">
-                  <Calendar class="size-3.5" />
-                </div>
-                <h3 class="text-sm font-semibold text-surface-800 dark:text-surface-200">Interviews</h3>
-              </div>
-              <div class="space-y-3">
-                <div
-                  v-for="iv in applicationInterviews"
-                  :key="iv.id"
-                  class="rounded-lg border border-surface-200/60 dark:border-surface-800/40 p-3"
-                >
-                  <div class="flex items-center justify-between mb-1">
-                    <NuxtLink
-                      :to="$localePath(`/dashboard/interviews/${iv.id}`)"
-                      class="text-sm font-medium text-surface-800 dark:text-surface-200 hover:text-brand-600 dark:hover:text-brand-400 transition-colors truncate"
-                    >
-                      {{ iv.title }}
-                    </NuxtLink>
-                    <span
-                      class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold capitalize shrink-0 ml-2"
-                      :class="{
-                        'bg-brand-50 text-brand-700 dark:bg-brand-950/40 dark:text-brand-400': iv.status === 'scheduled',
-                        'bg-success-50 text-success-700 dark:bg-success-950/40 dark:text-success-400': iv.status === 'completed',
-                        'bg-surface-100 text-surface-500 dark:bg-surface-800 dark:text-surface-400': iv.status === 'cancelled' || iv.status === 'no_show',
-                      }"
-                    >
-                      {{ iv.status === 'no_show' ? 'No show' : iv.status }}
-                    </span>
-                  </div>
-                  <div class="flex items-center gap-2 text-xs text-surface-400 dark:text-surface-500">
-                    <span class="font-medium">{{ formatInterviewDate(iv.scheduledAt) }}</span>
-                    <span class="text-surface-200 dark:text-surface-700">&middot;</span>
-                    <span>{{ interviewTypeLabels[iv.type] ?? iv.type }}</span>
-                    <span class="text-surface-200 dark:text-surface-700">&middot;</span>
-                    <span>{{ iv.duration }} min</span>
-                  </div>
-                  <div class="mt-2">
-                    <a
-                      v-if="iv.googleCalendarEventLink"
-                      :href="iv.googleCalendarEventLink"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="inline-flex items-center gap-1 rounded-full bg-emerald-50 dark:bg-emerald-950/30 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-400 hover:bg-emerald-100 dark:hover:bg-emerald-950/50 transition-colors"
-                    >
-                      <Calendar class="size-2.5" />
-                      Open in Calendar
-                      <ExternalLink class="size-2" />
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <ApplicationInterviewsPanel
+              surface="sidebar"
+              :interviews="applicationInterviews"
+            />
 
             <!-- Quick links -->
             <div class="flex items-center gap-4 pt-1">
@@ -734,8 +457,7 @@ function formatInterviewDate(dateStr: string) {
           <!-- ═══════════════════════════════════════ -->
           <!-- DOCUMENTS TAB                           -->
           <!-- ═══════════════════════════════════════ -->
-          <div v-if="activeTab === 'documents'" class="space-y-4">
-            <!-- Hidden file input -->
+          <div v-if="activeTab === 'documents'">
             <input
               ref="fileInput"
               type="file"
@@ -744,192 +466,52 @@ function formatInterviewDate(dateStr: string) {
               @change="handleFileSelected"
             />
 
-            <!-- ── Inline PDF preview (replaces document list when active) ── -->
-            <template v-if="showPreview">
-              <!-- Preview toolbar -->
-              <div class="flex items-center justify-between">
-                <button
-                  class="factory-toolbar-button inline-flex h-10 min-h-10 items-center gap-1.5 border px-3 py-0 text-xs font-medium transition-colors hover:bg-white hover:text-black"
-                  @click="closePreview"
-                >
-                  <ArrowLeft class="size-3.5" />
-                  Back to documents
-                </button>
-                <div class="flex items-center gap-1">
+            <ApplicationDocumentsPanel
+              :documents="documents"
+              :preview="documentPreviewState"
+              surface="sidebar"
+              allow-reparse
+              :reparsing-doc-id="reparsingDocId"
+              empty-description="Upload a resume, cover letter, or other document (PDF, DOC, DOCX — max 10 MB)."
+              @preview="documentPreview.handlePreview"
+              @download="handleDownload"
+              @delete="showDocDeleteConfirm = $event"
+              @reparse="handleReparse"
+              @close-preview="documentPreview.closePreview"
+            >
+              <template #toolbar>
+                <div class="flex items-center justify-between">
+                  <div class="flex items-center gap-2">
+                    <FactorySelect
+                      v-model="selectedDocType"
+                      class="w-40"
+                      :options="[
+                        { value: 'resume', label: 'Resume' },
+                        { value: 'cover_letter', label: 'Cover Letter' },
+                        { value: 'other', label: 'Other' },
+                      ]"
+                    />
+                  </div>
                   <button
-                    v-if="previewDocId"
-                    class="ui-button ui-button-ghost p-1.5"
-                    title="Download"
-                    @click="handleDownload(previewDocId!)"
+                    :disabled="isUploading"
+                    class="ui-button ui-button-secondary gap-1.5 px-3 py-1.5 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                    @click="triggerFileSelect"
                   >
-                    <Download class="size-4" />
+                    <Upload class="size-3.5" />
+                    {{ isUploading ? 'Uploading…' : 'Upload Document' }}
                   </button>
                 </div>
-              </div>
-
-              <!-- Filename -->
-              <div v-if="previewFilename" class="flex items-center gap-2">
-                <FileText class="size-4 text-surface-400 shrink-0" />
-                <span class="text-sm font-medium text-surface-700 dark:text-surface-200 truncate">
-                  {{ previewFilename }}
-                </span>
-              </div>
-
-              <!-- Error state -->
-              <div
-                v-if="previewError"
-                class="ui-alert ui-alert-danger p-6 text-center"
-              >
-                <AlertTriangle class="size-8 text-danger-400 mx-auto mb-2" />
-                <p class="text-sm text-danger-700 dark:text-danger-400">{{ previewError }}</p>
-                <button
-                  class="ui-inline-link-brand mt-3 text-sm font-medium"
-                  @click="closePreview"
-                >
-                  Go back
-                </button>
-              </div>
-
-              <!-- PDF iframe — same-origin, server streams the bytes -->
-              <iframe
-                v-else-if="previewUrl && isPdfPreview"
-                :src="previewUrl"
-                class="w-full rounded-lg border border-surface-200 dark:border-surface-800"
-                style="height: calc(100vh - 280px);"
-                title="Document preview"
-              />
-            </template>
-
-            <!-- ── Document list (normal state) ── -->
-            <template v-else>
-              <!-- Upload controls -->
-              <div class="flex items-center justify-between">
-                <div class="flex items-center gap-2">
-                  <FactorySelect
-                    v-model="selectedDocType"
-                    class="w-40"
-                    :options="[
-                      { value: 'resume', label: 'Resume' },
-                      { value: 'cover_letter', label: 'Cover Letter' },
-                      { value: 'other', label: 'Other' },
-                    ]"
-                  />
-                </div>
-                <button
-                  :disabled="isUploading"
-                  class="ui-button ui-button-secondary gap-1.5 px-3 py-1.5 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
-                  @click="triggerFileSelect"
-                >
-                  <Upload class="size-3.5" />
-                  {{ isUploading ? 'Uploading…' : 'Upload Document' }}
-                </button>
-              </div>
-
-              <!-- Empty state -->
-              <div
-                v-if="documents.length === 0"
-                class="ui-empty-panel p-8"
-              >
-                <div class="flex size-14 items-center justify-center rounded-2xl bg-surface-100 dark:bg-surface-800/60 mx-auto mb-3">
-                  <FileText class="size-6 text-surface-400 dark:text-surface-500" />
-                </div>
-                <p class="text-sm font-medium text-surface-600 dark:text-surface-300">No documents yet.</p>
-                <p class="text-xs text-surface-400 dark:text-surface-500 mt-1">
-                  Upload a resume, cover letter, or other document (PDF, DOC, DOCX — max 10 MB).
-                </p>
-              </div>
-
-              <!-- Document list -->
-              <div v-else class="space-y-2">
-                <div
-                  v-for="doc in documents"
-                  :key="doc.id"
-                  class="ui-panel group flex items-center justify-between px-4 py-3 transition-colors"
-                  :class="doc.mimeType === 'application/pdf' ? 'cursor-pointer hover:border-brand-300 dark:hover:border-brand-700 hover:bg-brand-50/50 dark:hover:bg-brand-950/30' : ''"
-                  @click="doc.mimeType === 'application/pdf' ? handlePreview(doc.id, doc.mimeType) : undefined"
-                >
-                  <div class="flex items-center gap-3 min-w-0">
-                    <FileText class="size-4 shrink-0" :class="doc.mimeType === 'application/pdf' ? 'text-danger-500 dark:text-danger-400' : 'text-surface-400'" />
-                    <div class="min-w-0">
-                      <p class="text-sm font-medium text-surface-700 dark:text-surface-200 truncate">
-                        {{ doc.originalFilename }}
-                      </p>
-                      <span class="text-xs text-surface-400">
-                        {{ documentTypeLabels[doc.type] ?? doc.type }}
-                        · {{ new Date(doc.createdAt).toLocaleDateString() }}
-                        <template v-if="doc.parsed === false">
-                          · <span class="text-warning-500 dark:text-warning-400">Text extraction failed</span>
-                        </template>
-                        <template v-else-if="doc.mimeType === 'application/pdf'"> · <span class="text-brand-500 dark:text-brand-400">Click to preview</span></template>
-                      </span>
-                    </div>
-                  </div>
-                  <div class="flex items-center gap-1 shrink-0" @click.stop>
-                    <button
-                      v-if="doc.parsed === false"
-                      :disabled="reparsingDocId === doc.id"
-                      class="ui-button ui-button-ghost p-1.5 text-warning-500 disabled:opacity-50"
-                      title="Retry text extraction"
-                      @click="handleReparse(doc.id)"
-                    >
-                      <RefreshCw class="size-4" :class="{ 'animate-spin': reparsingDocId === doc.id }" />
-                    </button>
-                    <button
-                      v-if="doc.mimeType === 'application/pdf'"
-                      class="ui-button ui-button-ghost p-1.5"
-                      title="Preview PDF"
-                      @click="handlePreview(doc.id, doc.mimeType)"
-                    >
-                      <Eye class="size-4" />
-                    </button>
-                    <button
-                      class="ui-button ui-button-ghost p-1.5"
-                      title="Download"
-                      @click="handleDownload(doc.id)"
-                    >
-                      <Download class="size-4" />
-                    </button>
-                    <button
-                      class="ui-button ui-button-ghost ui-button-ghost-danger p-1.5"
-                      title="Delete"
-                      @click="showDocDeleteConfirm = doc.id"
-                    >
-                      <Trash2 class="size-4" />
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </template>
+              </template>
+            </ApplicationDocumentsPanel>
           </div>
           <!-- ═══════════════════════════════════════ -->
           <!-- RESPONSES TAB                           -->
           <!-- ═══════════════════════════════════════ -->
-          <div v-if="activeTab === 'responses'" class="space-y-3">
-            <div
-              v-if="responsesCount === 0"
-              class="ui-empty-panel p-8"
-            >
-              <div class="flex size-14 items-center justify-center rounded-2xl bg-surface-100 dark:bg-surface-800/60 mx-auto mb-3">
-                <FileText class="size-6 text-surface-400 dark:text-surface-500" />
-              </div>
-              <p class="text-sm font-medium text-surface-600 dark:text-surface-300">No application responses.</p>
-            </div>
-
-            <div v-else class="space-y-3">
-              <div
-                v-for="response in application.responses"
-                :key="response.id"
-                class="ui-panel p-4"
-              >
-                <dt class="text-xs font-semibold text-surface-400 dark:text-surface-500 mb-1.5 uppercase tracking-wider">
-                  {{ response.question?.label ?? 'Unknown question' }}
-                </dt>
-                <dd class="text-sm text-surface-700 dark:text-surface-200 leading-relaxed">
-                  {{ formatResponseValue(response.value) }}
-                </dd>
-              </div>
-            </div>
-          </div>
+          <ApplicationResponsesPanel
+            v-if="activeTab === 'responses'"
+            surface="sidebar"
+            :responses="application.responses ?? []"
+          />
 
           <!-- ═══════════════════════════════════════ -->
           <!-- AI ANALYSIS TAB                         -->
@@ -941,79 +523,13 @@ function formatInterviewDate(dateStr: string) {
           <!-- ═══════════════════════════════════════ -->
           <!-- TIMELINE TAB                            -->
           <!-- ═══════════════════════════════════════ -->
-          <div v-if="activeTab === 'timeline'" class="space-y-1">
-            <!-- Loading -->
-            <div v-if="timelineLoading" class="text-center py-12 text-surface-400">
-              <div class="size-6 rounded-full border-2 border-brand-200 border-t-brand-600 dark:border-brand-800 dark:border-t-brand-400 animate-spin mx-auto mb-3" />
-              Loading timeline…
-            </div>
-
-            <!-- Error -->
-            <div
-              v-else-if="timelineError"
-              class="ui-alert ui-alert-danger p-5 text-center"
-            >
-              <AlertTriangle class="size-6 text-danger-400 mx-auto mb-2" />
-              <p class="text-sm text-danger-700 dark:text-danger-400">{{ timelineError }}</p>
-              <button
-                class="ui-inline-link-brand mt-3 text-sm font-medium"
-                @click="loadTimeline"
-              >
-                Retry
-              </button>
-            </div>
-
-            <!-- Empty -->
-            <div
-              v-else-if="timelineItems.length === 0"
-              class="ui-empty-panel p-8"
-            >
-              <div class="flex size-14 items-center justify-center rounded-2xl bg-surface-100 dark:bg-surface-800/60 mx-auto mb-3">
-                <History class="size-6 text-surface-400 dark:text-surface-500" />
-              </div>
-              <p class="text-sm font-medium text-surface-600 dark:text-surface-300">No activity recorded yet.</p>
-              <p class="text-xs text-surface-400 dark:text-surface-500 mt-1">Activity for this candidate will appear here.</p>
-            </div>
-
-            <!-- Timeline list -->
-            <div v-else>
-              <div
-                v-for="(item, index) in timelineItems"
-                :key="item.id"
-                class="flex gap-3 py-2 group"
-              >
-                <!-- Dot + connector -->
-                <div class="flex flex-col items-center shrink-0 mt-[3px]">
-                  <div
-                    class="size-[9px] rounded-full ring-2 ring-white dark:ring-surface-950 shrink-0"
-                    :class="getTimelineActionColor(item.action)"
-                  />
-                  <div
-                    v-if="index < timelineItems.length - 1"
-                    class="w-px flex-1 min-h-[14px] bg-surface-200 dark:bg-surface-700 mt-1"
-                  />
-                </div>
-
-                <!-- Content -->
-                <div class="min-w-0 flex-1">
-                  <p class="text-sm text-surface-700 dark:text-surface-200 leading-snug">
-                    {{ describeTimelineItem(item) }}
-                  </p>
-                  <div class="flex items-center gap-2 mt-0.5">
-                    <span class="text-[11px] text-surface-400 dark:text-surface-500 tabular-nums">
-                      {{ formatTimelineDate(item.createdAt) }}
-                    </span>
-                    <span
-                      v-if="item.jobTitle"
-                      class="text-[10px] text-surface-400 dark:text-surface-500 bg-surface-100 dark:bg-surface-800 rounded px-1.5 py-0.5 truncate max-w-[140px]"
-                    >
-                      {{ item.jobTitle }}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+          <ApplicationTimelinePanel
+            v-if="activeTab === 'timeline'"
+            :items="timelineItems"
+            :loading="timelineLoading"
+            :error="timelineError"
+            @retry="loadTimeline"
+          />
 
         </template>
       </div>

--- a/app/components/CandidateDetailSidebar.vue
+++ b/app/components/CandidateDetailSidebar.vue
@@ -3,7 +3,6 @@ import {
   X, User, Calendar, Hash, FileText,
   ExternalLink, Phone, Upload, Brain, History,
 } from 'lucide-vue-next'
-import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
 import {
   getApplicationTransitionButtonClass,
   getApplicationTransitionLabel,

--- a/app/composables/useApplicationDocumentActions.ts
+++ b/app/composables/useApplicationDocumentActions.ts
@@ -1,0 +1,138 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { computed, toValue } from 'vue'
+
+type PreviewableDocument = {
+  id: string
+  originalFilename?: string | null
+  mimeType?: string | null
+}
+
+type UseApplicationDocumentActionsOptions = {
+  candidateId: MaybeRefOrGetter<string | null | undefined>
+  documents?: () => PreviewableDocument[] | undefined
+  afterMutation?: () => Promise<void> | void
+  trackDownloads?: boolean
+}
+
+export function useApplicationDocumentActions(options: UseApplicationDocumentActionsOptions) {
+  const toast = useToast()
+  const { track } = useTrack()
+  const { handlePreviewReadOnlyError } = usePreviewReadOnly()
+  const { uploadDocument, downloadDocument, getPreviewUrl, deleteDocument } = useDocuments()
+
+  const fileInput = ref<HTMLInputElement | null>(null)
+  const selectedDocType = ref<'resume' | 'cover_letter' | 'other'>('resume')
+  const isUploading = ref(false)
+  const showDocDeleteConfirm = ref<string | null>(null)
+  const isDeletingDoc = ref(false)
+  const reparsingDocId = ref<string | null>(null)
+
+  const documentPreview = useDocumentPreview({
+    documents: options.documents ?? (() => []),
+    getPreviewUrl,
+    downloadDocument,
+    onDownloadError: () => toast.error('Failed to download document'),
+  })
+
+  const documentPreviewState = computed(() => ({
+    showPreview: documentPreview.showPreview.value,
+    previewUrl: documentPreview.previewUrl.value,
+    previewFilename: documentPreview.previewFilename.value,
+    previewDocId: documentPreview.previewDocId.value,
+    previewError: documentPreview.previewError.value,
+    isPdfPreview: documentPreview.isPdfPreview.value,
+  }))
+
+  function triggerFileSelect() {
+    fileInput.value?.click()
+  }
+
+  async function handleFileSelected(event: Event) {
+    const input = event.target as HTMLInputElement
+    const file = input.files?.[0]
+    const candidateId = toValue(options.candidateId)
+    if (!file || !candidateId) return
+
+    isUploading.value = true
+
+    try {
+      await uploadDocument(candidateId, file, selectedDocType.value)
+      await options.afterMutation?.()
+    } catch (err: any) {
+      toast.error('Upload failed', {
+        message: err.data?.statusMessage ?? err.statusMessage,
+        statusCode: err.data?.statusCode ?? err.statusCode,
+      })
+    } finally {
+      isUploading.value = false
+      input.value = ''
+    }
+  }
+
+  async function handleReparse(docId: string) {
+    reparsingDocId.value = docId
+    try {
+      await $fetch(`/api/documents/${docId}/parse`, {
+        method: 'POST',
+        headers: useRequestHeaders(['cookie']),
+      })
+      toast.add({ title: 'Resume parsed successfully', type: 'success' })
+      await options.afterMutation?.()
+    } catch (err: any) {
+      toast.add({
+        title: 'Parse failed',
+        message: err?.data?.statusMessage ?? 'Could not extract text from this document.',
+        type: 'error',
+      })
+    } finally {
+      reparsingDocId.value = null
+    }
+  }
+
+  async function handleDownload(docId: string) {
+    try {
+      if (options.trackDownloads !== false) {
+        track('document_downloaded', { document_id: docId })
+      }
+      await downloadDocument(docId)
+    } catch {
+      toast.error('Failed to download document')
+    }
+  }
+
+  async function handleDeleteDoc(docId: string) {
+    const candidateId = toValue(options.candidateId)
+    if (!candidateId) return
+
+    isDeletingDoc.value = true
+    try {
+      await deleteDocument(docId, candidateId)
+      await options.afterMutation?.()
+      showDocDeleteConfirm.value = null
+    } catch (err: any) {
+      if (handlePreviewReadOnlyError(err)) return
+      toast.error('Failed to delete document', {
+        message: err.data?.statusMessage,
+        statusCode: err.data?.statusCode,
+      })
+    } finally {
+      isDeletingDoc.value = false
+    }
+  }
+
+  return {
+    fileInput,
+    selectedDocType,
+    isUploading,
+    showDocDeleteConfirm,
+    isDeletingDoc,
+    reparsingDocId,
+    documentPreview,
+    documentPreviewState,
+    triggerFileSelect,
+    handleFileSelected,
+    handleReparse,
+    handleDownload,
+    handleDeleteDoc,
+  }
+}

--- a/app/composables/useApplicationDocumentActions.ts
+++ b/app/composables/useApplicationDocumentActions.ts
@@ -60,8 +60,8 @@ export function useApplicationDocumentActions(options: UseApplicationDocumentAct
       await options.afterMutation?.()
     } catch (err: any) {
       toast.error('Upload failed', {
-        message: err.data?.statusMessage ?? err.statusMessage,
-        statusCode: err.data?.statusCode ?? err.statusCode,
+        message: err?.data?.statusMessage ?? err?.statusMessage ?? 'Upload failed.',
+        statusCode: err?.data?.statusCode ?? err?.statusCode,
       })
     } finally {
       isUploading.value = false

--- a/app/composables/useApplicationPanelClass.ts
+++ b/app/composables/useApplicationPanelClass.ts
@@ -1,0 +1,23 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { computed, toValue } from 'vue'
+
+export type ApplicationPanelSurface = 'sidebar' | 'drawer' | 'page'
+
+export const APPLICATION_PANEL_PAGE_CLASS = 'ui-panel ui-dashboard-panel'
+export const APPLICATION_PANEL_DRAWER_CLASS = 'border border-white/12 bg-white/[0.025]'
+export const APPLICATION_PANEL_SIDEBAR_CLASS = 'ui-panel'
+
+export function getApplicationPanelClass(surface: ApplicationPanelSurface = 'page') {
+  switch (surface) {
+    case 'sidebar':
+      return APPLICATION_PANEL_SIDEBAR_CLASS
+    case 'drawer':
+      return APPLICATION_PANEL_DRAWER_CLASS
+    default:
+      return APPLICATION_PANEL_PAGE_CLASS
+  }
+}
+
+export function useApplicationPanelClass(surface: MaybeRefOrGetter<ApplicationPanelSurface | undefined>) {
+  return computed(() => getApplicationPanelClass(toValue(surface) ?? 'page'))
+}

--- a/app/composables/useApplicationScoringData.ts
+++ b/app/composables/useApplicationScoringData.ts
@@ -1,0 +1,54 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { computed, toValue } from 'vue'
+import type { ScoringBand } from '~~/shared/scoring-bands'
+
+export type ApplicationScoresResponse = {
+  scoreBand?: ScoringBand | null
+  compositeScore?: number | null
+  latestRun?: {
+    id: string
+    summary: string | null
+  } | null
+}
+
+type UseApplicationScoringDataOptions = {
+  applicationId: MaybeRefOrGetter<string>
+  applicationScore?: MaybeRefOrGetter<number | null | undefined>
+}
+
+export function useApplicationScoringData(options: UseApplicationScoringDataOptions) {
+  const applicationId = computed(() => toValue(options.applicationId))
+
+  const { data: scoringData, refresh: refreshScoring } = useFetch<ApplicationScoresResponse>(
+    () => `/api/applications/${applicationId.value}/scores`,
+    {
+      key: computed(() => `application-scores-${applicationId.value}`),
+      headers: useRequestHeaders(['cookie']),
+      watch: [applicationId],
+    },
+  )
+
+  const scoringSummary = computed(() => {
+    const summary = scoringData.value?.latestRun?.summary
+    return typeof summary === 'string' ? summary.trim() : ''
+  })
+
+  const scoringSummaryFallback = computed(() => {
+    const score = toValue(options.applicationScore)
+    if (score != null) {
+      return 'No AI summary was stored for this score. Re-score to generate one.'
+    }
+
+    return 'Run analysis to generate an AI scoring summary.'
+  })
+
+  const scoreBand = computed(() => scoringData.value?.scoreBand ?? null)
+
+  return {
+    scoringData,
+    refreshScoring,
+    scoringSummary,
+    scoringSummaryFallback,
+    scoreBand,
+  }
+}

--- a/app/composables/useApplicationScoringPanel.ts
+++ b/app/composables/useApplicationScoringPanel.ts
@@ -1,0 +1,63 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { toValue } from 'vue'
+
+type ApplicationScoringTarget = {
+  score: number | null
+  job: {
+    id: string
+  }
+}
+
+type UseApplicationScoringPanelOptions = {
+  applicationId: MaybeRefOrGetter<string>
+  application: MaybeRefOrGetter<ApplicationScoringTarget | null | undefined>
+  source: string
+  refreshApplication?: boolean
+  refresh?: () => Promise<unknown> | unknown
+}
+
+export function useApplicationScoringPanel(options: UseApplicationScoringPanelOptions) {
+  const application = computed(() => toValue(options.application))
+
+  const {
+    scoringData,
+    refreshScoring,
+    scoringSummary,
+    scoringSummaryFallback,
+    scoreBand,
+  } = useApplicationScoringData({
+    applicationId: options.applicationId,
+    applicationScore: computed(() => application.value?.score),
+  })
+
+  const { isScoringApplication, scoreApplicationCandidate } = useApplicationScoring()
+
+  async function scoreCurrentApplication() {
+    const currentApplication = application.value
+    if (!currentApplication) return
+
+    const refreshApplication = options.refreshApplication ?? true
+    const result = await scoreApplicationCandidate(toValue(options.applicationId), {
+      refreshApplication,
+      refresh: options.refresh,
+      jobId: currentApplication.job.id,
+      source: options.source,
+    })
+
+    if (result && !refreshApplication && currentApplication) {
+      currentApplication.score = result.compositeScore
+    }
+
+    await refreshScoring()
+  }
+
+  return {
+    scoringData,
+    refreshScoring,
+    scoringSummary,
+    scoringSummaryFallback,
+    scoreBand,
+    isScoringApplication,
+    scoreCurrentApplication,
+  }
+}

--- a/app/composables/useApplicationTimeline.ts
+++ b/app/composables/useApplicationTimeline.ts
@@ -1,0 +1,122 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { toValue } from 'vue'
+
+export interface ApplicationTimelineEntry {
+  id: string
+  action: string
+  resourceType: string
+  resourceId: string
+  metadata: Record<string, unknown> | null
+  createdAt: string
+  actorName: string | null
+  actorEmail: string | null
+  resourceName: string | null
+  jobTitle: string | null
+  candidateName: string | null
+}
+
+export const APPLICATION_TIMELINE_ACTION_LABELS: Record<string, string> = {
+  created: 'Created',
+  updated: 'Updated',
+  deleted: 'Deleted',
+  status_changed: 'Status changed',
+  comment_added: 'Comment added',
+  scored: 'Scored',
+  scheduled: 'Scheduled',
+}
+
+export function formatApplicationTimelineDate(dateStr: string) {
+  const date = new Date(dateStr)
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function getApplicationTimelineActionColor(action: string): string {
+  switch (action) {
+    case 'created':
+      return 'bg-green-500'
+    case 'status_changed':
+      return 'bg-blue-500'
+    case 'updated':
+      return 'bg-amber-500'
+    case 'deleted':
+      return 'bg-danger-500'
+    case 'comment_added':
+      return 'bg-violet-500'
+    case 'scored':
+      return 'bg-teal-500'
+    case 'scheduled':
+      return 'bg-brand-500'
+    default:
+      return 'bg-surface-400'
+  }
+}
+
+export function describeApplicationTimelineItem(item: ApplicationTimelineEntry): string {
+  const actor = item.actorName ?? item.actorEmail ?? 'System'
+  const action = APPLICATION_TIMELINE_ACTION_LABELS[item.action] ?? item.action
+  const resource = item.resourceType
+
+  if (item.action === 'status_changed' && item.metadata) {
+    const from = item.metadata.from_status ?? item.metadata.fromStatus
+    const to = item.metadata.to_status ?? item.metadata.toStatus
+    if (from && to) return `${actor} changed ${resource} status from ${from} to ${to}`
+  }
+
+  if (item.action === 'scored' && item.metadata) {
+    const score = item.metadata.score
+    if (score != null) return `${actor} scored ${resource} — ${score} pts`
+  }
+
+  return `${actor} ${action.toLowerCase()} ${resource}`
+}
+
+type UseApplicationTimelineOptions = {
+  candidateId: MaybeRefOrGetter<string | null | undefined>
+}
+
+export function useApplicationTimeline(options: UseApplicationTimelineOptions) {
+  const timelineItems = ref<ApplicationTimelineEntry[]>([])
+  const timelineLoading = ref(false)
+  const timelineError = ref<string | null>(null)
+  const timelineLoaded = ref(false)
+
+  async function loadTimeline() {
+    const candidateId = toValue(options.candidateId)
+    if (!candidateId) return
+
+    timelineLoading.value = true
+    timelineError.value = null
+
+    try {
+      const result = await $fetch<{ items: ApplicationTimelineEntry[] }>('/api/activity-log/candidate-timeline', {
+        query: { candidateId },
+      })
+      timelineItems.value = result.items
+      timelineLoaded.value = true
+    } catch (err: any) {
+      timelineError.value = err?.data?.statusMessage ?? 'Failed to load timeline'
+    } finally {
+      timelineLoading.value = false
+    }
+  }
+
+  function resetTimeline() {
+    timelineItems.value = []
+    timelineLoaded.value = false
+    timelineError.value = null
+  }
+
+  return {
+    timelineItems,
+    timelineLoading,
+    timelineError,
+    timelineLoaded,
+    loadTimeline,
+    resetTimeline,
+  }
+}

--- a/app/pages/dashboard/applications/[id].vue
+++ b/app/pages/dashboard/applications/[id].vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
-import { User, Briefcase, Calendar, Clock, FileText, MessageSquare, Brain, Loader2 } from 'lucide-vue-next'
+import { User, Briefcase, Calendar } from 'lucide-vue-next'
 import {
   getApplicationTransitionActionLabel,
   getApplicationTransitionButtonClass,
 } from '~/utils/status-display'
 import { formatPhoneNumber } from '~/utils/phone-format'
-import { formatResponseValue } from '~/utils/application-response-format'
 
 definePageMeta({
   layout: 'dashboard',
@@ -15,44 +14,21 @@ definePageMeta({
 const route = useRoute()
 const applicationId = route.params.id as string
 
-type ApplicationScoresResponse = {
-  compositeScore: number | null
-  scores: Array<{
-    criterionKey: string
-    maxScore: number
-    score: number
-    confidence: number
-    evidence: string
-    strengths: string[] | null
-    gaps: string[] | null
-    criterionName: string | null
-    weight: number | null
-    category: string | null
-  }>
-  latestRun: {
-    id: string
-    status: string
-    provider: string
-    model: string
-    compositeScore: number | null
-    promptTokens: number | null
-    completionTokens: number | null
-    createdAt: string
-    summary: string | null
-  } | null
-}
-
 const { application, status: fetchStatus, error, refresh, updateApplication } = useApplication(applicationId)
-const { isScoringApplication, scoreApplicationCandidate } = useApplicationScoring()
-const { data: scoringData, refresh: refreshScoring } = useFetch<ApplicationScoresResponse>(
-  `/api/applications/${applicationId}/scores`,
-  {
-    key: `application-scores-${applicationId}`,
-    headers: useRequestHeaders(['cookie']),
-  },
-)
-
 const { formatCandidateName } = useOrgSettings()
+
+const {
+  scoringData,
+  scoringSummary,
+  scoringSummaryFallback,
+  isScoringApplication,
+  scoreCurrentApplication,
+} = useApplicationScoringPanel({
+  applicationId,
+  application,
+  source: 'application_detail_page',
+  refresh,
+})
 
 useSeoMeta({
   title: computed(() =>
@@ -63,24 +39,22 @@ useSeoMeta({
 })
 
 const showInterviewSidebar = ref(false)
-const scoringSummary = computed(() => {
-  const summary = scoringData.value?.latestRun?.summary
-  return typeof summary === 'string' ? summary.trim() : ''
-})
-const scoringSummaryFallback = computed(() => {
-  if (application.value?.score != null) {
-    return 'No AI summary was stored for this score. Re-score to generate one.'
-  }
-
-  return 'Run analysis to generate an AI scoring summary.'
-})
 
 const { allowedTransitions, isTransitioning, transitionToStatus } = useApplicationStatusActions({
   application,
   updateStatus: status => updateApplication({ status: status as any }),
 })
 
-const { isEditingNotes, notesInput, isSavingNotes, notesSaveStatus, notesTextarea, startEditNotes, saveNotes, autosaveNotes, finishEditNotes } = useEditableApplicationNotes({
+const {
+  isEditingNotes,
+  notesInput,
+  isSavingNotes,
+  notesSaveStatus,
+  startEditNotes,
+  saveNotes,
+  autosaveNotes,
+  finishEditNotes,
+} = useEditableApplicationNotes({
   application,
   focusOnEdit: true,
   save: notes => updateApplication({ notes }),
@@ -89,17 +63,6 @@ const { isEditingNotes, notesInput, isSavingNotes, notesSaveStatus, notesTextare
 function openInterviewScheduler() {
   showInterviewSidebar.value = true
 }
-
-async function scoreCurrentApplication() {
-  if (!application.value) return
-  await scoreApplicationCandidate(applicationId, {
-    refresh,
-    jobId: application.value.job.id,
-    source: 'application_detail_page',
-  })
-  await refreshScoring()
-}
-
 </script>
 
 <template>
@@ -240,118 +203,33 @@ async function scoreCurrentApplication() {
           </dl>
         </div>
 
-        <!-- Application scoring -->
-        <div class="ui-panel ui-dashboard-panel p-5 md:col-span-2">
-          <div class="mb-5 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div class="flex items-center gap-2">
-              <Brain class="size-4 text-surface-500 dark:text-surface-400" />
-              <h2 class="text-sm font-semibold text-surface-700 dark:text-surface-200">Scoring</h2>
-            </div>
-            <div class="flex items-center gap-2">
-              <ScoringFeedbackControl
-                :application-id="applicationId"
-                :analysis-run-id="scoringData?.latestRun?.id ?? null"
-              />
-              <button
-                type="button"
-                :disabled="isScoringApplication"
-                class="factory-button-cta factory-button-premium inline-flex h-8 min-h-8 cursor-pointer items-center justify-center gap-1.5 px-2.5 py-0 text-[11px] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                @click="scoreCurrentApplication"
-              >
-                <Loader2 v-if="isScoringApplication" class="size-3 animate-spin" />
-                <Brain v-else class="size-3" />
-                {{ isScoringApplication ? 'Scoring...' : (application.score != null ? 'Re-score' : 'Run Analysis') }}
-              </button>
-            </div>
-          </div>
-
-          <dl class="grid gap-5 text-sm md:grid-cols-[10rem_minmax(0,1fr)]">
-            <div>
-              <dt class="text-xs font-semibold uppercase tracking-[0.18em] text-surface-500 dark:text-surface-500">Score</dt>
-              <dd class="mt-2 text-2xl font-semibold text-surface-900 dark:text-white">
-                {{ application.score != null ? application.score : '—' }}
-                <span v-if="application.score != null" class="ml-1 text-sm font-medium text-surface-500 dark:text-surface-500">
-                  pts
-                </span>
-              </dd>
-            </div>
-            <div>
-              <dt class="text-xs font-semibold uppercase tracking-[0.18em] text-surface-500 dark:text-surface-500">
-                AI summary
-              </dt>
-              <dd
-                v-if="scoringSummary"
-                class="mt-2 max-w-3xl text-sm leading-6 text-surface-700 dark:text-surface-300"
-              >
-                {{ scoringSummary }}
-              </dd>
-              <dd
-                v-else
-                class="mt-2 max-w-3xl text-sm leading-6 text-surface-500 dark:text-surface-500"
-              >
-                {{ scoringSummaryFallback }}
-              </dd>
-            </div>
-          </dl>
-        </div>
+        <ApplicationScoringPanel
+          surface="page"
+          :application-id="applicationId"
+          :score="application.score"
+          :analysis-run-id="scoringData?.latestRun?.id ?? null"
+          :scoring-summary="scoringSummary"
+          :scoring-summary-fallback="scoringSummaryFallback"
+          :is-scoring="isScoringApplication"
+          full-width
+          @score="scoreCurrentApplication"
+        />
       </div>
 
-      <!-- Notes -->
-      <div class="mt-4 ui-panel ui-dashboard-panel p-5 mb-4">
-        <div class="flex items-center justify-between mb-3">
-          <div class="flex items-center gap-2">
-            <MessageSquare class="size-4 text-surface-500 dark:text-surface-400" />
-            <h2 class="text-sm font-semibold text-surface-700 dark:text-surface-200">Notes</h2>
-          </div>
-          <button
-            v-if="!isEditingNotes && application.notes"
-            class="cursor-pointer text-xs text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300 font-medium transition-colors"
-            @click="startEditNotes"
-          >
-            Edit
-          </button>
-        </div>
-
-        <div v-if="isEditingNotes">
-          <textarea
-            ref="notesTextarea"
-            v-model="notesInput"
-            rows="4"
-            placeholder="Add notes about this application…"
-            class="w-full border border-white/16 bg-black/45 px-3 py-2 text-sm text-white placeholder:text-white/34 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20 transition-colors"
-            @input="autosaveNotes"
-            @blur="saveNotes"
-          />
-          <div class="flex items-center gap-2 mt-2">
-            <p class="min-w-0 flex-1 text-xs text-surface-400" role="status">
-              {{ notesSaveStatus === 'saving' || isSavingNotes ? 'Saving notes...' : notesSaveStatus === 'saved' ? 'Notes saved' : notesSaveStatus === 'error' ? 'Autosave failed' : 'Automatically saves changes' }}
-            </p>
-            <button
-              class="factory-toolbar-button cursor-pointer border px-3 py-1.5 text-xs font-medium text-white/78 hover:text-white transition-colors"
-              :disabled="isSavingNotes"
-              @click="finishEditNotes"
-            >
-              Done
-            </button>
-          </div>
-        </div>
-
-        <p
-          v-else-if="application.notes"
-          class="text-sm text-surface-600 dark:text-surface-300 whitespace-pre-wrap"
-        >
-          {{ application.notes }}
-        </p>
-        <button
-          v-else
-          type="button"
-          class="group flex w-full cursor-pointer items-center justify-between border border-dashed border-white/12 bg-black px-3 py-3 text-left text-sm text-surface-400 transition-colors hover:border-brand-500/70 hover:bg-brand-500/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-brand-500/40"
-          @click="startEditNotes"
-        >
-          <span class="italic">No notes yet.</span>
-          <span class="text-xs font-semibold uppercase text-brand-400 transition-colors group-hover:text-brand-300">Add Notes</span>
-        </button>
-      </div>
+      <ApplicationNotesPanel
+        surface="page"
+        :notes="application.notes"
+        :is-editing-notes="isEditingNotes"
+        :notes-input="notesInput"
+        :is-saving-notes="isSavingNotes"
+        :notes-save-status="notesSaveStatus"
+        focus-on-edit
+        @update:notes-input="notesInput = $event"
+        @start-edit="startEditNotes"
+        @autosave="autosaveNotes"
+        @save="saveNotes"
+        @finish-edit="finishEditNotes"
+      />
 
       <!-- Custom properties (Notion-style) -->
       <div class="ui-panel ui-dashboard-panel p-4 mb-4">
@@ -365,32 +243,11 @@ async function scoreCurrentApplication() {
         />
       </div>
 
-      <!-- Question Responses -->
-      <div
+      <ApplicationResponsesPanel
         v-if="application.responses && application.responses.length > 0"
-        class="ui-panel ui-dashboard-panel p-5"
-      >
-        <div class="flex items-center gap-2 mb-3">
-          <FileText class="size-4 text-surface-500 dark:text-surface-400" />
-          <h2 class="text-sm font-semibold text-surface-700 dark:text-surface-200">
-            Application Responses ({{ application.responses.length }})
-          </h2>
-        </div>
-        <div class="space-y-3">
-          <div
-            v-for="response in application.responses"
-            :key="response.id"
-            class="border-b border-white/10 pb-3 last:border-0 last:pb-0"
-          >
-            <dt class="text-xs font-medium text-surface-500 dark:text-surface-400 mb-0.5">
-              {{ response.question?.label ?? 'Unknown question' }}
-            </dt>
-            <dd class="text-sm text-surface-700 dark:text-surface-200">
-              {{ formatResponseValue(response.value) }}
-            </dd>
-          </div>
-        </div>
-      </div>
+        surface="page"
+        :responses="application.responses"
+      />
     </template>
   </div>
 

--- a/app/pages/dashboard/candidates/[id].vue
+++ b/app/pages/dashboard/candidates/[id].vue
@@ -153,63 +153,22 @@ function openScheduleInterview(app: { id: string; job: { title: string } }) {
 // Documents — upload, download, delete
 // ─────────────────────────────────────────────
 
-const { uploadDocument, downloadDocument, getPreviewUrl, deleteDocument } = useDocuments()
-
-const fileInput = ref<HTMLInputElement | null>(null)
-const selectedDocType = ref<'resume' | 'cover_letter' | 'other'>('resume')
-const isUploading = ref(false)
-const showDocDeleteConfirm = ref<string | null>(null)
-const isDeletingDoc = ref(false)
-const documentPreview = useDocumentPreview({
+const {
+  fileInput,
+  selectedDocType,
+  isUploading,
+  showDocDeleteConfirm,
+  isDeletingDoc,
+  documentPreview,
+  documentPreviewState,
+  triggerFileSelect,
+  handleFileSelected,
+  handleDeleteDoc,
+} = useApplicationDocumentActions({
+  candidateId,
   documents: () => candidate.value?.documents,
-  getPreviewUrl,
-  downloadDocument,
-  onDownloadError: () => toast.error('Failed to download document'),
+  trackDownloads: false,
 })
-const documentPreviewState = computed(() => ({
-  showPreview: documentPreview.showPreview.value,
-  previewUrl: documentPreview.previewUrl.value,
-  previewFilename: documentPreview.previewFilename.value,
-  previewDocId: documentPreview.previewDocId.value,
-  previewError: documentPreview.previewError.value,
-  isPdfPreview: documentPreview.isPdfPreview.value,
-}))
-
-function triggerFileSelect() {
-  fileInput.value?.click()
-}
-
-async function handleFileSelected(event: Event) {
-  const input = event.target as HTMLInputElement
-  const file = input.files?.[0]
-  if (!file) return
-
-  isUploading.value = true
-
-  try {
-    await uploadDocument(candidateId, file, selectedDocType.value)
-  } catch (err: any) {
-    const msg = err.data?.statusMessage ?? err.statusMessage ?? 'Upload failed'
-    toast.error('Upload failed', { message: msg, statusCode: err.data?.statusCode ?? err.statusCode })
-  } finally {
-    isUploading.value = false
-    // Reset input so the same file can be re-selected
-    input.value = ''
-  }
-}
-
-async function handleDeleteDoc(docId: string) {
-  isDeletingDoc.value = true
-  try {
-    await deleteDocument(docId, candidateId)
-    showDocDeleteConfirm.value = null
-  } catch (err: any) {
-    if (handlePreviewReadOnlyError(err)) return
-    toast.error('Failed to delete document', { message: err.data?.statusMessage, statusCode: err.data?.statusCode })
-  } finally {
-    isDeletingDoc.value = false
-  }
-}
 
 </script>
 

--- a/app/utils/document-display.ts
+++ b/app/utils/document-display.ts
@@ -1,0 +1,5 @@
+export const DOCUMENT_TYPE_LABELS: Record<string, string> = {
+  resume: 'Resume',
+  cover_letter: 'Cover Letter',
+  other: 'Other',
+}

--- a/app/utils/interview-display.ts
+++ b/app/utils/interview-display.ts
@@ -1,0 +1,21 @@
+export const INTERVIEW_TYPE_LABELS: Record<string, string> = {
+  phone: 'Phone',
+  video: 'Video',
+  in_person: 'In-person',
+  panel: 'Panel',
+  technical: 'Technical',
+  take_home: 'Take-home',
+}
+
+export function formatInterviewDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function formatInterviewStatusLabel(status: string) {
+  return status === 'no_show' ? 'No show' : status
+}

--- a/tests/unit/action-error-toasts.test.ts
+++ b/tests/unit/action-error-toasts.test.ts
@@ -26,7 +26,6 @@ const toastTargets = [
   'app/components/JobQuestions.vue',
   'app/pages/dashboard/candidates/new.vue',
   'app/pages/dashboard/candidates/[id].vue',
-  'app/components/CandidateDetailSidebar.vue',
   'app/components/ApplicationLinkModal.vue',
   'app/components/FeedbackModal.vue',
   'app/components/PropertySchemaEditor.vue',
@@ -140,10 +139,6 @@ const disallowedInlineActionErrors: Record<string, string[]> = {
     'uploadError.value = msg',
     'v-if="uploadError"',
   ],
-  'app/components/CandidateDetailSidebar.vue': [
-    'uploadError.value = err.data?.statusMessage',
-    'v-if="uploadError"',
-  ],
   'app/components/ApplicationLinkModal.vue': [
     'applyError.value = err.data?.statusMessage',
     'v-if="applyError"',
@@ -171,6 +166,14 @@ describe('action error toast handling', () => {
         expect(source, `${path} should not keep inline action error pattern: ${pattern}`).not.toContain(pattern)
       }
     }
+
+    const sidebar = readProjectFile('app/components/CandidateDetailSidebar.vue')
+    const documentActions = readProjectFile('app/composables/useApplicationDocumentActions.ts')
+
+    expect(sidebar).toContain('useApplicationDocumentActions')
+    expect(sidebar).not.toContain('useToast()')
+    expect(documentActions).toContain('useToast()')
+    expect(documentActions).toContain('toast.error(')
   })
 
   it('keeps client-side form validation anchored in the form', () => {

--- a/tests/unit/application-detail-actions.test.ts
+++ b/tests/unit/application-detail-actions.test.ts
@@ -69,6 +69,7 @@ describe('application detail shared actions', () => {
 
   it('autosaves application notes instead of rendering manual save buttons', () => {
     const editableNotes = readProjectFile('app/composables/useEditableApplicationNotes.ts')
+    const notesPanel = readProjectFile('app/components/ApplicationNotesPanel.vue')
 
     expect(editableNotes).toContain('autosaveNotes')
     expect(editableNotes).toContain('notesSaveStatus')
@@ -77,11 +78,17 @@ describe('application detail shared actions', () => {
     expect(editableNotes).toContain('activeNotesSave')
     expect(editableNotes).toContain('Save notes after typing stops')
 
+    expect(notesPanel).toContain("emit('autosave')")
+    expect(notesPanel).toContain("emit('finishEdit')")
+    expect(notesPanel).toContain('notesSaveStatus')
+    expect(notesPanel).not.toContain("{{ isSavingNotes ? 'Saving…' : 'Save' }}")
+
     for (const path of applicationDetailSurfaces) {
       const source = readProjectFile(path)
 
-      expect(source, `${path} should use the autosave note handler`).toContain('@input="autosaveNotes"')
-      expect(source, `${path} should save before closing note edit mode`).toContain('@click="finishEditNotes"')
+      expect(source, `${path} should render the shared notes panel`).toContain('<ApplicationNotesPanel')
+      expect(source, `${path} should wire autosave through the shared panel`).toContain('@autosave="autosaveNotes"')
+      expect(source, `${path} should save before closing note edit mode`).toContain('@finish-edit="finishEditNotes"')
       expect(source, `${path} should surface autosave status`).toContain('notesSaveStatus')
       expect(source, `${path} should not render the old manual notes save label`).not.toContain("{{ isSavingNotes ? 'Saving…' : 'Save' }}")
     }

--- a/tests/unit/application-detail-epic5-pr1.test.ts
+++ b/tests/unit/application-detail-epic5-pr1.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function projectPath(path: string) {
+  return fileURLToPath(new URL(`../../${path}`, import.meta.url))
+}
+
+function readProjectFile(path: string) {
+  return readFileSync(projectPath(path), 'utf-8')
+}
+
+const applicationDetailSurfaces = [
+  'app/components/ApplicationDetailDrawer.vue',
+  'app/pages/dashboard/applications/[id].vue',
+  'app/components/CandidateDetailSidebar.vue',
+]
+
+const sharedPanels = [
+  'ApplicationNotesPanel',
+  'ApplicationScoringPanel',
+  'ApplicationInterviewsPanel',
+  'ApplicationDocumentsPanel',
+  'ApplicationResponsesPanel',
+  'ApplicationTimelinePanel',
+]
+
+describe('application detail epic 5 pr1', () => {
+  it('grounds shared sub-panels and composables in repo files', () => {
+    for (const path of [
+      'app/composables/useApplicationPanelClass.ts',
+      'app/composables/useApplicationScoringData.ts',
+      'app/composables/useApplicationScoringPanel.ts',
+      'app/composables/useApplicationDocumentActions.ts',
+      'app/composables/useApplicationTimeline.ts',
+      'app/utils/interview-display.ts',
+      'app/utils/document-display.ts',
+      'app/components/ApplicationNotesPanel.vue',
+      'app/components/ApplicationScoringPanel.vue',
+      'app/components/ApplicationInterviewsPanel.vue',
+      'app/components/ApplicationDocumentsPanel.vue',
+      'app/components/ApplicationResponsesPanel.vue',
+      'app/components/ApplicationTimelinePanel.vue',
+    ]) {
+      expect(existsSync(projectPath(path)), path).toBe(true)
+    }
+
+    const panelClass = readProjectFile('app/composables/useApplicationPanelClass.ts')
+    expect(panelClass).toContain("export type ApplicationPanelSurface = 'sidebar' | 'drawer' | 'page'")
+    expect(panelClass).toContain('export function getApplicationPanelClass')
+    expect(panelClass).toContain("export const APPLICATION_PANEL_SIDEBAR_CLASS = 'ui-panel'")
+    expect(panelClass).toContain("export const APPLICATION_PANEL_DRAWER_CLASS = 'border border-white/12 bg-white/[0.025]'")
+    expect(panelClass).toContain("export const APPLICATION_PANEL_PAGE_CLASS = 'ui-panel ui-dashboard-panel'")
+  })
+
+  it('uses shared sub-panels on application detail surfaces without hand-rolled panel markup', () => {
+    const expectations: Record<string, { uses: string[], avoids: string[] }> = {
+      'app/components/ApplicationDetailDrawer.vue': {
+        uses: ['<ApplicationNotesPanel', '<ApplicationScoringPanel', '<ApplicationResponsesPanel', 'useApplicationScoringPanel'],
+        avoids: ['const scoringSummary = computed', 'const documentTypeLabels', 'const interviewTypeLabels'],
+      },
+      'app/pages/dashboard/applications/[id].vue': {
+        uses: ['<ApplicationNotesPanel', '<ApplicationScoringPanel', '<ApplicationResponsesPanel', 'useApplicationScoringPanel'],
+        avoids: ['const scoringSummary = computed', 'type ApplicationScoresResponse', 'function scoreCurrentApplication'],
+      },
+      'app/components/CandidateDetailSidebar.vue': {
+        uses: [
+          '<ApplicationNotesPanel',
+          '<ApplicationInterviewsPanel',
+          '<ApplicationDocumentsPanel',
+          '<ApplicationResponsesPanel',
+          '<ApplicationTimelinePanel',
+          'useApplicationDocumentActions',
+          'useApplicationTimeline',
+        ],
+        avoids: [
+          'const documentTypeLabels',
+          'const interviewTypeLabels',
+          'function formatInterviewDate',
+          'const previewUrl = ref',
+          'function describeTimelineItem',
+        ],
+      },
+    }
+
+    for (const [path, { uses, avoids }] of Object.entries(expectations)) {
+      const source = readProjectFile(path)
+      for (const snippet of uses) {
+        expect(source, `${path} should use ${snippet}`).toContain(snippet)
+      }
+      for (const snippet of avoids) {
+        expect(source, `${path} should not define ${snippet}`).not.toContain(snippet)
+      }
+    }
+  })
+
+  it('keeps document and interview labels in shared helpers and panels', () => {
+    const documentsPanel = readProjectFile('app/components/ApplicationDocumentsPanel.vue')
+    const interviewsPanel = readProjectFile('app/components/ApplicationInterviewsPanel.vue')
+    const interviewDisplay = readProjectFile('app/utils/interview-display.ts')
+    const documentDisplay = readProjectFile('app/utils/document-display.ts')
+
+    expect(documentDisplay).toContain('DOCUMENT_TYPE_LABELS')
+    expect(documentsPanel).toContain('DOCUMENT_TYPE_LABELS')
+    expect(interviewDisplay).toContain('INTERVIEW_TYPE_LABELS')
+    expect(interviewsPanel).toContain('INTERVIEW_TYPE_LABELS')
+    expect(interviewsPanel).toContain('formatInterviewDate')
+  })
+
+  it('prefers shared sub-panels over a single variant prop on the shell', () => {
+    const notesPanel = readProjectFile('app/components/ApplicationNotesPanel.vue')
+    const scoringPanel = readProjectFile('app/components/ApplicationScoringPanel.vue')
+
+    for (const source of [notesPanel, scoringPanel]) {
+      expect(source).toContain('useApplicationPanelClass(() => props.surface)')
+      expect(source).not.toContain('variant=')
+    }
+
+    for (const path of applicationDetailSurfaces) {
+      const source = readProjectFile(path)
+      expect(source, `${path} should pass explicit surface props`).toMatch(/surface="(?:sidebar|drawer|page)"/)
+    }
+  })
+
+  it('shares document action wiring with the candidate detail page', () => {
+    const candidatePage = readProjectFile('app/pages/dashboard/candidates/[id].vue')
+    const documentActions = readProjectFile('app/composables/useApplicationDocumentActions.ts')
+
+    expect(candidatePage).toContain('useApplicationDocumentActions')
+    expect(candidatePage).not.toContain('const previewUrl = ref')
+    expect(documentActions).toContain('useDocumentPreview')
+    expect(documentActions).toContain('handleReparse')
+  })
+
+  it('keeps panel ownership split for PR2/PR3 follow-up', () => {
+    for (const panel of sharedPanels) {
+      expect(readProjectFile(`app/components/${panel}.vue`)).toContain('surface')
+    }
+
+    const sidebar = readProjectFile('app/components/CandidateDetailSidebar.vue')
+    const drawer = readProjectFile('app/components/ApplicationDetailDrawer.vue')
+
+    expect(sidebar).toContain('Candidate detail')
+    expect(drawer).toContain('<AppDetailDrawerShell')
+    expect(sidebar).not.toContain('<AppDetailDrawerShell')
+    expect(drawer).not.toContain('activeTab')
+  })
+})

--- a/tests/unit/back-buttons.test.ts
+++ b/tests/unit/back-buttons.test.ts
@@ -62,9 +62,9 @@ describe('back button hover treatment', () => {
 
   it('uses white-fill hover for inline document preview back buttons', () => {
     const documentsPanel = readSource('app/components/CandidateDocumentsPanel.vue')
-    const sidebar = readSource('app/components/CandidateDetailSidebar.vue')
+    const applicationDocumentsPanel = readSource('app/components/ApplicationDocumentsPanel.vue')
 
-    for (const source of [documentsPanel, sidebar]) {
+    for (const source of [documentsPanel, applicationDocumentsPanel]) {
       const backButton = elementContaining(source, 'button', 'Back to documents')
       expect(backButton).toContain(expectedHover)
       expect(backButton).not.toContain('ui-inline-link-brand')

--- a/tests/unit/candidate-detail-shared-panels.test.ts
+++ b/tests/unit/candidate-detail-shared-panels.test.ts
@@ -15,8 +15,10 @@ describe('candidate detail shared panels', () => {
       expect(source).toContain('<CandidateDetailsCard')
       expect(source).toContain('<CandidateApplicationsPanel')
       expect(source).toContain('<CandidateDocumentsPanel')
-      expect(source).toContain('useDocumentPreview')
     }
+
+    expect(drawer).toContain('useDocumentPreview')
+    expect(page).toContain('useApplicationDocumentActions')
 
     for (const path of [
       'app/components/CandidateDetailDrawer.vue',

--- a/tests/unit/scoring-feedback-history.test.ts
+++ b/tests/unit/scoring-feedback-history.test.ts
@@ -49,6 +49,7 @@ describe('scoring feedback and history', () => {
 
   it('renders the scoring feedback control next to scoring actions on both application detail surfaces', () => {
     const component = readProjectFile('app/components/ScoringFeedbackControl.vue')
+    const scoringPanel = readProjectFile('app/components/ApplicationScoringPanel.vue')
     const drawer = readProjectFile('app/components/ApplicationDetailDrawer.vue')
     const fullPage = readProjectFile('app/pages/dashboard/applications/[id].vue')
 
@@ -59,8 +60,12 @@ describe('scoring feedback and history', () => {
     expect(component).toContain("submitFeedback('up')")
     expect(component).toContain('$fetch(`/api/applications/${props.applicationId}/scoring-feedback`')
 
+    expect(scoringPanel).toContain('<ScoringFeedbackControl')
+    expect(scoringPanel).toContain(':application-id="applicationId"')
+    expect(scoringPanel).toContain(':analysis-run-id="analysisRunId"')
+
     for (const source of [drawer, fullPage]) {
-      expect(source).toContain('<ScoringFeedbackControl')
+      expect(source).toContain('<ApplicationScoringPanel')
       expect(source).toContain(':application-id="applicationId"')
       expect(source).toContain(':analysis-run-id="scoringData?.latestRun?.id ?? null"')
     }


### PR DESCRIPTION
Partial implementation of #227 / Epic 5 PR1 (#250).

## Design note: shared sub-panels vs variant prop

This PR extracts **focused sub-panels and composables** (notes, scoring, documents, interviews, responses, timeline) that application-detail surfaces can compose independently. Each panel accepts an explicit `surface` prop (`sidebar` | `drawer` | `page`) via `useApplicationPanelClass`, rather than pushing all layout differences into a single shell `variant` prop.

**Why sub-panels over one variant prop?**
- The three entry points keep meaningfully different chrome today (sidebar tabs vs drawer shell vs full page). A monolithic `variant` on one container would still leak panel-specific markup and data wiring upward.
- Sub-panels mirror the successful Epic 4 candidate-detail pattern (`CandidateDocumentsPanel`, `useCandidatePanelClass`) and let PR2/PR3 migrate shells incrementally without blocking on full surface unification.
- Composables own repeated fetch/action wiring (`useApplicationScoringPanel`, `useApplicationDocumentActions`, `useApplicationTimeline`) while panels own render-only concerns.

**Out of scope for PR1 (follow-up PR2/PR3):**
- Renaming `CandidateDetailSidebar` or unifying full application-detail shells
- Changing visible layout/UX on any touched entry point

## What changed

### New shared building blocks
- `ApplicationNotesPanel`, `ApplicationScoringPanel`, `ApplicationInterviewsPanel`, `ApplicationDocumentsPanel`, `ApplicationResponsesPanel`, `ApplicationTimelinePanel`
- `useApplicationPanelClass`, `useApplicationScoringData`, `useApplicationScoringPanel`, `useApplicationDocumentActions`, `useApplicationTimeline`
- `interview-display` / `document-display` utils

### Wired into existing surfaces (UX unchanged)
- `CandidateDetailSidebar.vue` — documents, interviews, notes, responses, timeline panels
- `ApplicationDetailDrawer.vue` — notes, scoring, responses panels
- `dashboard/applications/[id].vue` — notes, scoring, responses panels
- `dashboard/candidates/[id].vue` — shared document action composable

## Verification
- `npm run test:unit` — 976 passed
- `npm run typecheck` — passed

Closes partial #227; Epic 5 PR1 for #250.