### PR TITLE
fix: inverse InterviewScheduleSidebar tone from detail drawers

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -2514,7 +2514,7 @@
       #000000 !important;
   }
 
-  .factory-dashboard-portal.ui-interview-schedule-sidebar,
+  .factory-dashboard-portal .ui-interview-schedule-sidebar,
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar {
     background-color: #000000 !important;
     color: #ffffff !important;

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -2514,6 +2514,56 @@
       #000000 !important;
   }
 
+  .factory-dashboard-portal.ui-interview-schedule-sidebar,
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar {
+    background-color: #000000 !important;
+    color: #ffffff !important;
+    border-color: rgb(255 255 255 / 0.12) !important;
+    box-shadow: none !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar label,
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar h3 {
+    color: rgb(255 255 255 / 0.78) !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar input:not([type='checkbox']),
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar textarea {
+    border-color: var(--ui-border-strong) !important;
+    background-color: rgb(255 255 255 / 0.035) !important;
+    color: #ffffff !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar input:not([type='checkbox'])::placeholder,
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar textarea::placeholder {
+    color: var(--ui-faint) !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar input:not([type='checkbox']):focus,
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar textarea:focus {
+    border-color: color-mix(in srgb, var(--color-brand-500) 75%, transparent) !important;
+    background-color: rgb(255 255 255 / 0.05) !important;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-brand-500) 20%, transparent) !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar .rounded-xl.border {
+    border-color: var(--ui-border-strong) !important;
+    background-color: rgb(255 255 255 / 0.025) !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar button.rounded-lg.px-3.py-1\.5.text-\[12px\] {
+    border-color: var(--ui-border-strong) !important;
+    background-color: rgb(255 255 255 / 0.035) !important;
+    color: rgb(255 255 255 / 0.68) !important;
+  }
+
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar button.rounded-lg.px-3.py-1\.5.text-\[12px\].bg-brand-600,
+  :where(.factory-dashboard-shell, .factory-dashboard-portal) .ui-interview-schedule-sidebar button.rounded-lg.px-2\.5.py-1\.5.bg-brand-600 {
+    border-color: transparent !important;
+    background-color: var(--color-brand-600) !important;
+    color: #ffffff !important;
+  }
+
   :where(.factory-dashboard-shell, .factory-dashboard-portal) .factory-filter-section {
     border-top: 1px solid var(--ui-border) !important;
     padding-top: 1rem;

--- a/app/components/ApplicationDetailDrawer.vue
+++ b/app/components/ApplicationDetailDrawer.vue
@@ -237,6 +237,7 @@ const {
         :application-id="applicationId"
         :candidate-name="formatCandidateName(application.candidate)"
         :job-title="application.job.title"
+        tone="inverse"
         @close="showInterviewSidebar = false"
         @scheduled="showInterviewSidebar = false"
       />

--- a/app/components/CandidateDetailDrawer.vue
+++ b/app/components/CandidateDetailDrawer.vue
@@ -228,6 +228,7 @@ const documentPreviewState = computed(() => ({
         :application-id="interviewTargetApp.id"
         :candidate-name="formatCandidateName(candidate)"
         :job-title="interviewTargetApp.jobTitle"
+        tone="inverse"
         @close="showInterviewSidebar = false"
         @scheduled="showInterviewSidebar = false"
       />

--- a/app/components/InterviewScheduleSidebar.vue
+++ b/app/components/InterviewScheduleSidebar.vue
@@ -13,9 +13,13 @@ const props = withDefaults(defineProps<{
   candidateName: string
   jobTitle: string
   teleportTarget?: string | HTMLElement
+  tone?: 'default' | 'inverse'
 }>(), {
   teleportTarget: 'body',
+  tone: 'default',
 })
+
+const isInverseTone = computed(() => props.tone === 'inverse')
 
 const emit = defineEmits<{
   close: []
@@ -488,7 +492,12 @@ async function handleMoveToInterview() {
       >
         <div
           ref="sidebarRef"
-          class="relative w-full max-w-2xl bg-white dark:bg-surface-900 shadow-2xl overflow-hidden flex flex-col border-l border-surface-200/40 dark:border-surface-800/60"
+          :class="[
+            'relative w-full max-w-2xl shadow-2xl overflow-hidden flex flex-col',
+            isInverseTone
+              ? 'ui-drawer-panel ui-interview-schedule-sidebar border-l border-white/12 bg-black text-white shadow-none'
+              : 'bg-white dark:bg-surface-900 border-l border-surface-200/40 dark:border-surface-800/60',
+          ]"
           role="dialog"
           aria-modal="true"
           aria-label="Schedule interview"
@@ -505,11 +514,17 @@ async function handleMoveToInterview() {
                     <CheckCircle2 v-if="showSuccess" class="size-4 text-emerald-600 dark:text-emerald-400" />
                     <Calendar v-else class="size-4 text-brand-600 dark:text-brand-400" />
                   </div>
-                  <h2 class="text-lg font-semibold text-surface-900 dark:text-surface-50 tracking-tight">
+                  <h2
+                    class="text-lg font-semibold tracking-tight"
+                    :class="isInverseTone ? 'text-white' : 'text-surface-900 dark:text-surface-50'"
+                  >
                     {{ showSuccess ? 'Interview Scheduled' : 'Schedule Interview' }}
                   </h2>
                 </div>
-                <p class="text-[13px] text-surface-500 dark:text-surface-400 truncate pl-[42px]">
+                <p
+                  class="text-[13px] truncate pl-[42px]"
+                  :class="isInverseTone ? 'text-white/42' : 'text-surface-500 dark:text-surface-400'"
+                >
                   {{ candidateName }} · {{ jobTitle }}
                 </p>
               </div>
@@ -523,7 +538,10 @@ async function handleMoveToInterview() {
             </div>
           </div>
 
-          <div class="h-px bg-gradient-to-r from-transparent via-surface-200 to-transparent dark:via-surface-700/60" />
+          <div
+            class="h-px"
+            :class="isInverseTone ? 'bg-white/10' : 'bg-gradient-to-r from-transparent via-surface-200 to-transparent dark:via-surface-700/60'"
+          />
 
           <!-- ─── Success view ─────────────────────────────────── -->
           <template v-if="showSuccess">
@@ -602,7 +620,12 @@ async function handleMoveToInterview() {
             </div>
 
             <!-- Success footer -->
-            <div class="shrink-0 border-t border-surface-200/60 dark:border-surface-800/40 bg-white/80 dark:bg-surface-900/80 backdrop-blur-sm px-6 py-4">
+            <div
+              class="shrink-0 border-t backdrop-blur-sm px-6 py-4"
+              :class="isInverseTone
+                ? 'border-white/10 bg-black/80'
+                : 'border-surface-200/60 dark:border-surface-800/40 bg-white/80 dark:bg-surface-900/80'"
+            >
               <button
                 type="button"
                 class="w-full rounded-xl bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-500 transition-colors cursor-pointer shadow-sm shadow-brand-600/20 dark:shadow-brand-500/10"
@@ -1072,7 +1095,12 @@ async function handleMoveToInterview() {
           </div>
 
           <!-- Footer with preview + submit -->
-          <div class="shrink-0 border-t border-surface-200/60 dark:border-surface-800/40 bg-white/80 dark:bg-surface-900/80 backdrop-blur-sm px-6 py-4">
+          <div
+            class="shrink-0 border-t backdrop-blur-sm px-6 py-4"
+            :class="isInverseTone
+              ? 'border-white/10 bg-black/80'
+              : 'border-surface-200/60 dark:border-surface-800/40 bg-white/80 dark:bg-surface-900/80'"
+          >
             <!-- Preview -->
             <div v-if="form.date && form.time" class="mb-3 flex items-center gap-2 min-w-0">
               <Calendar class="size-3.5 shrink-0 text-brand-500 dark:text-brand-400" />

--- a/tests/unit/interview-schedule-sidebar-tone.test.ts
+++ b/tests/unit/interview-schedule-sidebar-tone.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('InterviewScheduleSidebar tone', () => {
+  it('exposes a defaultable inverse tone prop and applies drawer styling when inverse', () => {
+    const sidebar = readProjectFile('app/components/InterviewScheduleSidebar.vue')
+    const css = readProjectFile('app/assets/css/main.css')
+
+    expect(sidebar).toContain("tone?: 'default' | 'inverse'")
+    expect(sidebar).toContain("tone: 'default'")
+    expect(sidebar).toContain('const isInverseTone = computed(() => props.tone === \'inverse\')')
+    expect(sidebar).toContain('ui-interview-schedule-sidebar')
+    expect(sidebar).toContain('border-white/12 bg-black text-white')
+    expect(css).toContain('.ui-interview-schedule-sidebar')
+    expect(css).toContain('background-color: #000000 !important')
+  })
+
+  it('passes tone="inverse" from detail drawer overlay call sites', () => {
+    const candidateDrawer = readProjectFile('app/components/CandidateDetailDrawer.vue')
+    const applicationDrawer = readProjectFile('app/components/ApplicationDetailDrawer.vue')
+
+    expect(candidateDrawer).toMatch(/<InterviewScheduleSidebar[\s\S]*?tone="inverse"/)
+    expect(applicationDrawer).toMatch(/<InterviewScheduleSidebar[\s\S]*?tone="inverse"/)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `tone?: 'default' | 'inverse'` to `InterviewScheduleSidebar` (defaults to `default`)
- When `tone="inverse"`, applies black drawer styling (`ui-drawer-panel`, `ui-interview-schedule-sidebar`) to match `AppDetailDrawerShell`
- Passes `tone="inverse"` from candidate and application detail drawer overlay slots
- Adds unit guards in `tests/unit/interview-schedule-sidebar-tone.test.ts`

Closes #277