### PR TITLE
feat: candidate page status transitions and tab accessibility

### DIFF
--- a/app/components/CandidateApplicationsPanel.vue
+++ b/app/components/CandidateApplicationsPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Briefcase, Calendar, Plus } from 'lucide-vue-next'
+import type { ApplicationStatus } from '~~/shared/application-status'
 import { APPLICATION_STATUS_TRANSITIONS } from '~~/shared/status-transitions'
 import {
   getApplicationTransitionActionLabel,
@@ -21,15 +22,15 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
   apply: []
   schedule: [application: any]
-  transition: [application: any, status: string]
+  transition: [application: any, status: ApplicationStatus]
 }>()
 
 const localePath = useLocalePath()
 
 const panelClass = useCandidatePanelClass(() => props.surface)
 
-function getApplicationTransitions(status: string) {
-  return APPLICATION_STATUS_TRANSITIONS[status] ?? []
+function getApplicationTransitions(status: string): ApplicationStatus[] {
+  return (APPLICATION_STATUS_TRANSITIONS[status as ApplicationStatus] ?? []) as ApplicationStatus[]
 }
 </script>
 

--- a/app/components/CandidateDetailDrawer.vue
+++ b/app/components/CandidateDetailDrawer.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { patchApplication } from '~/composables/useApplication'
+import type { ApplicationStatus } from '~~/shared/application-status'
+
 const props = defineProps<{
   candidateId: string
 }>()
@@ -15,7 +18,21 @@ const { formatCandidateName } = useOrgSettings()
 
 // ─── Tabs ─────────────────────────────────────────────────────────────────────
 
-const activeTab = ref<'applications' | 'documents'>('applications')
+const candidateDetailTabs = ['applications', 'documents'] as const
+const activeTab = ref<(typeof candidateDetailTabs)[number]>('applications')
+
+function handleCandidateTabKeydown(event: KeyboardEvent) {
+  const currentIndex = candidateDetailTabs.indexOf(activeTab.value)
+  if (currentIndex === -1) return
+
+  if (event.key === 'ArrowRight') {
+    event.preventDefault()
+    activeTab.value = candidateDetailTabs[(currentIndex + 1) % candidateDetailTabs.length]!
+  } else if (event.key === 'ArrowLeft') {
+    event.preventDefault()
+    activeTab.value = candidateDetailTabs[(currentIndex - 1 + candidateDetailTabs.length) % candidateDetailTabs.length]!
+  }
+}
 
 // ─── Apply to job modal ───────────────────────────────────────────────────────
 
@@ -36,10 +53,7 @@ const transitioningApplicationIds = ref<Set<string>>(new Set())
 async function updateTransitionTargetStatus(status: string) {
   const appId = transitionTarget.value?.id
   if (!appId) return
-  await $fetch(`/api/applications/${appId}`, {
-    method: 'PATCH',
-    body: { status },
-  })
+  await patchApplication(appId, { status: status as ApplicationStatus })
 }
 
 const { transitionToStatus } = useApplicationStatusActions({
@@ -114,8 +128,19 @@ const documentPreviewState = computed(() => ({
 
       <!-- Tabs -->
       <div class="border-b border-white/10">
-        <div class="flex gap-1">
+        <div
+          role="tablist"
+          aria-label="Candidate sections"
+          class="flex gap-1"
+          @keydown="handleCandidateTabKeydown"
+        >
           <button
+            id="candidate-tab-applications"
+            role="tab"
+            type="button"
+            aria-controls="candidate-tabpanel-applications"
+            :aria-selected="activeTab === 'applications'"
+            :tabindex="activeTab === 'applications' ? 0 : -1"
             class="cursor-pointer px-3 py-2 text-sm font-medium transition-colors border-b-2 -mb-px"
             :class="activeTab === 'applications'
               ? 'border-brand-500 text-brand-400'
@@ -125,6 +150,12 @@ const documentPreviewState = computed(() => ({
             Applications ({{ candidate.applications?.length ?? 0 }})
           </button>
           <button
+            id="candidate-tab-documents"
+            role="tab"
+            type="button"
+            aria-controls="candidate-tabpanel-documents"
+            :aria-selected="activeTab === 'documents'"
+            :tabindex="activeTab === 'documents' ? 0 : -1"
             class="cursor-pointer px-3 py-2 text-sm font-medium transition-colors border-b-2 -mb-px"
             :class="activeTab === 'documents'
               ? 'border-brand-500 text-brand-400'
@@ -139,6 +170,9 @@ const documentPreviewState = computed(() => ({
       <!-- Applications tab -->
       <CandidateApplicationsPanel
         v-if="activeTab === 'applications'"
+        id="candidate-tabpanel-applications"
+        role="tabpanel"
+        aria-labelledby="candidate-tab-applications"
         :applications="candidate.applications ?? []"
         surface="drawer"
         show-status-transitions
@@ -151,6 +185,9 @@ const documentPreviewState = computed(() => ({
       <!-- Documents tab -->
       <CandidateDocumentsPanel
         v-if="activeTab === 'documents'"
+        id="candidate-tabpanel-documents"
+        role="tabpanel"
+        aria-labelledby="candidate-tab-documents"
         :documents="candidate.documents ?? []"
         :preview="documentPreviewState"
         surface="drawer"

--- a/app/components/CandidateDetailDrawer.vue
+++ b/app/components/CandidateDetailDrawer.vue
@@ -19,7 +19,15 @@ const { formatCandidateName } = useOrgSettings()
 // ─── Tabs ─────────────────────────────────────────────────────────────────────
 
 const candidateDetailTabs = ['applications', 'documents'] as const
-const activeTab = ref<(typeof candidateDetailTabs)[number]>('applications')
+type CandidateDetailTab = (typeof candidateDetailTabs)[number]
+const activeTab = ref<CandidateDetailTab>('applications')
+const applicationsTabRef = ref<HTMLButtonElement | null>(null)
+const documentsTabRef = ref<HTMLButtonElement | null>(null)
+
+function focusCandidateTab(tab: CandidateDetailTab) {
+  const target = tab === 'applications' ? applicationsTabRef.value : documentsTabRef.value
+  target?.focus()
+}
 
 function handleCandidateTabKeydown(event: KeyboardEvent) {
   const currentIndex = candidateDetailTabs.indexOf(activeTab.value)
@@ -27,10 +35,14 @@ function handleCandidateTabKeydown(event: KeyboardEvent) {
 
   if (event.key === 'ArrowRight') {
     event.preventDefault()
-    activeTab.value = candidateDetailTabs[(currentIndex + 1) % candidateDetailTabs.length]!
+    const nextTab = candidateDetailTabs[(currentIndex + 1) % candidateDetailTabs.length]!
+    activeTab.value = nextTab
+    focusCandidateTab(nextTab)
   } else if (event.key === 'ArrowLeft') {
     event.preventDefault()
-    activeTab.value = candidateDetailTabs[(currentIndex - 1 + candidateDetailTabs.length) % candidateDetailTabs.length]!
+    const nextTab = candidateDetailTabs[(currentIndex - 1 + candidateDetailTabs.length) % candidateDetailTabs.length]!
+    activeTab.value = nextTab
+    focusCandidateTab(nextTab)
   }
 }
 
@@ -50,10 +62,10 @@ const interviewTargetApp = ref<{ id: string; jobTitle: string } | null>(null)
 const transitionTarget = ref<{ id: string; status: string } | null>(null)
 const transitioningApplicationIds = ref<Set<string>>(new Set())
 
-async function updateTransitionTargetStatus(status: string) {
+async function updateTransitionTargetStatus(status: ApplicationStatus) {
   const appId = transitionTarget.value?.id
   if (!appId) return
-  await patchApplication(appId, { status: status as ApplicationStatus })
+  await patchApplication(appId, { status })
 }
 
 const { transitionToStatus } = useApplicationStatusActions({
@@ -73,7 +85,7 @@ function openScheduleInterview(app: { id: string; job: { title: string } }) {
   showInterviewSidebar.value = true
 }
 
-function handleApplicationTransition(app: { id: string; status: string }, status: string) {
+function handleApplicationTransition(app: { id: string; status: string }, status: ApplicationStatus) {
   transitionTarget.value = app
   transitionToStatus(status)
 }
@@ -136,6 +148,7 @@ const documentPreviewState = computed(() => ({
         >
           <button
             id="candidate-tab-applications"
+            ref="applicationsTabRef"
             role="tab"
             type="button"
             aria-controls="candidate-tabpanel-applications"
@@ -151,6 +164,7 @@ const documentPreviewState = computed(() => ({
           </button>
           <button
             id="candidate-tab-documents"
+            ref="documentsTabRef"
             role="tab"
             type="button"
             aria-controls="candidate-tabpanel-documents"
@@ -169,10 +183,11 @@ const documentPreviewState = computed(() => ({
 
       <!-- Applications tab -->
       <CandidateApplicationsPanel
-        v-if="activeTab === 'applications'"
+        v-show="activeTab === 'applications'"
         id="candidate-tabpanel-applications"
         role="tabpanel"
         aria-labelledby="candidate-tab-applications"
+        :hidden="activeTab !== 'applications'"
         :applications="candidate.applications ?? []"
         surface="drawer"
         show-status-transitions
@@ -184,10 +199,11 @@ const documentPreviewState = computed(() => ({
 
       <!-- Documents tab -->
       <CandidateDocumentsPanel
-        v-if="activeTab === 'documents'"
+        v-show="activeTab === 'documents'"
         id="candidate-tabpanel-documents"
         role="tabpanel"
         aria-labelledby="candidate-tab-documents"
+        :hidden="activeTab !== 'documents'"
         :documents="candidate.documents ?? []"
         :preview="documentPreviewState"
         surface="drawer"

--- a/app/composables/useApplication.ts
+++ b/app/composables/useApplication.ts
@@ -1,5 +1,19 @@
 import type { MaybeRefOrGetter } from 'vue'
 
+export type ApplicationUpdatePayload = Partial<{
+  status: 'new' | 'screening' | 'interview' | 'offer' | 'hired' | 'rejected'
+  notes: string | null
+  score: number | null
+}>
+
+/** PATCH `/api/applications/:id` — shared by detail surfaces and list transitions */
+export async function patchApplication(applicationId: string, payload: ApplicationUpdatePayload) {
+  return await $fetch(`/api/applications/${applicationId}`, {
+    method: 'PATCH',
+    body: payload,
+  })
+}
+
 /**
  * Composable for a single application detail with update mutation.
  * Wraps `useFetch('/api/applications/:id')` with a reactive key.
@@ -17,16 +31,9 @@ export function useApplication(id: MaybeRefOrGetter<string>) {
   )
 
   /** Update application fields (status, notes, score) and refresh caches */
-  async function updateApplication(payload: Partial<{
-    status: 'new' | 'screening' | 'interview' | 'offer' | 'hired' | 'rejected'
-    notes: string | null
-    score: number | null
-  }>) {
+  async function updateApplication(payload: ApplicationUpdatePayload) {
     try {
-      const updated = await $fetch(`/api/applications/${applicationId.value}`, {
-        method: 'PATCH',
-        body: payload,
-      })
+      const updated = await patchApplication(applicationId.value, payload)
       await refresh()
       await refreshNuxtData('applications')
       return updated

--- a/app/composables/useApplication.ts
+++ b/app/composables/useApplication.ts
@@ -1,7 +1,8 @@
 import type { MaybeRefOrGetter } from 'vue'
+import type { ApplicationStatus } from '~~/shared/application-status'
 
 export type ApplicationUpdatePayload = Partial<{
-  status: 'new' | 'screening' | 'interview' | 'offer' | 'hired' | 'rejected'
+  status: ApplicationStatus
   notes: string | null
   score: number | null
 }>

--- a/app/composables/useApplicationStatusActions.ts
+++ b/app/composables/useApplicationStatusActions.ts
@@ -1,5 +1,6 @@
 import type { MaybeRefOrGetter, Ref } from 'vue'
 import { computed, ref, toValue } from 'vue'
+import type { ApplicationStatus } from '~~/shared/application-status'
 import { APPLICATION_STATUS_TRANSITIONS } from '~~/shared/status-transitions'
 
 type ApplicationWithStatus = {
@@ -8,12 +9,12 @@ type ApplicationWithStatus = {
 
 type TransitionContext = {
   fromStatus?: string | null
-  toStatus: string
+  toStatus: ApplicationStatus
 }
 
 type UseApplicationStatusActionsOptions = {
   application: MaybeRefOrGetter<ApplicationWithStatus | null | undefined>
-  updateStatus: (status: string) => Promise<unknown>
+  updateStatus: (status: ApplicationStatus) => Promise<unknown>
   afterTransition?: (context: TransitionContext) => Promise<unknown> | unknown
   trackTransition?: (context: TransitionContext) => void
   transitionKey?: MaybeRefOrGetter<string | null | undefined>
@@ -24,10 +25,10 @@ export function useApplicationStatusActions(options: UseApplicationStatusActions
   const { handlePreviewReadOnlyError } = usePreviewReadOnly()
   const toast = useToast()
 
-  const allowedTransitions = computed(() => {
+  const allowedTransitions = computed((): ApplicationStatus[] => {
     const status = toValue(options.application)?.status
     if (!status) return []
-    return APPLICATION_STATUS_TRANSITIONS[status as keyof typeof APPLICATION_STATUS_TRANSITIONS] ?? []
+    return (APPLICATION_STATUS_TRANSITIONS[status as ApplicationStatus] ?? []) as ApplicationStatus[]
   })
 
   const isTransitioning = ref(false)
@@ -44,7 +45,7 @@ export function useApplicationStatusActions(options: UseApplicationStatusActions
     options.transitioningKeys.value = nextKeys
   }
 
-  async function transitionToStatus(newStatus: string) {
+  async function transitionToStatus(newStatus: ApplicationStatus) {
     const context = {
       fromStatus: toValue(options.application)?.status,
       toStatus: newStatus,

--- a/app/pages/dashboard/candidates/[id].vue
+++ b/app/pages/dashboard/candidates/[id].vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { Pencil, Trash2, Upload } from 'lucide-vue-next'
+import { patchApplication } from '~/composables/useApplication'
 import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
+import type { ApplicationStatus } from '~~/shared/application-status'
 import {
   candidateEditFormSchema,
   normalizeEmptyCandidateFormFields,
@@ -31,7 +33,21 @@ useSeoMeta({
 // Tabs
 // ─────────────────────────────────────────────
 
-const activeTab = ref<'applications' | 'documents'>('applications')
+const candidateDetailTabs = ['applications', 'documents'] as const
+const activeTab = ref<(typeof candidateDetailTabs)[number]>('applications')
+
+function handleCandidateTabKeydown(event: KeyboardEvent) {
+  const currentIndex = candidateDetailTabs.indexOf(activeTab.value)
+  if (currentIndex === -1) return
+
+  if (event.key === 'ArrowRight') {
+    event.preventDefault()
+    activeTab.value = candidateDetailTabs[(currentIndex + 1) % candidateDetailTabs.length]!
+  } else if (event.key === 'ArrowLeft') {
+    event.preventDefault()
+    activeTab.value = candidateDetailTabs[(currentIndex - 1 + candidateDetailTabs.length) % candidateDetailTabs.length]!
+  }
+}
 
 // ─────────────────────────────────────────────
 // Edit mode
@@ -143,10 +159,35 @@ function handleApplied() {
 
 const showInterviewSidebar = ref(false)
 const interviewTargetApp = ref<{ id: string; jobTitle: string } | null>(null)
+const transitionTarget = ref<{ id: string; status: string } | null>(null)
+const transitioningApplicationIds = ref<Set<string>>(new Set())
+
+async function updateTransitionTargetStatus(status: string) {
+  const appId = transitionTarget.value?.id
+  if (!appId) return
+  await patchApplication(appId, { status: status as ApplicationStatus })
+}
+
+const { transitionToStatus } = useApplicationStatusActions({
+  application: computed(() => transitionTarget.value),
+  transitionKey: computed(() => transitionTarget.value?.id),
+  transitioningKeys: transitioningApplicationIds,
+  updateStatus: updateTransitionTargetStatus,
+  afterTransition: async () => {
+    await refresh()
+    await refreshNuxtData('applications')
+    toast.success('Application status updated')
+  },
+})
 
 function openScheduleInterview(app: { id: string; job: { title: string } }) {
   interviewTargetApp.value = { id: app.id, jobTitle: app.job.title }
   showInterviewSidebar.value = true
+}
+
+function handleApplicationTransition(app: { id: string; status: string }, status: string) {
+  transitionTarget.value = app
+  transitionToStatus(status)
 }
 
 // ─────────────────────────────────────────────
@@ -229,8 +270,19 @@ const {
 
         <!-- Tabs -->
         <div class="mb-4 border-b border-white/10">
-          <div class="flex gap-1">
+          <div
+            role="tablist"
+            aria-label="Candidate sections"
+            class="flex gap-1"
+            @keydown="handleCandidateTabKeydown"
+          >
             <button
+              id="candidate-tab-applications"
+              role="tab"
+              type="button"
+              aria-controls="candidate-tabpanel-applications"
+              :aria-selected="activeTab === 'applications'"
+              :tabindex="activeTab === 'applications' ? 0 : -1"
               class="-mb-px cursor-pointer border-b-2 px-3 py-2 text-sm font-medium transition-colors"
               :class="activeTab === 'applications'
                 ? 'border-brand-500 text-brand-400'
@@ -240,6 +292,12 @@ const {
               Applications ({{ candidate.applications?.length ?? 0 }})
             </button>
             <button
+              id="candidate-tab-documents"
+              role="tab"
+              type="button"
+              aria-controls="candidate-tabpanel-documents"
+              :aria-selected="activeTab === 'documents'"
+              :tabindex="activeTab === 'documents' ? 0 : -1"
               class="-mb-px cursor-pointer border-b-2 px-3 py-2 text-sm font-medium transition-colors"
               :class="activeTab === 'documents'
                 ? 'border-brand-500 text-brand-400'
@@ -253,10 +311,16 @@ const {
 
         <CandidateApplicationsPanel
           v-if="activeTab === 'applications'"
+          id="candidate-tabpanel-applications"
+          role="tabpanel"
+          aria-labelledby="candidate-tab-applications"
           :applications="candidate.applications ?? []"
           surface="page"
+          show-status-transitions
+          :transitioning-application-ids="transitioningApplicationIds"
           @apply="showApplyModal = true"
           @schedule="openScheduleInterview"
+          @transition="handleApplicationTransition"
         />
 
         <!-- Apply to Job Modal -->
@@ -279,7 +343,12 @@ const {
         />
 
         <!-- Documents tab -->
-        <div v-if="activeTab === 'documents'">
+        <div
+          v-if="activeTab === 'documents'"
+          id="candidate-tabpanel-documents"
+          role="tabpanel"
+          aria-labelledby="candidate-tab-documents"
+        >
           <input
             ref="fileInput"
             type="file"

--- a/app/pages/dashboard/candidates/[id].vue
+++ b/app/pages/dashboard/candidates/[id].vue
@@ -34,7 +34,15 @@ useSeoMeta({
 // ─────────────────────────────────────────────
 
 const candidateDetailTabs = ['applications', 'documents'] as const
-const activeTab = ref<(typeof candidateDetailTabs)[number]>('applications')
+type CandidateDetailTab = (typeof candidateDetailTabs)[number]
+const activeTab = ref<CandidateDetailTab>('applications')
+const applicationsTabRef = ref<HTMLButtonElement | null>(null)
+const documentsTabRef = ref<HTMLButtonElement | null>(null)
+
+function focusCandidateTab(tab: CandidateDetailTab) {
+  const target = tab === 'applications' ? applicationsTabRef.value : documentsTabRef.value
+  target?.focus()
+}
 
 function handleCandidateTabKeydown(event: KeyboardEvent) {
   const currentIndex = candidateDetailTabs.indexOf(activeTab.value)
@@ -42,10 +50,14 @@ function handleCandidateTabKeydown(event: KeyboardEvent) {
 
   if (event.key === 'ArrowRight') {
     event.preventDefault()
-    activeTab.value = candidateDetailTabs[(currentIndex + 1) % candidateDetailTabs.length]!
+    const nextTab = candidateDetailTabs[(currentIndex + 1) % candidateDetailTabs.length]!
+    activeTab.value = nextTab
+    focusCandidateTab(nextTab)
   } else if (event.key === 'ArrowLeft') {
     event.preventDefault()
-    activeTab.value = candidateDetailTabs[(currentIndex - 1 + candidateDetailTabs.length) % candidateDetailTabs.length]!
+    const nextTab = candidateDetailTabs[(currentIndex - 1 + candidateDetailTabs.length) % candidateDetailTabs.length]!
+    activeTab.value = nextTab
+    focusCandidateTab(nextTab)
   }
 }
 
@@ -162,10 +174,10 @@ const interviewTargetApp = ref<{ id: string; jobTitle: string } | null>(null)
 const transitionTarget = ref<{ id: string; status: string } | null>(null)
 const transitioningApplicationIds = ref<Set<string>>(new Set())
 
-async function updateTransitionTargetStatus(status: string) {
+async function updateTransitionTargetStatus(status: ApplicationStatus) {
   const appId = transitionTarget.value?.id
   if (!appId) return
-  await patchApplication(appId, { status: status as ApplicationStatus })
+  await patchApplication(appId, { status })
 }
 
 const { transitionToStatus } = useApplicationStatusActions({
@@ -185,7 +197,7 @@ function openScheduleInterview(app: { id: string; job: { title: string } }) {
   showInterviewSidebar.value = true
 }
 
-function handleApplicationTransition(app: { id: string; status: string }, status: string) {
+function handleApplicationTransition(app: { id: string; status: string }, status: ApplicationStatus) {
   transitionTarget.value = app
   transitionToStatus(status)
 }
@@ -278,6 +290,7 @@ const {
           >
             <button
               id="candidate-tab-applications"
+              ref="applicationsTabRef"
               role="tab"
               type="button"
               aria-controls="candidate-tabpanel-applications"
@@ -293,6 +306,7 @@ const {
             </button>
             <button
               id="candidate-tab-documents"
+              ref="documentsTabRef"
               role="tab"
               type="button"
               aria-controls="candidate-tabpanel-documents"
@@ -310,10 +324,11 @@ const {
         </div>
 
         <CandidateApplicationsPanel
-          v-if="activeTab === 'applications'"
+          v-show="activeTab === 'applications'"
           id="candidate-tabpanel-applications"
           role="tabpanel"
           aria-labelledby="candidate-tab-applications"
+          :hidden="activeTab !== 'applications'"
           :applications="candidate.applications ?? []"
           surface="page"
           show-status-transitions
@@ -344,10 +359,11 @@ const {
 
         <!-- Documents tab -->
         <div
-          v-if="activeTab === 'documents'"
+          v-show="activeTab === 'documents'"
           id="candidate-tabpanel-documents"
           role="tabpanel"
           aria-labelledby="candidate-tab-documents"
+          :hidden="activeTab !== 'documents'"
         >
           <input
             ref="fileInput"

--- a/e2e/critical-flows/candidate-application.spec.ts
+++ b/e2e/critical-flows/candidate-application.spec.ts
@@ -475,7 +475,7 @@ test.describe('Candidate Application Flow — All Custom Question Field Types', 
     expect(fileIdText?.trim().length, 'file_upload response value must not be empty').toBeGreaterThan(0)
 
     // ── Documents tab: cover letter file should be listed ─────────────────────
-    await page.getByRole('button', { name: /^Documents/i }).click()
+    await page.getByRole('tab', { name: /^Documents/i }).click()
     // The file uploaded via the file_upload custom question is stored as a
     // candidate document — verify the original filename is visible.
     await expect(page.getByText('cover-letter.pdf', { exact: false })).toBeVisible({ timeout: 10_000 })

--- a/e2e/critical-flows/candidate-application.spec.ts
+++ b/e2e/critical-flows/candidate-application.spec.ts
@@ -475,7 +475,8 @@ test.describe('Candidate Application Flow — All Custom Question Field Types', 
     expect(fileIdText?.trim().length, 'file_upload response value must not be empty').toBeGreaterThan(0)
 
     // ── Documents tab: cover letter file should be listed ─────────────────────
-    await page.getByRole('tab', { name: /^Documents/i }).click()
+    // ApplicationDetailDrawer sidebar tabs remain role=button (not candidate page tabs).
+    await page.getByRole('button', { name: /^Documents/i }).click()
     // The file uploaded via the file_upload custom question is stored as a
     // candidate document — verify the original filename is visible.
     await expect(page.getByText('cover-letter.pdf', { exact: false })).toBeVisible({ timeout: 10_000 })

--- a/e2e/critical-flows/candidate-documents.spec.ts
+++ b/e2e/critical-flows/candidate-documents.spec.ts
@@ -91,7 +91,7 @@ async function uploadPdfFromDashboard(page: Page, candidateId: string, filename:
   await page.waitForLoadState('networkidle')
   await expect(page.getByRole('heading', { name: /Candidate|Document/i })).toBeVisible()
 
-  const documentsTab = page.getByRole('button', { name: /^Documents \(/ })
+  const documentsTab = page.getByRole('tab', { name: /^Documents \(/ })
   const uploadButton = page.getByRole('button', { name: 'Upload Document' })
   await expect(documentsTab).toBeVisible()
   await expect(async () => {

--- a/tests/unit/candidate-detail-drawer.test.ts
+++ b/tests/unit/candidate-detail-drawer.test.ts
@@ -11,11 +11,15 @@ describe('candidate detail drawer', () => {
     const source = readProjectFile('app/components/CandidateApplicationsPanel.vue')
     const drawer = readProjectFile('app/components/CandidateDetailDrawer.vue')
     const badge = readProjectFile('app/components/ApplicationStatusBadge.vue')
+    const useApplication = readProjectFile('app/composables/useApplication.ts')
 
     expect(drawer).toContain('<CandidateApplicationsPanel')
     expect(drawer).toContain('show-status-transitions')
     expect(drawer).toContain('const transitioningApplicationIds = ref<Set<string>>(new Set())')
     expect(drawer).toContain('useApplicationStatusActions')
+    expect(drawer).toContain('patchApplication')
+    expect(drawer).not.toContain('$fetch(`/api/applications/${appId}`')
+    expect(useApplication).toContain('export async function patchApplication')
     expect(source).toContain('APPLICATION_STATUS_TRANSITIONS')
     expect(source).toContain('getApplicationTransitionButtonClass(nextStatus, \'factory\')')
     expect(source).toContain('getApplicationTransitionActionLabel(nextStatus)')
@@ -85,5 +89,33 @@ describe('candidate detail drawer', () => {
     expect(modal).toContain('<AppModalShell')
     expect(modal).not.toContain('ui-modal-frame')
     expect(modal).not.toContain('ui-modal-list-row')
+  })
+
+  it('exposes accessible candidate detail tabs with keyboard navigation in drawer and page', () => {
+    const drawer = readProjectFile('app/components/CandidateDetailDrawer.vue')
+    const page = readProjectFile('app/pages/dashboard/candidates/[id].vue')
+
+    for (const source of [drawer, page]) {
+      expect(source).toContain('role="tablist"')
+      expect(source).toContain('role="tab"')
+      expect(source).toContain(':aria-selected="activeTab === \'applications\'"')
+      expect(source).toContain(':aria-selected="activeTab === \'documents\'"')
+      expect(source).toContain('handleCandidateTabKeydown')
+      expect(source).toContain("event.key === 'ArrowRight'")
+      expect(source).toContain("event.key === 'ArrowLeft'")
+    }
+  })
+
+  it('keeps status transitions on the full candidate page aligned with the drawer', () => {
+    const drawer = readProjectFile('app/components/CandidateDetailDrawer.vue')
+    const page = readProjectFile('app/pages/dashboard/candidates/[id].vue')
+
+    for (const source of [drawer, page]) {
+      expect(source).toContain('show-status-transitions')
+      expect(source).toContain('useApplicationStatusActions')
+      expect(source).toContain('transitioningApplicationIds')
+      expect(source).toContain('patchApplication')
+      expect(source).toContain('@transition="handleApplicationTransition"')
+    }
   })
 })

--- a/tests/unit/dashboard-shell-epic4.test.ts
+++ b/tests/unit/dashboard-shell-epic4.test.ts
@@ -76,6 +76,8 @@ describe('dashboard shell epic 4', () => {
     expect(drawer).toContain('useApplicationStatusActions')
     expect(drawer).toContain('transitioningApplicationIds')
     expect(drawer).toContain('transitionKey: computed(() => transitionTarget.value?.id)')
+    expect(drawer).toContain('patchApplication')
+    expect(drawer).not.toContain('$fetch(`/api/applications/${appId}`')
     expect(drawer).not.toContain('handlePreviewReadOnlyError')
     expect(drawer).not.toContain('toast.error(\'Failed to update status\'')
     expect(statusActions).toContain('transitioningKeys?: Ref<Set<string>>')


### PR DESCRIPTION
## Summary

- **#274** — Replace raw `$fetch` PATCH in `CandidateDetailDrawer` with shared `patchApplication` helper extracted from `useApplication.ts`
- **#280** — Add status transition parity to `candidates/[id].vue` using `useApplicationStatusActions` + `transitioningApplicationIds`
- **#279** — Add `role="tablist"` / `role="tab"` / `aria-selected` semantics and Arrow Left/Right keyboard navigation on candidate detail tabs (drawer + page)

## Test plan

- [x] `npm run test:unit` — 175 files, 1013 tests passed
- [ ] Manual QA: status transitions on candidate drawer and full page
- [ ] Manual QA: tab keyboard navigation (Arrow Left/Right)

Closes #274, #280, #279