### PR TITLE
refactor: unify detail drawer and apply modal chrome

### DIFF
--- a/app/components/AppDetailDrawerShell.vue
+++ b/app/components/AppDetailDrawerShell.vue
@@ -53,13 +53,13 @@ useFocusTrap({
     >
       <aside
         ref="drawerRef"
-        class="factory-dashboard-portal fixed inset-y-0 right-0 z-[60] w-full max-w-2xl flex flex-col border-l border-white/12 bg-black text-white shadow-none"
+        class="factory-dashboard-portal ui-drawer-panel fixed inset-y-0 right-0 z-[60] w-full max-w-2xl flex flex-col border-l border-white/12 bg-black text-white shadow-none"
         role="dialog"
         aria-modal="true"
         :aria-label="drawerAriaLabel"
       >
-        <header class="flex shrink-0 items-center justify-between gap-3 border-b border-white/10 bg-white/[0.035] px-5 py-4">
-          <span class="truncate text-sm font-semibold text-white">{{ title }}</span>
+        <header class="ui-drawer-header flex shrink-0 items-center justify-between gap-3 border-b border-white/10 bg-white/[0.035] px-5 py-4">
+          <h2 class="truncate text-sm font-semibold text-white">{{ title }}</h2>
           <div class="flex shrink-0 items-center gap-2">
             <NuxtLink
               :to="fullPageHref"
@@ -69,7 +69,8 @@ useFocusTrap({
               Open full page
             </NuxtLink>
             <button
-              class="ui-panel-close-button p-1.5 transition-colors"
+              type="button"
+              class="ui-button ui-button-ghost ui-panel-close-button shrink-0 p-1.5"
               :aria-label="closeAriaLabel"
               @click="emit('close')"
             >
@@ -78,7 +79,7 @@ useFocusTrap({
           </div>
         </header>
 
-        <div class="flex-1 space-y-4 overflow-y-auto bg-black p-5">
+        <div class="ui-drawer-body flex-1 space-y-4 overflow-y-auto bg-black p-5">
           <slot />
         </div>
       </aside>

--- a/app/components/ApplicationDetailDrawer.vue
+++ b/app/components/ApplicationDetailDrawer.vue
@@ -70,165 +70,165 @@ const {
     </div>
 
     <template v-else-if="application">
-            <!-- Header card -->
-            <div class="relative border border-white/12 bg-white/[0.025] p-5">
-              <div class="flex flex-col gap-4 sm:pr-56">
-                <div class="min-w-0">
-                  <p class="mb-2 text-xs font-medium uppercase tracking-wide text-surface-500 dark:text-surface-400">
-                    Application Overview
-                  </p>
-                  <div class="mb-3 flex flex-wrap items-center gap-2 text-surface-400">
-                    <h2 class="truncate text-2xl font-bold text-surface-900 dark:text-surface-50">
-                      {{ formatCandidateName(application.candidate) }}
-                    </h2>
-                    <span class="text-surface-400">→</span>
-                    <NuxtLink
-                      :to="localePath(`/dashboard/jobs/${application.job.id}`)"
-                      class="truncate text-xl text-brand-600 transition-colors hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-                    >
-                      {{ application.job.title }}
-                    </NuxtLink>
-                  </div>
-                  <ApplicationStatusBadge :status="application.status" />
-                </div>
-
-                <ApplicationTimestampStack
-                  :applied-at="application.createdAt"
-                  :updated-at="application.updatedAt"
-                  floating
-                />
-              </div>
+      <!-- Header card -->
+      <div class="relative border border-white/12 bg-white/[0.025] p-5">
+        <div class="flex flex-col gap-4 sm:pr-56">
+          <div class="min-w-0">
+            <p class="mb-2 text-xs font-medium uppercase tracking-wide text-surface-500 dark:text-surface-400">
+              Application Overview
+            </p>
+            <div class="mb-3 flex flex-wrap items-center gap-2 text-surface-400">
+              <h2 class="truncate text-2xl font-bold text-surface-900 dark:text-surface-50">
+                {{ formatCandidateName(application.candidate) }}
+              </h2>
+              <span class="text-surface-400">→</span>
+              <NuxtLink
+                :to="localePath(`/dashboard/jobs/${application.job.id}`)"
+                class="truncate text-xl text-brand-600 transition-colors hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+              >
+                {{ application.job.title }}
+              </NuxtLink>
             </div>
+            <ApplicationStatusBadge :status="application.status" />
+          </div>
 
-            <!-- Quick actions -->
-            <div class="border border-white/12 bg-white/[0.025] p-3">
-              <div class="flex flex-nowrap items-center gap-1.5 overflow-x-auto">
-                <span class="inline-flex shrink-0 items-center whitespace-nowrap bg-white/[0.04] px-2 py-1.5 text-[10px] font-semibold uppercase leading-none tracking-normal text-white/58">Quick actions</span>
-                <button
-                  v-for="nextStatus in allowedTransitions"
-                  :key="nextStatus"
-                  :disabled="isTransitioning"
-                  class="inline-flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap px-2.5 py-1.5 text-[10px] font-semibold uppercase leading-none tracking-normal transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500/40 disabled:cursor-not-allowed disabled:opacity-50"
-                  :class="getApplicationTransitionButtonClass(nextStatus, 'factory')"
-                  @click="transitionToStatus(nextStatus)"
+          <ApplicationTimestampStack
+            :applied-at="application.createdAt"
+            :updated-at="application.updatedAt"
+            floating
+          />
+        </div>
+      </div>
+
+      <!-- Quick actions -->
+      <div class="border border-white/12 bg-white/[0.025] p-3">
+        <div class="flex flex-nowrap items-center gap-1.5 overflow-x-auto">
+          <span class="inline-flex shrink-0 items-center whitespace-nowrap bg-white/[0.04] px-2 py-1.5 text-[10px] font-semibold uppercase leading-none tracking-normal text-white/58">Quick actions</span>
+          <button
+            v-for="nextStatus in allowedTransitions"
+            :key="nextStatus"
+            :disabled="isTransitioning"
+            class="inline-flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap px-2.5 py-1.5 text-[10px] font-semibold uppercase leading-none tracking-normal transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500/40 disabled:cursor-not-allowed disabled:opacity-50"
+            :class="getApplicationTransitionButtonClass(nextStatus, 'factory')"
+            @click="transitionToStatus(nextStatus)"
+          >
+            <ApplicationTransitionIcon :status="nextStatus" />
+            {{ getApplicationTransitionActionLabel(nextStatus) }}
+          </button>
+          <button
+            class="inline-flex shrink-0 cursor-pointer items-center gap-1 whitespace-nowrap border border-white/16 bg-black px-2.5 py-1.5 text-[10px] font-semibold uppercase leading-none tracking-normal text-white/80 hover:border-brand-500 hover:bg-brand-500/12 hover:text-white transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500/40"
+            @click="openInterviewScheduler"
+          >
+            <Calendar class="size-3" />
+            Schedule Interview
+          </button>
+        </div>
+      </div>
+
+      <!-- Candidate & Job cards -->
+      <div class="grid gap-4 sm:grid-cols-2">
+        <!-- Candidate info -->
+        <div class="border border-white/12 bg-white/[0.025] p-5">
+          <div class="flex items-center gap-2 mb-3">
+            <User class="size-4 text-surface-500 dark:text-surface-400" />
+            <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-200">Candidate</h3>
+          </div>
+          <dl class="grid grid-cols-1 gap-3 text-sm">
+            <div>
+              <dt class="text-surface-400">Name</dt>
+              <dd class="text-surface-700 dark:text-surface-200 font-medium">
+                <NuxtLink
+                  :to="localePath(`/dashboard/candidates/${application.candidate.id}`)"
+                  class="text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300 transition-colors"
                 >
-                  <ApplicationTransitionIcon :status="nextStatus" />
-                  {{ getApplicationTransitionActionLabel(nextStatus) }}
-                </button>
-                <button
-                  class="inline-flex shrink-0 cursor-pointer items-center gap-1 whitespace-nowrap border border-white/16 bg-black px-2.5 py-1.5 text-[10px] font-semibold uppercase leading-none tracking-normal text-white/80 hover:border-brand-500 hover:bg-brand-500/12 hover:text-white transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500/40"
-                  @click="openInterviewScheduler"
+                  {{ formatCandidateName(application.candidate) }}
+                </NuxtLink>
+              </dd>
+            </div>
+            <div>
+              <dt class="text-surface-400">Email</dt>
+              <dd class="text-surface-700 dark:text-surface-200 font-medium">
+                <CopyEmailButton :email="application.candidate.email" :show-icon="false" class="text-surface-700 dark:text-surface-200" />
+              </dd>
+            </div>
+            <div v-if="application.candidate.phone">
+              <dt class="text-surface-400">Phone</dt>
+              <dd class="text-surface-700 dark:text-surface-200 font-medium">{{ formatPhoneNumber(application.candidate.phone) }}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <!-- Job info -->
+        <div class="border border-white/12 bg-white/[0.025] p-5">
+          <div class="flex items-center gap-2 mb-3">
+            <Briefcase class="size-4 text-surface-500 dark:text-surface-400" />
+            <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-200">Job</h3>
+          </div>
+          <dl class="grid grid-cols-1 gap-3 text-sm">
+            <div>
+              <dt class="text-surface-400">Title</dt>
+              <dd class="text-surface-700 dark:text-surface-200 font-medium">
+                <NuxtLink
+                  :to="localePath(`/dashboard/jobs/${application.job.id}`)"
+                  class="text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300 transition-colors"
                 >
-                  <Calendar class="size-3" />
-                  Schedule Interview
-                </button>
-              </div>
+                  {{ application.job.title }}
+                </NuxtLink>
+              </dd>
             </div>
-
-            <!-- Candidate & Job cards -->
-            <div class="grid gap-4 sm:grid-cols-2">
-              <!-- Candidate info -->
-              <div class="border border-white/12 bg-white/[0.025] p-5">
-                <div class="flex items-center gap-2 mb-3">
-                  <User class="size-4 text-surface-500 dark:text-surface-400" />
-                  <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-200">Candidate</h3>
-                </div>
-                <dl class="grid grid-cols-1 gap-3 text-sm">
-                  <div>
-                    <dt class="text-surface-400">Name</dt>
-                    <dd class="text-surface-700 dark:text-surface-200 font-medium">
-                      <NuxtLink
-                        :to="localePath(`/dashboard/candidates/${application.candidate.id}`)"
-                        class="text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300 transition-colors"
-                      >
-                        {{ formatCandidateName(application.candidate) }}
-                      </NuxtLink>
-                    </dd>
-                  </div>
-                  <div>
-                    <dt class="text-surface-400">Email</dt>
-                    <dd class="text-surface-700 dark:text-surface-200 font-medium">
-                      <CopyEmailButton :email="application.candidate.email" :show-icon="false" class="text-surface-700 dark:text-surface-200" />
-                    </dd>
-                  </div>
-                  <div v-if="application.candidate.phone">
-                    <dt class="text-surface-400">Phone</dt>
-                    <dd class="text-surface-700 dark:text-surface-200 font-medium">{{ formatPhoneNumber(application.candidate.phone) }}</dd>
-                  </div>
-                </dl>
-              </div>
-
-              <!-- Job info -->
-              <div class="border border-white/12 bg-white/[0.025] p-5">
-                <div class="flex items-center gap-2 mb-3">
-                  <Briefcase class="size-4 text-surface-500 dark:text-surface-400" />
-                  <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-200">Job</h3>
-                </div>
-                <dl class="grid grid-cols-1 gap-3 text-sm">
-                  <div>
-                    <dt class="text-surface-400">Title</dt>
-                    <dd class="text-surface-700 dark:text-surface-200 font-medium">
-                      <NuxtLink
-                        :to="localePath(`/dashboard/jobs/${application.job.id}`)"
-                        class="text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300 transition-colors"
-                      >
-                        {{ application.job.title }}
-                      </NuxtLink>
-                    </dd>
-                  </div>
-                  <div>
-                    <dt class="text-surface-400">Job Status</dt>
-                    <dd class="text-surface-700 dark:text-surface-200 font-medium capitalize">{{ application.job.status }}</dd>
-                  </div>
-                </dl>
-              </div>
+            <div>
+              <dt class="text-surface-400">Job Status</dt>
+              <dd class="text-surface-700 dark:text-surface-200 font-medium capitalize">{{ application.job.status }}</dd>
             </div>
+          </dl>
+        </div>
+      </div>
 
-            <ApplicationScoringPanel
-              surface="drawer"
-              :application-id="applicationId"
-              :score="application.score"
-              :analysis-run-id="scoringData?.latestRun?.id ?? null"
-              :score-band="scoreBand"
-              :scoring-summary="scoringSummary"
-              :scoring-summary-fallback="scoringSummaryFallback"
-              :is-scoring="isScoringApplication"
-              show-score-band
-              @score="scoreCurrentApplication"
-            />
+      <ApplicationScoringPanel
+        surface="drawer"
+        :application-id="applicationId"
+        :score="application.score"
+        :analysis-run-id="scoringData?.latestRun?.id ?? null"
+        :score-band="scoreBand"
+        :scoring-summary="scoringSummary"
+        :scoring-summary-fallback="scoringSummaryFallback"
+        :is-scoring="isScoringApplication"
+        show-score-band
+        @score="scoreCurrentApplication"
+      />
 
-            <ApplicationNotesPanel
-              surface="drawer"
-              :notes="application.notes"
-              :is-editing-notes="isEditingNotes"
-              :notes-input="notesInput"
-              :is-saving-notes="isSavingNotes"
-              :notes-save-status="notesSaveStatus"
-              focus-on-edit
-              @update:notes-input="notesInput = $event"
-              @start-edit="startEditNotes"
-              @autosave="autosaveNotes"
-              @save="saveNotes"
-              @finish-edit="finishEditNotes"
-            />
+      <ApplicationNotesPanel
+        surface="drawer"
+        :notes="application.notes"
+        :is-editing-notes="isEditingNotes"
+        :notes-input="notesInput"
+        :is-saving-notes="isSavingNotes"
+        :notes-save-status="notesSaveStatus"
+        focus-on-edit
+        @update:notes-input="notesInput = $event"
+        @start-edit="startEditNotes"
+        @autosave="autosaveNotes"
+        @save="saveNotes"
+        @finish-edit="finishEditNotes"
+      />
 
-            <!-- Properties -->
-            <div class="border border-white/12 bg-white/[0.025] p-4">
-              <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-200 mb-2 px-2">Properties</h3>
-              <PropertyBlock
-                entity-type="application"
-                :entity-id="applicationId"
-                :job-id="application.job.id"
-                :entries="(application.properties ?? []) as import('~~/shared/properties').PropertyEntry[]"
-                @refresh="refresh()"
-              />
-            </div>
+      <!-- Properties -->
+      <div class="border border-white/12 bg-white/[0.025] p-4">
+        <h3 class="text-sm font-semibold text-surface-700 dark:text-surface-200 mb-2 px-2">Properties</h3>
+        <PropertyBlock
+          entity-type="application"
+          :entity-id="applicationId"
+          :job-id="application.job.id"
+          :entries="(application.properties ?? []) as import('~~/shared/properties').PropertyEntry[]"
+          @refresh="refresh()"
+        />
+      </div>
 
-            <ApplicationResponsesPanel
-              v-if="application.responses && application.responses.length > 0"
-              surface="drawer"
-              :responses="application.responses"
-            />
+      <ApplicationResponsesPanel
+        v-if="application.responses && application.responses.length > 0"
+        surface="drawer"
+        :responses="application.responses"
+      />
     </template>
 
     <template #overlays>

--- a/app/components/ApplicationLinkModal.vue
+++ b/app/components/ApplicationLinkModal.vue
@@ -7,6 +7,7 @@ const props = withDefaults(defineProps<{
   candidateId?: string
   jobId?: string
   teleportTo?: string | HTMLElement
+  /** Modal stacking layer. Defaults to z-[90] in job mode (above drawer overlays) and z-50 in candidate mode. */
   zIndexClass?: string
 }>(), {
   teleportTo: 'body',
@@ -116,29 +117,33 @@ function applyCandidate(candidateId: string) {
     @close="emit('close')"
   >
     <AppModalPanel class="flex w-full max-w-lg flex-col overflow-hidden border border-white/12 bg-black text-white shadow-2xl shadow-black/70">
-      <div class="flex items-center justify-between gap-4 border-b border-white/10 bg-white/[0.035] px-5 py-4">
+      <header class="ui-panel-header flex items-center justify-between gap-4 px-5 py-4">
         <div class="flex min-w-0 items-center gap-3">
           <div class="flex size-9 shrink-0 items-center justify-center border border-brand-500/45 bg-brand-500/12 text-brand-300">
             <Briefcase v-if="mode === 'job'" class="size-4" />
             <UserPlus v-else class="size-4" />
           </div>
           <div class="min-w-0">
-            <h3 class="text-base font-semibold text-white">
-              {{ mode === 'job' ? 'Apply to Job' : 'Add Candidate' }}
-            </h3>
+            <h2 class="text-base font-semibold text-white">
+              {{ mode === 'job' ? 'Apply to job' : 'Add candidate' }}
+            </h2>
             <p v-if="mode === 'job'" class="mt-0.5 text-xs text-white/42">
               Choose an open role for this candidate.
+            </p>
+            <p v-else class="mt-0.5 text-xs text-white/42">
+              Search and link an existing candidate to this job.
             </p>
           </div>
         </div>
         <button
-          class="ui-panel-close-button inline-flex size-9 shrink-0 cursor-pointer items-center justify-center border border-transparent bg-transparent text-white/58 transition-colors hover:border-white hover:bg-white hover:text-black"
+          type="button"
+          class="ui-button ui-button-ghost ui-panel-close-button shrink-0 p-1.5"
           :aria-label="mode === 'job' ? 'Close apply to job modal' : 'Close add candidate modal'"
           @click="emit('close')"
         >
           <X class="size-4" />
         </button>
-      </div>
+      </header>
 
       <div v-if="mode === 'candidate'" class="px-5 pt-4">
         <GooeySearchInput

--- a/tests/unit/dashboard-shell-epic4.test.ts
+++ b/tests/unit/dashboard-shell-epic4.test.ts
@@ -16,6 +16,10 @@ describe('dashboard shell epic 4', () => {
       'previousBodyOverflow',
       'document.body.style.overflow = previousBodyOverflow',
       'factory-dashboard-portal ui-modal-backdrop fixed inset-0 z-[55]',
+      'ui-drawer-panel',
+      'ui-drawer-header',
+      '<h2 class="truncate text-sm font-semibold text-white">{{ title }}</h2>',
+      'type="button"',
       'fixed inset-y-0 right-0 z-[60]',
       'Open full page',
       '<slot name="overlays" />',
@@ -38,15 +42,20 @@ describe('dashboard shell epic 4', () => {
 
     for (const snippet of [
       "mode: 'job' | 'candidate'",
+      '/** Modal stacking layer. Defaults to z-[90] in job mode',
       '<AppModalShell',
       '<AppModalPanel',
+      'ui-panel-header',
       'useDebouncedRef',
       'import.meta.dev',
       'ApplicationLinkModal requires candidateId when mode is "job".',
       'ApplicationLinkModal requires jobId when mode is "candidate".',
       'immediate: props.mode === \'job\'',
       'immediate: props.mode === \'candidate\'',
+      'Apply to job',
+      'Add candidate',
       'Choose an open role for this candidate.',
+      'Search and link an existing candidate to this job.',
       'Search candidates by name or email',
     ]) {
       expect(modal, snippet).toContain(snippet)

--- a/tests/unit/panel-close-buttons.test.ts
+++ b/tests/unit/panel-close-buttons.test.ts
@@ -30,5 +30,14 @@ describe('panel close buttons', () => {
     ]) {
       expect(readProjectFile(path), `${path} should use panel close styling`).toContain('ui-panel-close-button')
     }
+
+    for (const path of [
+      'app/components/FilterDrawer.vue',
+      'app/components/AppDetailDrawerShell.vue',
+      'app/components/ApplicationLinkModal.vue',
+    ]) {
+      const source = readProjectFile(path)
+      expect(source, `${path} close button should be an explicit button type`).toMatch(/type="button"[\s\S]*ui-panel-close-button|ui-panel-close-button[\s\S]*type="button"/)
+    }
   })
 })

--- a/tests/unit/panel-close-buttons.test.ts
+++ b/tests/unit/panel-close-buttons.test.ts
@@ -37,7 +37,11 @@ describe('panel close buttons', () => {
       'app/components/ApplicationLinkModal.vue',
     ]) {
       const source = readProjectFile(path)
-      expect(source, `${path} close button should be an explicit button type`).toMatch(/type="button"[\s\S]*ui-panel-close-button|ui-panel-close-button[\s\S]*type="button"/)
+      const closeButtons = [...source.matchAll(/<button\b[^>]*\bui-panel-close-button\b[^>]*>/g)]
+      expect(closeButtons.length, `${path} should declare a ui-panel-close-button`).toBeGreaterThan(0)
+      for (const [match] of closeButtons) {
+        expect(match, `${path} panel close button should be an explicit button type`).toContain('type="button"')
+      }
     }
   })
 })


### PR DESCRIPTION
Unifies detail drawer and ApplicationLinkModal chrome on shared panel recipes.

- `AppDetailDrawerShell`: `ui-drawer-panel` / `ui-drawer-header`, semantic `<h2>` title, standard ghost close button with `type="button"`
- `ApplicationLinkModal`: `ui-panel-header`, sentence-case titles, candidate-mode subtitle, `zIndexClass` JSDoc
- Fixes double-indentation in `ApplicationDetailDrawer.vue` template

Closes #260, #261, #262, #272, #265, #267, #275, #278