### PR TITLE
refactor: Epic 5 PR3 — unify sidebar application data wiring

### DIFF
--- a/app/components/CandidateDetailSidebar.vue
+++ b/app/components/CandidateDetailSidebar.vue
@@ -8,6 +8,7 @@ import {
   getApplicationTransitionLabel,
 } from '~/utils/status-display'
 import { formatPhoneNumber } from '~/utils/phone-format'
+import type { ApplicationStatus } from '~~/shared/application-status'
 
 
 const props = defineProps<{
@@ -71,7 +72,7 @@ const documents = computed(() => candidateData.value?.documents ?? [])
 
 const { allowedTransitions, isTransitioning, transitionToStatus } = useApplicationStatusActions({
   application,
-  updateStatus: status => updateApplication({ status: status as any }),
+  updateStatus: status => updateApplication({ status: status as ApplicationStatus }),
   trackTransition: ({ fromStatus, toStatus }) => {
     track('sidebar_status_changed', {
       application_id: props.applicationId,

--- a/app/components/CandidateDetailSidebar.vue
+++ b/app/components/CandidateDetailSidebar.vue
@@ -41,17 +41,10 @@ const activeTab = ref<'overview' | 'documents' | 'responses' | 'ai_analysis' | '
 const sidebarRef = ref<HTMLElement | null>(null)
 
 // ─────────────────────────────────────────────
-// Fetch application detail
+// Application detail
 // ─────────────────────────────────────────────
 
-const { data: application, status: fetchStatus, refresh } = useFetch(
-  () => `/api/applications/${props.applicationId}`,
-  {
-    key: computed(() => `sidebar-application-${props.applicationId}`),
-    headers: useRequestHeaders(['cookie']),
-    watch: [() => props.applicationId],
-  },
-)
+const { application, status: fetchStatus, refresh, updateApplication } = useApplication(() => props.applicationId)
 
 // ─────────────────────────────────────────────
 // Fetch full candidate detail (for documents)
@@ -76,23 +69,9 @@ watch(candidateId, (id) => {
 
 const documents = computed(() => candidateData.value?.documents ?? [])
 
-async function updateApplicationStatus(status: string) {
-  await $fetch(`/api/applications/${props.applicationId}`, {
-    method: 'PATCH',
-    body: { status },
-  })
-}
-
-async function updateApplicationNotes(notes: string | null) {
-  await $fetch(`/api/applications/${props.applicationId}`, {
-    method: 'PATCH',
-    body: { notes },
-  })
-}
-
 const { allowedTransitions, isTransitioning, transitionToStatus } = useApplicationStatusActions({
   application,
-  updateStatus: updateApplicationStatus,
+  updateStatus: status => updateApplication({ status: status as any }),
   trackTransition: ({ fromStatus, toStatus }) => {
     track('sidebar_status_changed', {
       application_id: props.applicationId,
@@ -101,16 +80,14 @@ const { allowedTransitions, isTransitioning, transitionToStatus } = useApplicati
     })
   },
   afterTransition: async () => {
-    await refresh()
     emit('updated')
   },
 })
 
 const { isEditingNotes, notesInput, isSavingNotes, notesSaveStatus, startEditNotes, saveNotes, autosaveNotes, finishEditNotes } = useEditableApplicationNotes({
   application,
-  save: updateApplicationNotes,
+  save: notes => updateApplication({ notes }),
   afterSave: async () => {
-    await refresh()
     emit('updated')
   },
 })

--- a/tests/unit/application-detail-epic5-pr3.test.ts
+++ b/tests/unit/application-detail-epic5-pr3.test.ts
@@ -12,7 +12,7 @@ describe('application detail epic 5 pr3', () => {
 
     expect(sidebar).toContain('useApplication(() => props.applicationId)')
     expect(sidebar).toContain('updateApplication')
-    expect(sidebar).toContain('updateStatus: status => updateApplication({ status: status as any })')
+    expect(sidebar).toMatch(/updateStatus:\s*status\s*=>\s*updateApplication\(\{\s*status:\s*status\s+as\s+ApplicationStatus\s*\}\)/)
     expect(sidebar).toContain('save: notes => updateApplication({ notes })')
     expect(sidebar).toContain("track('sidebar_status_changed'")
     expect(sidebar).toContain("emit('updated')")

--- a/tests/unit/application-detail-epic5-pr3.test.ts
+++ b/tests/unit/application-detail-epic5-pr3.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('application detail epic 5 pr3', () => {
+  it('unifies CandidateDetailSidebar on useApplication for fetch and mutations', () => {
+    const sidebar = readProjectFile('app/components/CandidateDetailSidebar.vue')
+
+    expect(sidebar).toContain('useApplication(() => props.applicationId)')
+    expect(sidebar).toContain('updateApplication')
+    expect(sidebar).toContain('updateStatus: status => updateApplication({ status: status as any })')
+    expect(sidebar).toContain('save: notes => updateApplication({ notes })')
+    expect(sidebar).toContain("track('sidebar_status_changed'")
+    expect(sidebar).toContain("emit('updated')")
+
+    expect(sidebar).not.toContain('updateApplicationStatus')
+    expect(sidebar).not.toContain('updateApplicationNotes')
+    expect(sidebar).not.toContain('sidebar-application-')
+    expect(sidebar).not.toMatch(/useFetch\(\s*\n?\s*\(\) => `\/api\/applications\/\$\{props\.applicationId\}`/)
+  })
+
+  it('keeps shared application detail panels on the sidebar surface', () => {
+    const sidebar = readProjectFile('app/components/CandidateDetailSidebar.vue')
+
+    for (const panel of [
+      'ApplicationNotesPanel',
+      'ApplicationInterviewsPanel',
+      'ApplicationDocumentsPanel',
+      'ApplicationResponsesPanel',
+      'ApplicationTimelinePanel',
+    ]) {
+      expect(sidebar, `sidebar should use ${panel}`).toContain(`<${panel}`)
+    }
+
+    expect(sidebar).toContain('surface="sidebar"')
+    expect(sidebar).toContain('useApplicationDocumentActions')
+    expect(sidebar).toContain('useApplicationTimeline')
+    expect(sidebar).toContain('useApplicationStatusActions')
+    expect(sidebar).toContain('useEditableApplicationNotes')
+  })
+})


### PR DESCRIPTION
## Summary

Final Epic 5 orchestration pass for the sidebar surface: `CandidateDetailSidebar` now uses the shared `useApplication` composable for fetch and mutations, matching the drawer and full application page.

## Changes

- Replace raw `useFetch` (`sidebar-application-*` key) with `useApplication(() => props.applicationId)`
- Remove manual `updateApplicationStatus` / `updateApplicationNotes` PATCH helpers
- Wire `useApplicationStatusActions` and `useEditableApplicationNotes` through `updateApplication`
- Preserve sidebar-specific analytics (`sidebar_status_changed`) and parent `updated` emit callbacks
- Add `tests/unit/application-detail-epic5-pr3.test.ts` guardrails

## Epic 5

- Closes #227
- Part of #250
- PR3 of 3