### PR TITLE
refactor: Epic 8 e2e auth fixtures and a11y helpers (PR2)

### DIFF
--- a/e2e/accessibility.ts
+++ b/e2e/accessibility.ts
@@ -29,6 +29,42 @@ export async function expectNoA11yViolations(page: Page, options: AxeOptions = {
   expect(violations).toEqual([])
 }
 
+export async function runAxeScan(page: Page) {
+  const results = await new AxeBuilder({ page })
+    .disableRules([
+      'color-contrast',
+      'heading-order',
+      'landmark-main-is-top-level',
+      'landmark-no-duplicate-main',
+      'landmark-unique',
+      'page-has-heading-one',
+      'region',
+    ])
+    .analyze()
+
+  expect(results.violations).toEqual([])
+}
+
+export async function expectVisibleFocus(page: Page) {
+  const focusStyle = await page.evaluate(() => {
+    const el = document.activeElement as HTMLElement | null
+    if (!el) return null
+    const styles = window.getComputedStyle(el)
+    return {
+      outlineStyle: styles.outlineStyle,
+      outlineWidth: styles.outlineWidth,
+      boxShadow: styles.boxShadow,
+    }
+  })
+
+  expect(focusStyle).not.toBeNull()
+  expect(
+    focusStyle!.outlineStyle !== 'none'
+      || focusStyle!.outlineWidth !== '0px'
+      || focusStyle!.boxShadow !== 'none',
+  ).toBeTruthy()
+}
+
 export async function expectVisibleKeyboardFocus(locator: Locator) {
   await expect(locator).toBeFocused()
 
@@ -54,4 +90,16 @@ export async function tabUntilFocused(page: Page, locator: Locator, maxTabs = 8)
   }
 
   await expectVisibleKeyboardFocus(locator)
+}
+
+export async function openWithKeyboard(page: Page, trigger: Locator) {
+  await page.waitForLoadState('networkidle')
+  await trigger.press('Enter')
+  await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+}
+
+export async function expectFocusRestored(page: Page, trigger: Locator) {
+  await page.keyboard.press('Escape')
+  await expect(trigger).toBeFocused()
+  await expect(trigger).toHaveAttribute('aria-expanded', 'false')
 }

--- a/e2e/accessibility/dashboard-controls.spec.ts
+++ b/e2e/accessibility/dashboard-controls.spec.ts
@@ -1,10 +1,9 @@
 import {
-  expect,
   expectFocusRestored,
   openWithKeyboard,
   runAxeScan,
-  test,
-} from '../fixtures'
+} from '../accessibility'
+import { expect, test } from '../fixtures'
 
 test.describe('dashboard keyboard controls', () => {
   test('candidate table menus support keyboard open, navigation, and Escape restore', async ({ authenticatedPage: page }) => {

--- a/e2e/accessibility/keyboard-regression.spec.ts
+++ b/e2e/accessibility/keyboard-regression.spec.ts
@@ -1,11 +1,10 @@
 import {
-  expect,
   expectFocusRestored,
   expectVisibleFocus,
   openWithKeyboard,
   runAxeScan,
-  test,
-} from '../fixtures'
+} from '../accessibility'
+import { expect, test } from '../fixtures'
 
 test.describe('keyboard regression matrix', () => {
   test('public jobs page keeps search and filters keyboard reachable', async ({ page }) => {

--- a/e2e/critical-flows/auth-recovery-fake-mail.spec.ts
+++ b/e2e/critical-flows/auth-recovery-fake-mail.spec.ts
@@ -1,5 +1,5 @@
 import { rm } from 'node:fs/promises'
-import { test, expect } from '../fixtures'
+import { test, expect, createGuestPage, withGuestContext } from '../fixtures'
 import { type CapturedEmail, readCapturedEmails } from '../helpers/captured-emails'
 
 function extractResetUrl(email: CapturedEmail) {
@@ -23,81 +23,82 @@ test.describe('Auth recovery fake mail', () => {
     await rm(capturePath!, { force: true })
 
     const newPassword = `${testAccount.password}-Reset1`
-    const guestContext = await browser.newContext()
-    const guestPage = await guestContext.newPage()
+    const guest = await createGuestPage(browser)
+    const guestPage = guest.page
 
-    await guestPage.goto('/auth/forgot-password')
-    await guestPage.waitForLoadState('networkidle')
-    await expect(guestPage.getByRole('heading', { name: 'Reset your password' })).toBeVisible()
-    await guestPage.getByLabel('Email').fill(testAccount.email)
+    try {
+      await guestPage.goto('/auth/forgot-password')
+      await guestPage.waitForLoadState('networkidle')
+      await expect(guestPage.getByRole('heading', { name: 'Reset your password' })).toBeVisible()
+      await guestPage.getByLabel('Email').fill(testAccount.email)
 
-    await guestPage.getByRole('button', { name: 'Send reset link' }).click()
-    await expect(guestPage.getByText("If an account with that email exists, we've sent a password reset link.")).toBeVisible()
+      await guestPage.getByRole('button', { name: 'Send reset link' }).click()
+      await expect(guestPage.getByText("If an account with that email exists, we've sent a password reset link.")).toBeVisible()
 
-    await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
-      message: 'password reset email should be captured',
-      timeout: 10_000,
-    }).toBeGreaterThanOrEqual(1)
+      await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
+        message: 'password reset email should be captured',
+        timeout: 10_000,
+      }).toBeGreaterThanOrEqual(1)
 
-    const capturedEmails = await readCapturedEmails(capturePath!)
-    const resetEmail = capturedEmails.find(email => email.subject === 'Reset your password — Factory Careers')
-    expect(resetEmail, 'password reset email should be captured').toBeTruthy()
-    expect(resetEmail?.renderError, 'password reset email should render successfully').toBeUndefined()
-    expect(resetEmail?.to).toContain(testAccount.email)
-    expect(resetEmail?.text).toContain('Reset your password')
+      const capturedEmails = await readCapturedEmails(capturePath!)
+      const resetEmail = capturedEmails.find(email => email.subject === 'Reset your password — Factory Careers')
+      expect(resetEmail, 'password reset email should be captured').toBeTruthy()
+      expect(resetEmail?.renderError, 'password reset email should render successfully').toBeUndefined()
+      expect(resetEmail?.to).toContain(testAccount.email)
+      expect(resetEmail?.text).toContain('Reset your password')
 
-    const resetUrl = extractResetUrl(resetEmail!)
-    expect(resetUrl, 'reset email should contain a local reset URL').toBeTruthy()
-    const parsedResetUrl = new URL(resetUrl)
-    const apiToken = parsedResetUrl.pathname.match(/^\/api\/auth\/reset-password\/([^/]+)$/)?.[1]
-    expect(
-      parsedResetUrl.pathname === '/auth/reset-password' || Boolean(apiToken),
-      'reset email should link to a supported reset route',
-    ).toBe(true)
-    expect(parsedResetUrl.searchParams.get('token') ?? apiToken, 'reset email should include a reset token').toBeTruthy()
-    expect(parsedResetUrl.hostname).not.toBe('thefactoryhq.com')
+      const resetUrl = extractResetUrl(resetEmail!)
+      expect(resetUrl, 'reset email should contain a local reset URL').toBeTruthy()
+      const parsedResetUrl = new URL(resetUrl)
+      const apiToken = parsedResetUrl.pathname.match(/^\/api\/auth\/reset-password\/([^/]+)$/)?.[1]
+      expect(
+        parsedResetUrl.pathname === '/auth/reset-password' || Boolean(apiToken),
+        'reset email should link to a supported reset route',
+      ).toBe(true)
+      expect(parsedResetUrl.searchParams.get('token') ?? apiToken, 'reset email should include a reset token').toBeTruthy()
+      expect(parsedResetUrl.hostname).not.toBe('thefactoryhq.com')
 
-    const resetContext = await browser.newContext()
-    const resetPage = await resetContext.newPage()
-    await resetPage.goto(resetUrl)
-    await resetPage.waitForLoadState('networkidle')
-    await expect(resetPage.getByRole('heading', { name: 'Set new password' })).toBeVisible()
-    await resetPage.getByLabel('New password', { exact: true }).fill(newPassword)
-    await resetPage.getByLabel('Confirm new password').fill(newPassword)
+      await withGuestContext(browser, async (resetPage) => {
+        await resetPage.goto(resetUrl)
+        await resetPage.waitForLoadState('networkidle')
+        await expect(resetPage.getByRole('heading', { name: 'Set new password' })).toBeVisible()
+        await resetPage.getByLabel('New password', { exact: true }).fill(newPassword)
+        await resetPage.getByLabel('Confirm new password').fill(newPassword)
 
-    const [resetResponse] = await Promise.all([
-      resetPage.waitForResponse(
-        resp => resp.url().includes('/api/auth/reset-password') && resp.request().method() === 'POST',
-        { timeout: 30_000 },
-      ),
-      resetPage.getByRole('button', { name: 'Reset password' }).click(),
-    ])
-    expect(resetResponse.status(), `Reset password API returned ${resetResponse.status()}`).toBe(200)
-    await expect(resetPage.getByText('Your password has been reset successfully.')).toBeVisible()
-    await resetContext.close()
+        const [resetResponse] = await Promise.all([
+          resetPage.waitForResponse(
+            resp => resp.url().includes('/api/auth/reset-password') && resp.request().method() === 'POST',
+            { timeout: 30_000 },
+          ),
+          resetPage.getByRole('button', { name: 'Reset password' }).click(),
+        ])
+        expect(resetResponse.status(), `Reset password API returned ${resetResponse.status()}`).toBe(200)
+        await expect(resetPage.getByText('Your password has been reset successfully.')).toBeVisible()
+      })
 
-    const oldPasswordContext = await browser.newContext()
-    const oldPasswordPage = await oldPasswordContext.newPage()
-    const oldSignInResponse = await oldPasswordPage.request.post('/api/auth/sign-in/email', {
-      data: {
-        email: testAccount.email,
-        password: testAccount.password,
-      },
-    })
-    expect(oldSignInResponse.status(), 'old password should no longer sign in').toBeGreaterThanOrEqual(400)
-    await oldPasswordContext.close()
+      await withGuestContext(browser, async (oldPasswordPage) => {
+        const oldSignInResponse = await oldPasswordPage.request.post('/api/auth/sign-in/email', {
+          data: {
+            email: testAccount.email,
+            password: testAccount.password,
+          },
+        })
+        expect(oldSignInResponse.status(), 'old password should no longer sign in').toBeGreaterThanOrEqual(400)
+      })
 
-    const newSignInResponse = await guestPage.request.post('/api/auth/sign-in/email', {
-      data: {
-        email: testAccount.email,
-        password: newPassword,
-      },
-    })
-    expect(newSignInResponse.status(), `new password sign-in returned ${newSignInResponse.status()}`).toBe(200)
-    await guestPage.goto('/dashboard')
-    await guestPage.waitForLoadState('networkidle')
-    await expect(guestPage.getByRole('heading', { name: /Dashboard|Welcome/i })).toBeVisible({ timeout: 30_000 })
-
-    await guestContext.close()
+      const newSignInResponse = await guestPage.request.post('/api/auth/sign-in/email', {
+        data: {
+          email: testAccount.email,
+          password: newPassword,
+        },
+      })
+      expect(newSignInResponse.status(), `new password sign-in returned ${newSignInResponse.status()}`).toBe(200)
+      await guestPage.goto('/dashboard')
+      await guestPage.waitForLoadState('networkidle')
+      await expect(guestPage.getByRole('heading', { name: /Dashboard|Welcome/i })).toBeVisible({ timeout: 30_000 })
+    }
+    finally {
+      await guest.close()
+    }
   })
 })

--- a/e2e/critical-flows/candidate-documents.spec.ts
+++ b/e2e/critical-flows/candidate-documents.spec.ts
@@ -1,7 +1,7 @@
 import type { APIRequestContext, APIResponse, Page } from '@playwright/test'
 import { assertMutatingE2ESafety } from '../safety'
 import { test, expect } from '../fixtures'
-import { INVALID_PNG } from '../fixtures/test-buffers'
+import { createTextPdf, INVALID_PNG } from '../fixtures/test-buffers'
 import {
   createApplication,
   createCandidate,
@@ -23,44 +23,6 @@ type ActivityItem = {
   resourceId: string
   resourceName?: string | null
   candidateName?: string | null
-}
-
-function createTextPdf(text: string): Buffer {
-  const pdfText = text.replace(/[\\()]/g, match => `\\${match}`)
-  const streamContent = `BT /F1 12 Tf 72 700 Td (${pdfText}) Tj ET`
-  const chunks = ['%PDF-1.4\n']
-  const offsets = [0]
-
-  function appendObject(index: number, body: string) {
-    offsets[index] = Buffer.byteLength(chunks.join(''), 'utf8')
-    chunks.push(`${index} 0 obj\n${body}\nendobj\n`)
-  }
-
-  appendObject(1, '<< /Type /Catalog /Pages 2 0 R >>')
-  appendObject(2, '<< /Type /Pages /Kids [3 0 R] /Count 1 >>')
-  appendObject(3, '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>')
-  appendObject(4, [
-    `<< /Length ${Buffer.byteLength(streamContent, 'utf8')} >>`,
-    'stream',
-    streamContent,
-    'endstream',
-  ].join('\n'))
-  appendObject(5, '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>')
-
-  const xrefOffset = Buffer.byteLength(chunks.join(''), 'utf8')
-  chunks.push([
-    'xref',
-    '0 6',
-    '0000000000 65535 f ',
-    ...offsets.slice(1).map(offset => `${offset.toString().padStart(10, '0')} 00000 n `),
-    'trailer',
-    '<< /Size 6 /Root 1 0 R >>',
-    'startxref',
-    String(xrefOffset),
-    '%%EOF',
-  ].join('\n'))
-
-  return Buffer.from(chunks.join(''))
 }
 
 async function expectResponseStatus(response: APIResponse, expected: number, label: string) {

--- a/e2e/critical-flows/fake-mail.spec.ts
+++ b/e2e/critical-flows/fake-mail.spec.ts
@@ -1,6 +1,6 @@
 import { rm } from "node:fs/promises";
 import type { Page } from "@playwright/test";
-import { test, expect, selectFactorySelectOption } from "../fixtures";
+import { test, expect, selectFactorySelectOption, withGuestContext } from "../fixtures";
 import { readCapturedEmails } from "../helpers/captured-emails";
 
 const JOB_TITLE = "Email Capture Test Job";
@@ -75,27 +75,27 @@ test.describe("Fake mail capture", () => {
     expect(publishedJob.slug, "published job slug must be present").toBeTruthy();
     await expect(recruiterPage.getByRole("heading", { name: "Your job is live!" })).toBeVisible({ timeout: 30_000 });
 
-    const candidateContext = await browser.newContext();
-    const candidatePage = await candidateContext.newPage();
-    await candidatePage.goto(`/jobs/${publishedJob.slug}/apply`);
-    await candidatePage.waitForLoadState("networkidle");
-    await candidatePage.getByLabel("First name").fill(applicant.firstName);
-    await candidatePage.getByLabel("Last name").fill(applicant.lastName);
-    await candidatePage.getByLabel("Email").fill(applicant.email);
-    await selectFactorySelectOption(candidatePage, /Country/, "United States");
-    await selectFactorySelectOption(candidatePage, /State/, "California");
+    await withGuestContext(browser, async (candidatePage) => {
+      await candidatePage.goto(`/jobs/${publishedJob.slug}/apply`);
+      await candidatePage.waitForLoadState("networkidle");
+      await candidatePage.getByLabel("First name").fill(applicant.firstName);
+      await candidatePage.getByLabel("Last name").fill(applicant.lastName);
+      await candidatePage.getByLabel("Email").fill(applicant.email);
+      await selectFactorySelectOption(candidatePage, /Country/, "United States");
+      await selectFactorySelectOption(candidatePage, /State/, "California");
 
-    const submitButton = await advanceToSubmitButton(candidatePage);
-    const [applyResponse] = await Promise.all([
-      candidatePage.waitForResponse(
-        (resp) => resp.url().includes(`/api/public/jobs/${publishedJob.slug}/apply`) && resp.request().method() === "POST",
-        { timeout: 30_000 },
-      ),
-      submitButton.click(),
-    ]);
-    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201);
-    await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}/confirmation`, { waitUntil: "commit", timeout: 15_000 });
-    await expect(candidatePage.getByRole("heading", { name: "Application submitted" })).toBeVisible();
+      const submitButton = await advanceToSubmitButton(candidatePage);
+      const [applyResponse] = await Promise.all([
+        candidatePage.waitForResponse(
+          (resp) => resp.url().includes(`/api/public/jobs/${publishedJob.slug}/apply`) && resp.request().method() === "POST",
+          { timeout: 30_000 },
+        ),
+        submitButton.click(),
+      ]);
+      expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201);
+      await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}/confirmation`, { waitUntil: "commit", timeout: 15_000 });
+      await expect(candidatePage.getByRole("heading", { name: "Application submitted" })).toBeVisible();
+    });
 
     await expect.poll(async () => (await readCapturedEmails(capturePath!)).length, {
       message: "application submission should capture receipt and team alert emails",
@@ -119,7 +119,5 @@ test.describe("Fake mail capture", () => {
     expect(teamAlert?.text).toContain(applicant.email);
     expect(teamAlert?.text).toContain(jobTitle);
     expect(teamAlert?.text).toContain(`/dashboard/applications/`);
-
-    await candidateContext.close();
   });
 });

--- a/e2e/critical-flows/job-lifecycle.spec.ts
+++ b/e2e/critical-flows/job-lifecycle.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../fixtures'
+import { test, expect, createGuestPage } from '../fixtures'
 
 const JOB_TITLE = 'Lifecycle Close Test Job'
 const JOB_DESCRIPTION = 'A published job used to verify close/unpublish behavior.'
@@ -44,54 +44,58 @@ test.describe('Job lifecycle after publish', () => {
     expect(publishedJob.status).toBe('open')
     await expect(page.getByRole('heading', { name: 'Your job is live!' })).toBeVisible({ timeout: 30_000 })
 
-    const publicContext = await browser.newContext()
-    const publicPage = await publicContext.newPage()
-    await publicPage.goto(`/jobs/${publishedJob.slug}`)
-    await expect(publicPage.getByRole('heading', { name: jobTitle })).toBeVisible({ timeout: 15_000 })
-    await expect(publicPage.getByRole('link', { name: /apply/i }).first()).toBeVisible()
+    const guest = await createGuestPage(browser)
+    const publicPage = guest.page
 
-    await page.goto(`/dashboard/jobs/${publishedJob.id}`)
-    await page.waitForLoadState('networkidle')
-    const dashboardBanner = page.getByRole('banner')
-    await expect(page.getByText(jobTitle).first()).toBeVisible({ timeout: 15_000 })
-    await expect(dashboardBanner).toContainText('Open')
+    try {
+      await publicPage.goto(`/jobs/${publishedJob.slug}`)
+      await expect(publicPage.getByRole('heading', { name: jobTitle })).toBeVisible({ timeout: 15_000 })
+      await expect(publicPage.getByRole('link', { name: /apply/i }).first()).toBeVisible()
 
-    const closeButton = page.getByRole('button', { name: /Close this job so new candidates can no longer apply/i })
-    await expect(closeButton).toBeVisible({ timeout: 15_000 })
-    const [closeResponse] = await Promise.all([
-      page.waitForResponse(
-        resp => resp.url().includes(`/api/jobs/${publishedJob.id}`) && resp.request().method() === 'PATCH',
-        { timeout: 30_000 },
-      ),
-      closeButton.click(),
-    ])
-    expect(closeResponse.status(), `Close API returned ${closeResponse.status()}`).toBe(200)
-    const closedJob = await closeResponse.json() as { id: string; status: string }
-    expect(closedJob).toEqual(expect.objectContaining({ id: publishedJob.id, status: 'closed' }))
+      await page.goto(`/dashboard/jobs/${publishedJob.id}`)
+      await page.waitForLoadState('networkidle')
+      const dashboardBanner = page.getByRole('banner')
+      await expect(page.getByText(jobTitle).first()).toBeVisible({ timeout: 15_000 })
+      await expect(dashboardBanner).toContainText('Open')
 
-    const jobResponse = await page.request.get(`/api/jobs/${publishedJob.id}`)
-    expect(jobResponse.status(), `Job API returned ${jobResponse.status()}`).toBe(200)
-    await expect(await jobResponse.json()).toEqual(expect.objectContaining({ status: 'closed' }))
-    await expect(dashboardBanner).toContainText('Closed', { timeout: 10_000 })
+      const closeButton = page.getByRole('button', { name: /Close this job so new candidates can no longer apply/i })
+      await expect(closeButton).toBeVisible({ timeout: 15_000 })
+      const [closeResponse] = await Promise.all([
+        page.waitForResponse(
+          resp => resp.url().includes(`/api/jobs/${publishedJob.id}`) && resp.request().method() === 'PATCH',
+          { timeout: 30_000 },
+        ),
+        closeButton.click(),
+      ])
+      expect(closeResponse.status(), `Close API returned ${closeResponse.status()}`).toBe(200)
+      const closedJob = await closeResponse.json() as { id: string; status: string }
+      expect(closedJob).toEqual(expect.objectContaining({ id: publishedJob.id, status: 'closed' }))
 
-    await publicPage.goto(`/jobs/${publishedJob.slug}`)
-    await expect(publicPage.getByRole('heading', { name: 'Job Not Found' })).toBeVisible({ timeout: 15_000 })
-    await publicPage.goto(`/jobs/${publishedJob.slug}/apply`)
-    await expect(publicPage.getByRole('heading', { name: 'Position Not Found' })).toBeVisible({ timeout: 15_000 })
+      const jobResponse = await page.request.get(`/api/jobs/${publishedJob.id}`)
+      expect(jobResponse.status(), `Job API returned ${jobResponse.status()}`).toBe(200)
+      await expect(await jobResponse.json()).toEqual(expect.objectContaining({ status: 'closed' }))
+      await expect(dashboardBanner).toContainText('Closed', { timeout: 10_000 })
 
-    const applyAfterCloseResponse = await publicPage.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
-      data: {
-        firstName: 'Closed',
-        lastName: 'Applicant',
-        email: `closed.applicant.${Date.now()}.r${testInfo.retry}@example.com`,
-        country: 'United States',
-        state: 'CA',
-        responses: [],
-      },
-    })
-    expect(applyAfterCloseResponse.status(), 'Closed jobs must reject public application POSTs').toBe(404)
-    expect(await applyAfterCloseResponse.text()).toContain('not accepting applications')
+      await publicPage.goto(`/jobs/${publishedJob.slug}`)
+      await expect(publicPage.getByRole('heading', { name: 'Job Not Found' })).toBeVisible({ timeout: 15_000 })
+      await publicPage.goto(`/jobs/${publishedJob.slug}/apply`)
+      await expect(publicPage.getByRole('heading', { name: 'Position Not Found' })).toBeVisible({ timeout: 15_000 })
 
-    await publicContext.close()
+      const applyAfterCloseResponse = await publicPage.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
+        data: {
+          firstName: 'Closed',
+          lastName: 'Applicant',
+          email: `closed.applicant.${Date.now()}.r${testInfo.retry}@example.com`,
+          country: 'United States',
+          state: 'CA',
+          responses: [],
+        },
+      })
+      expect(applyAfterCloseResponse.status(), 'Closed jobs must reject public application POSTs').toBe(404)
+      expect(await applyAfterCloseResponse.text()).toContain('not accepting applications')
+    }
+    finally {
+      await guest.close()
+    }
   })
 })

--- a/e2e/critical-flows/org-admin-membership.spec.ts
+++ b/e2e/critical-flows/org-admin-membership.spec.ts
@@ -1,76 +1,12 @@
-import type { Browser, Page } from '@playwright/test'
 import { assertMutatingE2ESafety } from '../safety'
-import { expect, expectFloatingMenuNotClipped, selectFactorySelectOption, test } from '../fixtures'
+import { expect, expectFloatingMenuNotClipped, selectFactorySelectOption, signUpUser, test } from '../fixtures'
 import {
   lookupJoinRequestStatus,
   lookupMemberByEmail,
   lookupMembership,
 } from '../helpers/db'
 
-interface SignedInApplicant {
-  email: string
-  name: string
-  page: Page
-  close: () => Promise<void>
-}
-
-async function signUpWithoutOrganization(browser: Browser, baseURL: string, label: string): Promise<SignedInApplicant> {
-  const context = await browser.newContext({ baseURL })
-  const page = await context.newPage()
-  const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`
-  const account = {
-    name: `Org Admin ${label} ${id}`,
-    email: `org-admin-${label}-${id}@test.local`,
-    password: process.env.E2E_TEST_PASSWORD || 'TestPassword123!',
-  }
-
-  await page.goto('/auth/sign-up')
-  await page.waitForLoadState('networkidle')
-  await page.getByLabel('Name').fill(account.name)
-  await page.getByLabel('Email').fill(account.email)
-  await page.getByLabel('Password', { exact: true }).fill(account.password)
-  await page.getByLabel('Confirm password').fill(account.password)
-
-  await Promise.all([
-    page.waitForResponse(
-      resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200,
-      { timeout: 30_000 },
-    ),
-    page.getByRole('button', { name: 'Sign up' }).click(),
-  ])
-
-  await page.waitForURL(
-    url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'),
-    { waitUntil: 'commit', timeout: 30_000 },
-  )
-
-  if (page.url().includes('/auth/sign-in')) {
-    await page.waitForLoadState('networkidle')
-    await page.getByLabel('Email').fill(account.email)
-    await page.getByLabel('Password').fill(account.password)
-
-    await Promise.all([
-      page.waitForResponse(
-        resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200,
-        { timeout: 30_000 },
-      ),
-      page.getByRole('button', { name: 'Sign in' }).click(),
-    ])
-
-    await page.waitForURL('**/onboarding/**', { waitUntil: 'networkidle', timeout: 30_000 })
-  }
-  else {
-    await page.waitForLoadState('networkidle')
-  }
-
-  return {
-    ...account,
-    page,
-    close: () => context.close(),
-  }
-}
-
-async function createJoinRequest(page: Page, organizationId: string, message: string) {
+async function createJoinRequest(page: import('@playwright/test').Page, organizationId: string, message: string) {
   const response = await page.request.post('/api/join-requests', {
     data: {
       organizationId,
@@ -96,8 +32,14 @@ test.describe('Organization administration and join requests', () => {
     const ownerMembership = await lookupMembership(testAccount.email, testAccount.orgName)
     const unique = `${Date.now()}-r${testInfo.retry}`
     const renamedOrg = `E2E Org Admin ${unique}`
-    const approvedApplicant = await signUpWithoutOrganization(browser, baseURL, `approved-${testInfo.workerIndex}`)
-    const rejectedApplicant = await signUpWithoutOrganization(browser, baseURL, `rejected-${testInfo.workerIndex}`)
+    const approvedApplicant = await signUpUser(browser, {
+      label: `approved-${testInfo.workerIndex}`,
+      baseURL,
+    })
+    const rejectedApplicant = await signUpUser(browser, {
+      label: `rejected-${testInfo.workerIndex}`,
+      baseURL,
+    })
 
     try {
       await page.goto('/dashboard/settings', { waitUntil: 'networkidle' })

--- a/e2e/critical-flows/org-admin-membership.spec.ts
+++ b/e2e/critical-flows/org-admin-membership.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test'
 import { assertMutatingE2ESafety } from '../safety'
 import { expect, expectFloatingMenuNotClipped, selectFactorySelectOption, signUpUser, test } from '../fixtures'
 import {
@@ -6,7 +7,7 @@ import {
   lookupMembership,
 } from '../helpers/db'
 
-async function createJoinRequest(page: import('@playwright/test').Page, organizationId: string, message: string) {
+async function createJoinRequest(page: Page, organizationId: string, message: string) {
   const response = await page.request.post('/api/join-requests', {
     data: {
       organizationId,

--- a/e2e/critical-flows/public-localization.spec.ts
+++ b/e2e/critical-flows/public-localization.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, selectFactorySelectOption } from '../fixtures'
+import { test, expect, selectFactorySelectOption, withGuestContext } from '../fixtures'
 import { advanceToSubmitButton } from '../helpers/application-form'
 
 type JobResponse = {
@@ -61,10 +61,7 @@ test.describe('Public localization flow', () => {
     const publishedJob = await publishJobResponse.json() as JobResponse
     expect(publishedJob.status).toBe('open')
 
-    const candidateContext = await browser.newContext()
-    const candidatePage = await candidateContext.newPage()
-
-    try {
+    await withGuestContext(browser, async (candidatePage) => {
       await candidatePage.goto('/jobs?i18nTest=1')
       await expect(candidatePage.getByTestId('i18n-probe')).toHaveText('Language')
       await expect(candidatePage.getByRole('link', { name: jobTitle })).toBeVisible({ timeout: 15_000 })
@@ -105,8 +102,6 @@ test.describe('Public localization flow', () => {
       })
       await expect(candidatePage.getByRole('heading', { name: 'Application submitted' })).toBeVisible()
       await expect(candidatePage.getByRole('link', { name: 'Browse more positions' })).toHaveAttribute('href', '/es/jobs')
-    } finally {
-      await candidateContext.close()
-    }
+    })
   })
 })

--- a/e2e/critical-flows/rbac-role-permissions.spec.ts
+++ b/e2e/critical-flows/rbac-role-permissions.spec.ts
@@ -1,84 +1,17 @@
-import { type Browser, type Page } from '@playwright/test'
-import { test, expect } from '../fixtures'
+import { test, expect, signUpUser } from '../fixtures'
 import { grantOrganizationRole, lookupMembership } from '../helpers/db'
-
-interface SignedInOrg {
-  page: Page
-  userId: string
-  organizationId: string
-  close: () => Promise<void>
-}
-
-async function signUpWithOrg(browser: Browser, label: string): Promise<SignedInOrg> {
-  const context = await browser.newContext()
-  const page = await context.newPage()
-  const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`
-  const account = {
-    name: `RBAC ${label} ${id}`,
-    email: `rbac-${label}-${id}@test.local`,
-    password: 'TestPassword123!',
-    orgName: `RBAC ${label} Org ${id}`,
-  }
-
-  await page.goto('/auth/sign-up')
-  await page.waitForLoadState('networkidle')
-  await page.getByLabel('Name').fill(account.name)
-  await page.getByLabel('Email').fill(account.email)
-  await page.getByLabel('Password', { exact: true }).fill(account.password)
-  await page.getByLabel('Confirm password').fill(account.password)
-
-  await Promise.all([
-    page.waitForResponse(
-      resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200,
-      { timeout: 30_000 },
-    ),
-    page.getByRole('button', { name: 'Sign up' }).click(),
-  ])
-
-  await page.waitForURL(
-    url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'),
-    { waitUntil: 'commit', timeout: 30_000 },
-  )
-
-  if (page.url().includes('/auth/sign-in')) {
-    await page.waitForLoadState('networkidle')
-    await page.getByLabel('Email').fill(account.email)
-    await page.getByLabel('Password').fill(account.password)
-
-    await Promise.all([
-      page.waitForResponse(
-        resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200,
-        { timeout: 30_000 },
-      ),
-      page.getByRole('button', { name: 'Sign in' }).click(),
-    ])
-
-    await page.waitForURL('**/onboarding/**', { waitUntil: 'commit', timeout: 30_000 })
-  }
-
-  await page.getByLabel('Organization name').waitFor({ state: 'visible', timeout: 30_000 })
-  await page.getByLabel('Organization name').fill(account.orgName)
-  await page.getByRole('button', { name: 'Create organization' }).click()
-  await page.waitForURL('**/dashboard**', { waitUntil: 'commit' })
-
-  const membership = await lookupMembership(account.email, account.orgName)
-
-  return {
-    page,
-    userId: membership.userId,
-    organizationId: membership.organizationId,
-    close: () => context.close(),
-  }
-}
 
 test.describe('RBAC role permissions', () => {
   test('member UI restrictions agree with direct API authorization while owner actions still work', async ({ authenticatedPage, testAccount, browser }, testInfo) => {
     const ownerPage = authenticatedPage
     const ownerMembership = await lookupMembership(testAccount.email, testAccount.orgName)
-    const member = await signUpWithOrg(browser, `member-${testInfo.workerIndex}`)
+    const member = await signUpUser(browser, {
+      label: `member-${testInfo.workerIndex}`,
+      withOrg: true,
+    })
 
     try {
-      await grantOrganizationRole(member.userId, ownerMembership.organizationId, 'member')
+      await grantOrganizationRole(member.userId!, ownerMembership.organizationId, 'member')
 
       const memberApi = member.page.context().request
       const ownerApi = ownerPage.context().request

--- a/e2e/critical-flows/rbac-role-permissions.spec.ts
+++ b/e2e/critical-flows/rbac-role-permissions.spec.ts
@@ -11,7 +11,7 @@ test.describe('RBAC role permissions', () => {
     })
 
     try {
-      await grantOrganizationRole(member.userId!, ownerMembership.organizationId, 'member')
+      await grantOrganizationRole(member.userId, ownerMembership.organizationId, 'member')
 
       const memberApi = member.page.context().request
       const ownerApi = ownerPage.context().request

--- a/e2e/critical-flows/tracking-analytics.spec.ts
+++ b/e2e/critical-flows/tracking-analytics.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, selectFactorySelectOption } from '../fixtures'
+import { test, expect, selectFactorySelectOption, withGuestContext } from '../fixtures'
 
 const JOB_TITLE = 'Tracking Analytics Test Job'
 const LINK_NAME = 'LinkedIn Analytics Campaign'
@@ -89,33 +89,33 @@ test.describe('Tracking analytics', () => {
     const copiedUrls = await page.evaluate(() => (window as any).__copiedTrackingUrls as string[])
     expect(copiedUrls.at(-1)).toContain(`/api/public/track/${encodeURIComponent(trackingLink.code)}`)
 
-    const candidateContext = await browser.newContext()
-    const candidatePage = await candidateContext.newPage()
-    await candidatePage.goto(`/api/public/track/${trackingLink.code}`)
-    await candidatePage.waitForURL('**/jobs?ref=*', { waitUntil: 'commit', timeout: 15_000 })
-    expect(new URL(candidatePage.url()).searchParams.get('ref')).toBe(trackingLink.code)
+    await withGuestContext(browser, async (candidatePage) => {
+      await candidatePage.goto(`/api/public/track/${trackingLink.code}`)
+      await candidatePage.waitForURL('**/jobs?ref=*', { waitUntil: 'commit', timeout: 15_000 })
+      expect(new URL(candidatePage.url()).searchParams.get('ref')).toBe(trackingLink.code)
 
-    await candidatePage.getByRole('link', { name: jobTitle }).first().click()
-    await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}**`, { waitUntil: 'commit', timeout: 15_000 })
-    await candidatePage.getByRole('link', { name: 'Apply Now' }).first().click()
-    await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}/apply**`, { waitUntil: 'commit', timeout: 15_000 })
-    expect(new URL(candidatePage.url()).searchParams.get('ref')).toBe(trackingLink.code)
+      await candidatePage.getByRole('link', { name: jobTitle }).first().click()
+      await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}**`, { waitUntil: 'commit', timeout: 15_000 })
+      await candidatePage.getByRole('link', { name: 'Apply Now' }).first().click()
+      await candidatePage.waitForURL(`**/jobs/${publishedJob.slug}/apply**`, { waitUntil: 'commit', timeout: 15_000 })
+      expect(new URL(candidatePage.url()).searchParams.get('ref')).toBe(trackingLink.code)
 
-    const applyResponse = await candidatePage.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
-      data: {
-        firstName: applicant.firstName,
-        lastName: applicant.lastName,
-        email: applicant.email,
-        country: 'United States',
-        state: 'CA',
-        ref: trackingLink.code,
-        utmSource: 'linkedin',
-        utmMedium: 'social',
-        utmCampaign: UTM_CAMPAIGN,
-        responses: [],
-      },
+      const applyResponse = await candidatePage.request.post(`/api/public/jobs/${publishedJob.slug}/apply`, {
+        data: {
+          firstName: applicant.firstName,
+          lastName: applicant.lastName,
+          email: applicant.email,
+          country: 'United States',
+          state: 'CA',
+          ref: trackingLink.code,
+          utmSource: 'linkedin',
+          utmMedium: 'social',
+          utmCampaign: UTM_CAMPAIGN,
+          responses: [],
+        },
+      })
+      expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
     })
-    expect(applyResponse.status(), `Apply API returned ${applyResponse.status()}`).toBe(201)
 
     await expect.poll(async () => {
       const response = await page.request.get(`/api/tracking-links/${trackingLink.id}`)
@@ -140,7 +140,5 @@ test.describe('Tracking analytics', () => {
     await expect(attributionRow).toContainText(jobTitle)
     await expect(attributionRow).toContainText('LinkedIn')
     await expect(attributionRow).toContainText(`via ${linkName}`)
-
-    await candidateContext.close()
   })
 })

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -123,6 +123,7 @@ export const test = base.extend<Fixtures>({
 
   authenticatedPageWithoutOrg: async ({ page, testAccount }, use) => {
     await signUpOnPage(page, testAccount)
+    await page.getByLabel('Organization name').waitFor({ state: 'visible', timeout: 30_000 })
     await use(page)
   },
 })

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,5 +1,5 @@
-import { AxeBuilder } from '@axe-core/playwright'
-import { expect, expect as baseExpect, test as base, type Locator, type Page } from '@playwright/test'
+import { expect as baseExpect, test as base, type Locator, type Page } from '@playwright/test'
+import { createOrganizationOnPage, signUpOnPage } from './helpers/auth'
 
 /**
  * Shared test fixtures for Reqcore E2E tests.
@@ -30,6 +30,7 @@ function generateTestAccount(workerId: number): TestAccount {
 type Fixtures = {
   testAccount: TestAccount
   authenticatedPage: Page
+  authenticatedPageWithoutOrg: Page
 }
 
 export async function selectFactorySelectOption(page: Page, label: string | RegExp, optionName: string) {
@@ -94,53 +95,15 @@ export async function expectFloatingMenuNotClipped(menu: Locator) {
   baseExpect(clippingReport.clippingAncestors, JSON.stringify(clippingReport, null, 2)).toEqual([])
 }
 
-export async function openWithKeyboard(page: Page, trigger: Locator) {
-  await page.waitForLoadState('networkidle')
-  await trigger.press('Enter')
-  await expect(trigger).toHaveAttribute('aria-expanded', 'true')
-}
+export {
+  expectFocusRestored,
+  expectVisibleFocus,
+  openWithKeyboard,
+  runAxeScan,
+} from './accessibility'
 
-export async function expectFocusRestored(page: Page, trigger: Locator) {
-  await page.keyboard.press('Escape')
-  await expect(trigger).toBeFocused()
-  await expect(trigger).toHaveAttribute('aria-expanded', 'false')
-}
-
-export async function expectVisibleFocus(page: Page) {
-  const focusStyle = await page.evaluate(() => {
-    const el = document.activeElement as HTMLElement | null
-    if (!el) return null
-    const styles = window.getComputedStyle(el)
-    return {
-      outlineStyle: styles.outlineStyle,
-      outlineWidth: styles.outlineWidth,
-      boxShadow: styles.boxShadow,
-    }
-  })
-
-  expect(focusStyle).not.toBeNull()
-  expect(
-    focusStyle!.outlineStyle !== 'none'
-      || focusStyle!.outlineWidth !== '0px'
-      || focusStyle!.boxShadow !== 'none',
-  ).toBeTruthy()
-}
-
-export async function runAxeScan(page: Page) {
-  const results = await new AxeBuilder({ page })
-    .disableRules([
-      'color-contrast',
-      'heading-order',
-      'landmark-main-is-top-level',
-      'landmark-no-duplicate-main',
-      'landmark-unique',
-      'page-has-heading-one',
-      'region',
-    ])
-    .analyze()
-
-  expect(results.violations).toEqual([])
-}
+export { createGuestPage, withGuestContext } from './helpers/guest-context'
+export { signUpUser } from './helpers/auth'
 
 export const test = base.extend<Fixtures>({
   testAccount: [
@@ -153,58 +116,13 @@ export const test = base.extend<Fixtures>({
   ],
 
   authenticatedPage: async ({ page, testAccount }, use) => {
-    // Sign up
-    await page.goto('/auth/sign-up')
-    await page.waitForLoadState('networkidle')
-    await page.getByLabel('Name').fill(testAccount.name)
-    await page.getByLabel('Email').fill(testAccount.email)
-    await page.getByLabel('Password', { exact: true }).fill(testAccount.password)
-    await page.getByLabel('Confirm password').fill(testAccount.password)
+    await signUpOnPage(page, testAccount)
+    await createOrganizationOnPage(page, testAccount.orgName)
+    await use(page)
+  },
 
-    // Click sign-up and wait for the auth API response before expecting navigation
-    await Promise.all([
-      page.waitForResponse(
-        resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200,
-        { timeout: 30_000 },
-      ),
-      page.getByRole('button', { name: 'Sign up' }).click(),
-    ])
-
-    // After sign-up the app navigates to /onboarding/create-org, but the
-    // auth middleware may not yet recognise the freshly-set session cookie
-    // and redirect to /auth/sign-in instead.  Handle both outcomes.
-    await page.waitForURL(
-      url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'),
-      { waitUntil: 'commit', timeout: 30_000 },
-    )
-
-    // If we landed on sign-in, explicitly sign in with the new credentials
-    if (page.url().includes('/auth/sign-in')) {
-      await page.waitForLoadState('networkidle')
-      await page.getByLabel('Email').fill(testAccount.email)
-      await page.getByLabel('Password').fill(testAccount.password)
-
-      await Promise.all([
-        page.waitForResponse(
-          resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200,
-          { timeout: 30_000 },
-        ),
-        page.getByRole('button', { name: 'Sign in' }).click(),
-      ])
-
-      // Sign-in navigates to /dashboard, then require-org middleware
-      // redirects to /onboarding/create-org (user has no org yet)
-      await page.waitForURL('**/onboarding/**', { waitUntil: 'commit', timeout: 30_000 })
-    }
-
-    // Wait for the org-creation form to render (loading spinner may show first)
-    await page.getByLabel('Organization name').waitFor({ state: 'visible', timeout: 30_000 })
-    await page.getByLabel('Organization name').fill(testAccount.orgName)
-    await page.getByRole('button', { name: 'Create organization' }).click()
-
-    // Wait for redirect to dashboard (use 'commit' for SPA navigation)
-    await page.waitForURL('**/dashboard**', { waitUntil: 'commit' })
-
+  authenticatedPageWithoutOrg: async ({ page, testAccount }, use) => {
+    await signUpOnPage(page, testAccount)
     await use(page)
   },
 })

--- a/e2e/fixtures/test-buffers.ts
+++ b/e2e/fixtures/test-buffers.ts
@@ -35,6 +35,48 @@ export const MINIMAL_PDF = Buffer.from(
 )
 
 /**
+ * Minimal valid PDF 1.4 document with embedded text content.
+ * Useful when tests need parseable resume text, not just magic-byte validity.
+ */
+export function createTextPdf(text: string): Buffer {
+  const pdfText = text.replace(/[\\()]/g, match => `\\${match}`)
+  const streamContent = `BT /F1 12 Tf 72 700 Td (${pdfText}) Tj ET`
+  const chunks = ['%PDF-1.4\n']
+  const offsets = [0]
+
+  function appendObject(index: number, body: string) {
+    offsets[index] = Buffer.byteLength(chunks.join(''), 'utf8')
+    chunks.push(`${index} 0 obj\n${body}\nendobj\n`)
+  }
+
+  appendObject(1, '<< /Type /Catalog /Pages 2 0 R >>')
+  appendObject(2, '<< /Type /Pages /Kids [3 0 R] /Count 1 >>')
+  appendObject(3, '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>')
+  appendObject(4, [
+    `<< /Length ${Buffer.byteLength(streamContent, 'utf8')} >>`,
+    'stream',
+    streamContent,
+    'endstream',
+  ].join('\n'))
+  appendObject(5, '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>')
+
+  const xrefOffset = Buffer.byteLength(chunks.join(''), 'utf8')
+  chunks.push([
+    'xref',
+    '0 6',
+    '0000000000 65535 f ',
+    ...offsets.slice(1).map(offset => `${offset.toString().padStart(10, '0')} 00000 n `),
+    'trailer',
+    '<< /Size 6 /Root 1 0 R >>',
+    'startxref',
+    String(xrefOffset),
+    '%%EOF',
+  ].join('\n'))
+
+  return Buffer.from(chunks.join(''))
+}
+
+/**
  * Minimal OLE2 Compound Binary File (.doc).
  * Starts with the 8-byte OLE2 magic `D0 CF 11 E0 A1 B1 1A E1`.
  * The server only accepts OLE2 documents as Word files when it also sees

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,117 @@
+import { type Browser, type Page } from '@playwright/test'
+import { lookupMembership } from './db'
+
+export type SignUpCredentials = {
+  name: string
+  email: string
+  password: string
+}
+
+export type SignUpUserOptions = {
+  /** Distinguishes parallel accounts in logs and email local-parts */
+  label?: string
+  /** When true, completes org creation and returns membership ids */
+  withOrg?: boolean
+  baseURL?: string
+  password?: string
+  name?: string
+  email?: string
+  orgName?: string
+}
+
+export type SignUpUserResult = SignUpCredentials & {
+  orgName?: string
+  page: Page
+  userId?: string
+  organizationId?: string
+  close: () => Promise<void>
+}
+
+const defaultPassword = () => process.env.E2E_TEST_PASSWORD || 'TestPassword123!'
+
+function buildAccountId(label?: string): string {
+  return `${Date.now()}-${label ?? Math.random().toString(36).slice(2)}`
+}
+
+export async function signUpOnPage(page: Page, account: SignUpCredentials): Promise<void> {
+  await page.goto('/auth/sign-up')
+  await page.waitForLoadState('networkidle')
+  await page.getByLabel('Name').fill(account.name)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password', { exact: true }).fill(account.password)
+  await page.getByLabel('Confirm password').fill(account.password)
+
+  await Promise.all([
+    page.waitForResponse(
+      resp => resp.url().includes('/api/auth/sign-up') && resp.status() === 200,
+      { timeout: 30_000 },
+    ),
+    page.getByRole('button', { name: 'Sign up' }).click(),
+  ])
+
+  await page.waitForURL(
+    url => url.pathname.includes('/onboarding/') || url.pathname.includes('/auth/sign-in'),
+    { waitUntil: 'commit', timeout: 30_000 },
+  )
+
+  if (page.url().includes('/auth/sign-in')) {
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Email').fill(account.email)
+    await page.getByLabel('Password').fill(account.password)
+
+    await Promise.all([
+      page.waitForResponse(
+        resp => resp.url().includes('/api/auth/sign-in') && resp.status() === 200,
+        { timeout: 30_000 },
+      ),
+      page.getByRole('button', { name: 'Sign in' }).click(),
+    ])
+
+    await page.waitForURL('**/onboarding/**', { waitUntil: 'commit', timeout: 30_000 })
+  }
+}
+
+export async function createOrganizationOnPage(page: Page, orgName: string): Promise<void> {
+  await page.getByLabel('Organization name').waitFor({ state: 'visible', timeout: 30_000 })
+  await page.getByLabel('Organization name').fill(orgName)
+  await page.getByRole('button', { name: 'Create organization' }).click()
+  await page.waitForURL('**/dashboard**', { waitUntil: 'commit' })
+}
+
+export async function signUpUser(browser: Browser, options: SignUpUserOptions = {}): Promise<SignUpUserResult> {
+  const context = await browser.newContext(options.baseURL ? { baseURL: options.baseURL } : {})
+  const page = await context.newPage()
+  const id = buildAccountId(options.label)
+  const labelPrefix = options.label ? `${options.label}-` : ''
+  const account: SignUpCredentials = {
+    name: options.name ?? `E2E User ${options.label ?? ''} ${id}`.replace(/\s+/g, ' ').trim(),
+    email: options.email ?? `e2e-${labelPrefix}${id}@test.local`,
+    password: options.password ?? defaultPassword(),
+  }
+  const orgName = options.withOrg
+    ? (options.orgName ?? `E2E Org ${options.label ?? ''} ${id}`.replace(/\s+/g, ' ').trim())
+    : undefined
+
+  await signUpOnPage(page, account)
+
+  if (!options.withOrg) {
+    await page.waitForLoadState('networkidle')
+    return {
+      ...account,
+      page,
+      close: () => context.close(),
+    }
+  }
+
+  await createOrganizationOnPage(page, orgName!)
+  const membership = await lookupMembership(account.email, orgName!)
+
+  return {
+    ...account,
+    orgName,
+    page,
+    userId: membership.userId,
+    organizationId: membership.organizationId,
+    close: () => context.close(),
+  }
+}

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -19,13 +19,24 @@ export type SignUpUserOptions = {
   orgName?: string
 }
 
-export type SignUpUserResult = SignUpCredentials & {
-  orgName?: string
+export type SignUpUserResultBase = SignUpCredentials & {
   page: Page
-  userId?: string
-  organizationId?: string
   close: () => Promise<void>
 }
+
+export type SignUpUserResultWithOrg = SignUpUserResultBase & {
+  orgName: string
+  userId: string
+  organizationId: string
+}
+
+export type SignUpUserResultWithoutOrg = SignUpUserResultBase & {
+  orgName?: undefined
+  userId?: undefined
+  organizationId?: undefined
+}
+
+export type SignUpUserResult = SignUpUserResultWithOrg | SignUpUserResultWithoutOrg
 
 const defaultPassword = () => process.env.E2E_TEST_PASSWORD || 'TestPassword123!'
 
@@ -78,6 +89,8 @@ export async function createOrganizationOnPage(page: Page, orgName: string): Pro
   await page.waitForURL('**/dashboard**', { waitUntil: 'commit' })
 }
 
+export async function signUpUser(browser: Browser, options: SignUpUserOptions & { withOrg: true }): Promise<SignUpUserResultWithOrg>
+export async function signUpUser(browser: Browser, options?: SignUpUserOptions): Promise<SignUpUserResult>
 export async function signUpUser(browser: Browser, options: SignUpUserOptions = {}): Promise<SignUpUserResult> {
   const context = await browser.newContext(options.baseURL ? { baseURL: options.baseURL } : {})
   const page = await context.newPage()
@@ -105,6 +118,9 @@ export async function signUpUser(browser: Browser, options: SignUpUserOptions = 
 
   await createOrganizationOnPage(page, orgName!)
   const membership = await lookupMembership(account.email, orgName!)
+  if (!membership.userId || !membership.organizationId) {
+    throw new Error(`Failed to resolve membership ids for ${account.email} in ${orgName}`)
+  }
 
   return {
     ...account,

--- a/e2e/helpers/guest-context.ts
+++ b/e2e/helpers/guest-context.ts
@@ -1,0 +1,40 @@
+import { type Browser, type BrowserContext, type Page } from '@playwright/test'
+
+export type GuestContextOptions = {
+  baseURL?: string
+}
+
+export type GuestPageHandle = {
+  page: Page
+  context: BrowserContext
+  close: () => Promise<void>
+}
+
+export async function createGuestPage(
+  browser: Browser,
+  options: GuestContextOptions = {},
+): Promise<GuestPageHandle> {
+  const context = await browser.newContext(options.baseURL ? { baseURL: options.baseURL } : {})
+  const page = await context.newPage()
+
+  return {
+    page,
+    context,
+    close: () => context.close(),
+  }
+}
+
+export async function withGuestContext<T>(
+  browser: Browser,
+  fn: (page: Page) => Promise<T>,
+  options: GuestContextOptions = {},
+): Promise<T> {
+  const guest = await createGuestPage(browser, options)
+
+  try {
+    return await fn(guest.page)
+  }
+  finally {
+    await guest.close()
+  }
+}

--- a/tests/unit/e2e-accessibility-helpers.test.ts
+++ b/tests/unit/e2e-accessibility-helpers.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('E2E accessibility helpers', () => {
+  it('consolidates keyboard and axe helpers under e2e/accessibility.ts', () => {
+    const source = readProjectFile('e2e/accessibility.ts')
+
+    for (const exportName of [
+      'expectNoA11yViolations',
+      'runAxeScan',
+      'expectVisibleFocus',
+      'expectVisibleKeyboardFocus',
+      'tabUntilFocused',
+      'openWithKeyboard',
+      'expectFocusRestored',
+    ]) {
+      expect(source, exportName).toContain(exportName)
+    }
+  })
+
+  it('re-exports accessibility helpers from fixtures for backward compatibility', () => {
+    const fixtures = readProjectFile('e2e/fixtures.ts')
+
+    expect(fixtures).toContain("from './accessibility'")
+    expect(fixtures).toContain('runAxeScan')
+    expect(fixtures).not.toContain("from '@axe-core/playwright'")
+  })
+
+  it('keeps accessibility specs on the shared accessibility API', () => {
+    const specs = [
+      'e2e/accessibility/dashboard-controls.spec.ts',
+      'e2e/accessibility/keyboard-regression.spec.ts',
+      'e2e/critical-flows/accessibility-keyboard.spec.ts',
+    ]
+
+    for (const spec of specs) {
+      const source = readProjectFile(spec)
+      expect(source, spec).toContain('../accessibility')
+      expect(source, spec).toMatch(/runAxeScan|expectNoA11yViolations/)
+    }
+  })
+})

--- a/tests/unit/e2e-auth-helpers.test.ts
+++ b/tests/unit/e2e-auth-helpers.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('E2E auth helpers', () => {
+  it('exports shared sign-up helpers for fixtures and secondary accounts', () => {
+    const source = readProjectFile('e2e/helpers/auth.ts')
+
+    for (const exportName of [
+      'signUpOnPage',
+      'createOrganizationOnPage',
+      'signUpUser',
+    ]) {
+      expect(source, exportName).toContain(exportName)
+    }
+  })
+
+  it('re-exports signUpUser and org-less fixture wiring from fixtures', () => {
+    const fixtures = readProjectFile('e2e/fixtures.ts')
+
+    expect(fixtures).toContain('authenticatedPageWithoutOrg')
+    expect(fixtures).toContain('signUpUser')
+    expect(fixtures).toContain('./helpers/auth')
+  })
+
+  it('is adopted by migrated specs with local sign-up helpers removed', () => {
+    const migratedSpecs = [
+      'e2e/critical-flows/org-admin-membership.spec.ts',
+      'e2e/critical-flows/rbac-role-permissions.spec.ts',
+    ]
+
+    for (const spec of migratedSpecs) {
+      const source = readProjectFile(spec)
+      expect(source, spec).toContain('signUpUser')
+      expect(source, spec).not.toContain('async function signUpWithoutOrganization')
+      expect(source, spec).not.toContain('async function signUpWithOrg')
+    }
+  })
+})

--- a/tests/unit/e2e-db-helpers.test.ts
+++ b/tests/unit/e2e-db-helpers.test.ts
@@ -50,5 +50,8 @@ describe('E2E database helpers', () => {
       expect(source, spec).not.toContain("import postgres from 'postgres'")
       expect(source, spec).not.toContain('async function lookupMembership(')
     }
+
+    expect(readProjectFile('e2e/critical-flows/org-admin-membership.spec.ts')).toContain('signUpUser')
+    expect(readProjectFile('e2e/critical-flows/rbac-role-permissions.spec.ts')).toContain('signUpUser')
   })
 })

--- a/tests/unit/e2e-guest-context.test.ts
+++ b/tests/unit/e2e-guest-context.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('E2E guest context helpers', () => {
+  it('exports createGuestPage and withGuestContext', () => {
+    const source = readProjectFile('e2e/helpers/guest-context.ts')
+
+    expect(source).toContain('export async function createGuestPage')
+    expect(source).toContain('export async function withGuestContext')
+  })
+
+  it('re-exports guest helpers from fixtures', () => {
+    const fixtures = readProjectFile('e2e/fixtures.ts')
+
+    expect(fixtures).toContain('createGuestPage')
+    expect(fixtures).toContain('withGuestContext')
+    expect(fixtures).toContain('./helpers/guest-context')
+  })
+
+  it('is adopted by representative guest-flow specs', () => {
+    const migratedSpecs = [
+      'e2e/critical-flows/job-lifecycle.spec.ts',
+      'e2e/critical-flows/fake-mail.spec.ts',
+      'e2e/critical-flows/public-localization.spec.ts',
+      'e2e/critical-flows/tracking-analytics.spec.ts',
+      'e2e/critical-flows/auth-recovery-fake-mail.spec.ts',
+    ]
+
+    for (const spec of migratedSpecs) {
+      const source = readProjectFile(spec)
+      expect(source, spec).toMatch(/createGuestPage|withGuestContext/)
+      expect(source, spec).not.toContain('browser.newContext()')
+    }
+  })
+})

--- a/tests/unit/e2e-test-buffers.test.ts
+++ b/tests/unit/e2e-test-buffers.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('E2E test buffers', () => {
+  it('exports createTextPdf with embedded text content', () => {
+    const source = readProjectFile('e2e/fixtures/test-buffers.ts')
+
+    expect(source).toContain('export function createTextPdf')
+    expect(source).toContain('%PDF-1.4')
+    expect(source).toContain('text.replace(/[\\\\()]')
+  })
+
+  it('is adopted by candidate-documents spec', () => {
+    const source = readProjectFile('e2e/critical-flows/candidate-documents.spec.ts')
+
+    expect(source).toContain('createTextPdf')
+    expect(source).toContain('../fixtures/test-buffers')
+    expect(source).not.toContain('function createTextPdf(')
+  })
+})

--- a/tests/unit/keyboard-a11y-controls.test.ts
+++ b/tests/unit/keyboard-a11y-controls.test.ts
@@ -48,15 +48,17 @@ describe('remaining keyboard and accessibility controls', () => {
   })
 
   it('adds axe-backed keyboard Playwright coverage', () => {
-    const fixtures = readProjectFile('e2e/fixtures.ts')
+    const accessibility = readProjectFile('e2e/accessibility.ts')
     const regression = readProjectFile('e2e/accessibility/keyboard-regression.spec.ts')
     const dashboard = readProjectFile('e2e/accessibility/dashboard-controls.spec.ts')
 
-    expect(fixtures).toContain("from '@axe-core/playwright'")
-    expect(fixtures).toContain('runAxeScan')
-    expect(fixtures).toContain('expectFocusRestored')
+    expect(accessibility).toContain("from '@axe-core/playwright'")
+    expect(accessibility).toContain('runAxeScan')
+    expect(accessibility).toContain('expectFocusRestored')
+    expect(regression).toContain('../accessibility')
     expect(regression).toContain('runAxeScan')
     expect(regression).toContain('expectVisibleFocus')
+    expect(dashboard).toContain('../accessibility')
     expect(dashboard).toContain('Columns')
     expect(dashboard).toContain('timezone')
   })


### PR DESCRIPTION
## Summary

Epic 8 PR2 — consolidates E2E auth, accessibility, guest-context, and PDF test-buffer helpers.

Closes #239, #242, #243, #244. Part of #253.

### #239 — Auth fixture extensions
- Add `e2e/helpers/auth.ts` with `signUpOnPage`, `createOrganizationOnPage`, and `signUpUser(browser, { withOrg?, baseURL?, label? })`
- Add `authenticatedPageWithoutOrg` fixture; refactor `authenticatedPage` to reuse shared auth helpers
- Migrate `org-admin-membership.spec.ts` and `rbac-role-permissions.spec.ts`

### #242 — Consolidate a11y helpers
- Move `runAxeScan`, `expectVisibleFocus`, `openWithKeyboard`, and `expectFocusRestored` into `e2e/accessibility.ts`
- Re-export from `e2e/fixtures.ts` for backward compatibility
- Update accessibility specs to import from `../accessibility`

### #243 — Guest context helper
- Add `createGuestPage` and `withGuestContext` in `e2e/helpers/guest-context.ts`
- Migrate representative specs: `job-lifecycle`, `fake-mail`, `public-localization`, `tracking-analytics`, `auth-recovery-fake-mail`

### #244 — createTextPdf in test-buffers
- Add `createTextPdf(text)` to `e2e/fixtures/test-buffers.ts`
- Migrate `candidate-documents.spec.ts`

## Verification

```bash
npm run test:unit
```

**Result:** 170 files, 981 tests passed.