### PR TITLE
chore: standardize defineEmits tuple syntax in modal primitives

### DIFF
--- a/app/components/AppModalShell.vue
+++ b/app/components/AppModalShell.vue
@@ -20,7 +20,7 @@ const props = withDefaults(defineProps<{
 })
 
 const emit = defineEmits<{
-  (e: 'close'): void
+  close: []
 }>()
 
 const attrs = useAttrs()

--- a/app/components/ConfirmDialog.vue
+++ b/app/components/ConfirmDialog.vue
@@ -29,8 +29,8 @@ const props = withDefaults(defineProps<{
 })
 
 const emit = defineEmits<{
-  (e: 'close'): void
-  (e: 'confirm'): void
+  close: []
+  confirm: []
 }>()
 
 const confirmButtonClass = computed(() => (

--- a/app/components/PreviewUpsellModal.vue
+++ b/app/components/PreviewUpsellModal.vue
@@ -2,7 +2,7 @@
 import { Eye, X, Github, Rocket, Cloud } from 'lucide-vue-next'
 
 const emit = defineEmits<{
-  (e: 'close'): void
+  close: []
 }>()
 
 const { message } = usePreviewReadOnly()


### PR DESCRIPTION
Closes #266. Aligns AppModalShell, ConfirmDialog, PreviewUpsellModal with tuple emit syntax. No behavior changes.