### PR TITLE
fix: use formatCandidateName for InterviewScheduleSidebar candidate-name prop

### DIFF
--- a/app/components/ApplicationDetailDrawer.vue
+++ b/app/components/ApplicationDetailDrawer.vue
@@ -235,7 +235,7 @@ const {
       <InterviewScheduleSidebar
         v-if="showInterviewSidebar && application"
         :application-id="applicationId"
-        :candidate-name="`${application.candidate.firstName} ${application.candidate.lastName}`"
+        :candidate-name="formatCandidateName(application.candidate)"
         :job-title="application.job.title"
         @close="showInterviewSidebar = false"
         @scheduled="showInterviewSidebar = false"

--- a/app/components/CandidateDetailDrawer.vue
+++ b/app/components/CandidateDetailDrawer.vue
@@ -11,6 +11,7 @@ const localePath = useLocalePath()
 const toast = useToast()
 
 const { candidate, status: fetchStatus, error, refresh } = useCandidate(() => props.candidateId)
+const { formatCandidateName } = useOrgSettings()
 
 // ─── Tabs ─────────────────────────────────────────────────────────────────────
 
@@ -172,7 +173,7 @@ const documentPreviewState = computed(() => ({
       <InterviewScheduleSidebar
         v-if="showInterviewSidebar && interviewTargetApp && candidate"
         :application-id="interviewTargetApp.id"
-        :candidate-name="`${candidate.firstName} ${candidate.lastName}`"
+        :candidate-name="formatCandidateName(candidate)"
         :job-title="interviewTargetApp.jobTitle"
         @close="showInterviewSidebar = false"
         @scheduled="showInterviewSidebar = false"

--- a/app/components/CandidateDetailSidebar.vue
+++ b/app/components/CandidateDetailSidebar.vue
@@ -517,7 +517,7 @@ const { interviews: applicationInterviews } = useInterviews({
   <InterviewScheduleSidebar
     v-if="showScheduleSidebar && application"
     :application-id="props.applicationId"
-    :candidate-name="`${application.candidate.firstName} ${application.candidate.lastName}`"
+    :candidate-name="formatCandidateName(application.candidate)"
     :job-title="application.job?.title ?? ''"
     @close="showScheduleSidebar = false"
     @scheduled="showScheduleSidebar = false"

--- a/app/pages/dashboard/applications/[id].vue
+++ b/app/pages/dashboard/applications/[id].vue
@@ -243,7 +243,7 @@ useSeoMeta({
   <InterviewScheduleSidebar
     v-if="showInterviewSidebar && application"
     :application-id="applicationId"
-    :candidate-name="`${application.candidate.firstName} ${application.candidate.lastName}`"
+    :candidate-name="formatCandidateName(application.candidate)"
     :job-title="application.job.title"
     @close="showInterviewSidebar = false"
     @scheduled="showInterviewSidebar = false"

--- a/app/pages/dashboard/candidates/[id].vue
+++ b/app/pages/dashboard/candidates/[id].vue
@@ -272,7 +272,7 @@ const {
         <InterviewScheduleSidebar
           v-if="showInterviewSidebar && interviewTargetApp"
           :application-id="interviewTargetApp.id"
-          :candidate-name="`${candidate.firstName} ${candidate.lastName}`"
+          :candidate-name="formatCandidateName(candidate)"
           :job-title="interviewTargetApp.jobTitle"
           @close="showInterviewSidebar = false"
           @scheduled="showInterviewSidebar = false"

--- a/tests/unit/interview-sidebar-candidate-name.test.ts
+++ b/tests/unit/interview-sidebar-candidate-name.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+const interviewSidebarCallSites = [
+  'app/components/ApplicationDetailDrawer.vue',
+  'app/components/CandidateDetailDrawer.vue',
+  'app/components/CandidateDetailSidebar.vue',
+  'app/pages/dashboard/candidates/[id].vue',
+  'app/pages/dashboard/applications/[id].vue',
+]
+
+describe('InterviewScheduleSidebar candidate-name formatting', () => {
+  it('uses formatCandidateName for candidate-name props instead of raw first/last concatenation', () => {
+    for (const path of interviewSidebarCallSites) {
+      const source = readProjectFile(path)
+
+      expect(source, `${path} should import formatCandidateName from useOrgSettings`).toContain('formatCandidateName')
+      expect(
+        source,
+        `${path} should pass formatCandidateName to InterviewScheduleSidebar`,
+      ).toMatch(/:candidate-name="formatCandidateName\(/)
+      expect(
+        source,
+        `${path} should not concatenate firstName and lastName for candidate-name`,
+      ).not.toMatch(/:candidate-name="\$\{[^}]*firstName[^}]*lastName/)
+    }
+  })
+})

--- a/tests/unit/interview-sidebar-candidate-name.test.ts
+++ b/tests/unit/interview-sidebar-candidate-name.test.ts
@@ -27,7 +27,7 @@ describe('InterviewScheduleSidebar candidate-name formatting', () => {
       expect(
         source,
         `${path} should not concatenate firstName and lastName for candidate-name`,
-      ).not.toMatch(/:candidate-name="\$\{[^}]*firstName[^}]*lastName/)
+      ).not.toMatch(/:candidate-name="`\$\{[^}]*firstName[^}]*\}\s*\$\{[^}]*lastName/)
     }
   })
 })


### PR DESCRIPTION
Uses org-aware `formatCandidateName` for all `InterviewScheduleSidebar` `:candidate-name` bindings instead of raw first/last concatenation.

Closes #273