### PR TITLE
refactor: Epic 5 PR2 — shared application detail surface composable

### DIFF
--- a/app/components/ApplicationDetailDrawer.vue
+++ b/app/components/ApplicationDetailDrawer.vue
@@ -26,21 +26,11 @@ const {
   scoreBand,
   isScoringApplication,
   scoreCurrentApplication,
-} = useApplicationScoringPanel({
-  applicationId: () => props.applicationId,
-  application,
-  source: 'application_detail_drawer',
-  refreshApplication: false,
-})
-
-const showInterviewSidebar = ref(false)
-
-const { allowedTransitions, isTransitioning, transitionToStatus } = useApplicationStatusActions({
-  application,
-  updateStatus: status => updateApplication({ status: status as any }),
-})
-
-const {
+  showInterviewSidebar,
+  openInterviewScheduler,
+  allowedTransitions,
+  isTransitioning,
+  transitionToStatus,
   isEditingNotes,
   notesInput,
   isSavingNotes,
@@ -49,10 +39,12 @@ const {
   saveNotes,
   autosaveNotes,
   finishEditNotes,
-} = useEditableApplicationNotes({
+} = useApplicationDetailSurface({
+  applicationId: () => props.applicationId,
   application,
-  focusOnEdit: true,
-  save: notes => updateApplication({ notes }),
+  source: 'application_detail_drawer',
+  refreshApplication: false,
+  updateApplication,
 })
 </script>
 
@@ -125,7 +117,7 @@ const {
                 </button>
                 <button
                   class="inline-flex shrink-0 cursor-pointer items-center gap-1 whitespace-nowrap border border-white/16 bg-black px-2.5 py-1.5 text-[10px] font-semibold uppercase leading-none tracking-normal text-white/80 hover:border-brand-500 hover:bg-brand-500/12 hover:text-white transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500/40"
-                  @click="showInterviewSidebar = true"
+                  @click="openInterviewScheduler"
                 >
                   <Calendar class="size-3" />
                   Schedule Interview

--- a/app/composables/useApplicationDetailSurface.ts
+++ b/app/composables/useApplicationDetailSurface.ts
@@ -1,4 +1,5 @@
 import type { MaybeRefOrGetter } from 'vue'
+import type { ApplicationStatus } from '~~/shared/application-status'
 
 type ApplicationDetailTarget = {
   score: number | null
@@ -46,7 +47,7 @@ export function useApplicationDetailSurface(options: UseApplicationDetailSurface
 
   const { allowedTransitions, isTransitioning, transitionToStatus } = useApplicationStatusActions({
     application: options.application,
-    updateStatus: status => options.updateApplication({ status: status as any }),
+    updateStatus: status => options.updateApplication({ status: status as ApplicationStatus }),
   })
 
   const {

--- a/app/composables/useApplicationDetailSurface.ts
+++ b/app/composables/useApplicationDetailSurface.ts
@@ -1,0 +1,88 @@
+import type { MaybeRefOrGetter } from 'vue'
+
+type ApplicationDetailTarget = {
+  score: number | null
+  job: {
+    id: string
+  }
+  notes?: string | null
+  status?: string | null
+}
+
+type UseApplicationDetailSurfaceOptions = {
+  applicationId: MaybeRefOrGetter<string>
+  application: MaybeRefOrGetter<ApplicationDetailTarget | null | undefined>
+  source: string
+  refreshApplication?: boolean
+  refresh?: () => Promise<unknown> | unknown
+  updateApplication: (payload: Partial<{
+    status: 'new' | 'screening' | 'interview' | 'offer' | 'hired' | 'rejected'
+    notes: string | null
+    score: number | null
+  }>) => Promise<unknown>
+}
+
+export function useApplicationDetailSurface(options: UseApplicationDetailSurfaceOptions) {
+  const {
+    scoringData,
+    scoringSummary,
+    scoringSummaryFallback,
+    scoreBand,
+    isScoringApplication,
+    scoreCurrentApplication,
+  } = useApplicationScoringPanel({
+    applicationId: options.applicationId,
+    application: options.application,
+    source: options.source,
+    refreshApplication: options.refreshApplication,
+    refresh: options.refresh,
+  })
+
+  const showInterviewSidebar = ref(false)
+
+  function openInterviewScheduler() {
+    showInterviewSidebar.value = true
+  }
+
+  const { allowedTransitions, isTransitioning, transitionToStatus } = useApplicationStatusActions({
+    application: options.application,
+    updateStatus: status => options.updateApplication({ status: status as any }),
+  })
+
+  const {
+    isEditingNotes,
+    notesInput,
+    isSavingNotes,
+    notesSaveStatus,
+    startEditNotes,
+    saveNotes,
+    autosaveNotes,
+    finishEditNotes,
+  } = useEditableApplicationNotes({
+    application: options.application,
+    focusOnEdit: true,
+    save: notes => options.updateApplication({ notes }),
+  })
+
+  return {
+    scoringData,
+    scoringSummary,
+    scoringSummaryFallback,
+    scoreBand,
+    isScoringApplication,
+    scoreCurrentApplication,
+    showInterviewSidebar,
+    openInterviewScheduler,
+    allowedTransitions,
+    isTransitioning,
+    transitionToStatus,
+    isEditingNotes,
+    notesInput,
+    isSavingNotes,
+    notesSaveStatus,
+    startEditNotes,
+    saveNotes,
+    autosaveNotes,
+    finishEditNotes,
+  }
+}

--- a/app/pages/dashboard/applications/[id].vue
+++ b/app/pages/dashboard/applications/[id].vue
@@ -23,11 +23,25 @@ const {
   scoringSummaryFallback,
   isScoringApplication,
   scoreCurrentApplication,
-} = useApplicationScoringPanel({
+  showInterviewSidebar,
+  openInterviewScheduler,
+  allowedTransitions,
+  isTransitioning,
+  transitionToStatus,
+  isEditingNotes,
+  notesInput,
+  isSavingNotes,
+  notesSaveStatus,
+  startEditNotes,
+  saveNotes,
+  autosaveNotes,
+  finishEditNotes,
+} = useApplicationDetailSurface({
   applicationId,
   application,
   source: 'application_detail_page',
   refresh,
+  updateApplication,
 })
 
 useSeoMeta({
@@ -37,32 +51,6 @@ useSeoMeta({
       : 'Application — Factory Careers',
   ),
 })
-
-const showInterviewSidebar = ref(false)
-
-const { allowedTransitions, isTransitioning, transitionToStatus } = useApplicationStatusActions({
-  application,
-  updateStatus: status => updateApplication({ status: status as any }),
-})
-
-const {
-  isEditingNotes,
-  notesInput,
-  isSavingNotes,
-  notesSaveStatus,
-  startEditNotes,
-  saveNotes,
-  autosaveNotes,
-  finishEditNotes,
-} = useEditableApplicationNotes({
-  application,
-  focusOnEdit: true,
-  save: notes => updateApplication({ notes }),
-})
-
-function openInterviewScheduler() {
-  showInterviewSidebar.value = true
-}
 </script>
 
 <template>

--- a/tests/unit/application-detail-actions.test.ts
+++ b/tests/unit/application-detail-actions.test.ts
@@ -51,11 +51,21 @@ describe('application detail shared actions', () => {
   })
 
   it('uses the shared composables on every application detail surface', () => {
+    const surfaceComposable = readProjectFile('app/composables/useApplicationDetailSurface.ts')
+
+    expect(surfaceComposable).toContain('useApplicationStatusActions')
+    expect(surfaceComposable).toContain('useEditableApplicationNotes')
+
     for (const path of applicationDetailSurfaces) {
       const source = readProjectFile(path)
+      const usesSharedSurface = path !== 'app/components/CandidateDetailSidebar.vue'
 
-      expect(source, `${path} should use shared status actions`).toContain('useApplicationStatusActions')
-      expect(source, `${path} should use shared editable notes`).toContain('useEditableApplicationNotes')
+      if (usesSharedSurface) {
+        expect(source, `${path} should use shared surface orchestration`).toContain('useApplicationDetailSurface')
+      } else {
+        expect(source, `${path} should use shared status actions`).toContain('useApplicationStatusActions')
+        expect(source, `${path} should use shared editable notes`).toContain('useEditableApplicationNotes')
+      }
       expect(source, `${path} should not define local status transitions`).not.toContain('APPLICATION_STATUS_TRANSITIONS')
       expect(source, `${path} should not define local transition state`).not.toContain('const isTransitioning = ref')
       expect(source, `${path} should not define local transition handler`).not.toContain('function handleTransition')

--- a/tests/unit/application-detail-epic5-pr1.test.ts
+++ b/tests/unit/application-detail-epic5-pr1.test.ts
@@ -56,12 +56,12 @@ describe('application detail epic 5 pr1', () => {
   it('uses shared sub-panels on application detail surfaces without hand-rolled panel markup', () => {
     const expectations: Record<string, { uses: string[], avoids: string[] }> = {
       'app/components/ApplicationDetailDrawer.vue': {
-        uses: ['<ApplicationNotesPanel', '<ApplicationScoringPanel', '<ApplicationResponsesPanel', 'useApplicationScoringPanel'],
-        avoids: ['const scoringSummary = computed', 'const documentTypeLabels', 'const interviewTypeLabels'],
+        uses: ['<ApplicationNotesPanel', '<ApplicationScoringPanel', '<ApplicationResponsesPanel', 'useApplicationDetailSurface'],
+        avoids: ['const scoringSummary = computed', 'const documentTypeLabels', 'const interviewTypeLabels', 'useApplicationScoringPanel', 'useEditableApplicationNotes'],
       },
       'app/pages/dashboard/applications/[id].vue': {
-        uses: ['<ApplicationNotesPanel', '<ApplicationScoringPanel', '<ApplicationResponsesPanel', 'useApplicationScoringPanel'],
-        avoids: ['const scoringSummary = computed', 'type ApplicationScoresResponse', 'function scoreCurrentApplication'],
+        uses: ['<ApplicationNotesPanel', '<ApplicationScoringPanel', '<ApplicationResponsesPanel', 'useApplicationDetailSurface'],
+        avoids: ['const scoringSummary = computed', 'type ApplicationScoresResponse', 'function scoreCurrentApplication', 'useApplicationScoringPanel', 'useEditableApplicationNotes'],
       },
       'app/components/CandidateDetailSidebar.vue': {
         uses: [

--- a/tests/unit/application-detail-epic5-pr2.test.ts
+++ b/tests/unit/application-detail-epic5-pr2.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function projectPath(path: string) {
+  return fileURLToPath(new URL(`../../${path}`, import.meta.url))
+}
+
+function readProjectFile(path: string) {
+  return readFileSync(projectPath(path), 'utf-8')
+}
+
+const sharedDetailSurfaces = [
+  'app/components/ApplicationDetailDrawer.vue',
+  'app/pages/dashboard/applications/[id].vue',
+]
+
+describe('application detail epic 5 pr2', () => {
+  it('exports the shared application detail surface composable', () => {
+    const path = 'app/composables/useApplicationDetailSurface.ts'
+    expect(existsSync(projectPath(path)), path).toBe(true)
+
+    const source = readProjectFile(path)
+    expect(source).toContain('export function useApplicationDetailSurface')
+    expect(source).toContain('useApplicationScoringPanel')
+    expect(source).toContain('useEditableApplicationNotes')
+    expect(source).toContain('useApplicationStatusActions')
+    expect(source).toContain('showInterviewSidebar')
+    expect(source).toContain('openInterviewScheduler')
+    expect(source).toContain('focusOnEdit: true')
+    expect(source).toContain('source: options.source')
+    expect(source).toContain('updateApplication({ notes })')
+    expect(source).toContain('updateApplication({ status: status as any })')
+  })
+
+  it('uses the shared surface composable on drawer and full page', () => {
+    for (const path of sharedDetailSurfaces) {
+      const source = readProjectFile(path)
+
+      expect(source, `${path} should use the shared surface composable`).toContain('useApplicationDetailSurface')
+      expect(source, `${path} should not wire scoring panel directly`).not.toContain('useApplicationScoringPanel')
+      expect(source, `${path} should not wire editable notes directly`).not.toContain('useEditableApplicationNotes')
+    }
+  })
+
+  it('keeps surface-specific scoring sources and refresh behavior', () => {
+    const drawer = readProjectFile('app/components/ApplicationDetailDrawer.vue')
+    const page = readProjectFile('app/pages/dashboard/applications/[id].vue')
+
+    expect(drawer).toContain("source: 'application_detail_drawer'")
+    expect(drawer).toContain('refreshApplication: false')
+    expect(page).toContain("source: 'application_detail_page'")
+    expect(page).toContain('refresh,')
+    expect(page).not.toContain('refreshApplication: false')
+  })
+})

--- a/tests/unit/application-detail-epic5-pr2.test.ts
+++ b/tests/unit/application-detail-epic5-pr2.test.ts
@@ -30,7 +30,7 @@ describe('application detail epic 5 pr2', () => {
     expect(source).toContain('focusOnEdit: true')
     expect(source).toContain('source: options.source')
     expect(source).toContain('updateApplication({ notes })')
-    expect(source).toContain('updateApplication({ status: status as any })')
+    expect(source).toContain('updateApplication({ status: status as ApplicationStatus })')
   })
 
   it('uses the shared surface composable on drawer and full page', () => {


### PR DESCRIPTION
Epic 5 PR2 (#250 partial #227).

Extracts useApplicationDetailSurface composable shared by drawer and full page.

Verification: npm run test:unit