### PR TITLE
refactor: migrate settings delete confirm to ConfirmDialog

### DIFF
--- a/app/pages/dashboard/settings/index.vue
+++ b/app/pages/dashboard/settings/index.vue
@@ -112,6 +112,7 @@ const canConfirmDelete = computed(() => {
 })
 
 function closeDeleteConfirm() {
+  if (isDeleting.value) return
   showDeleteConfirm.value = false
   deleteConfirmText.value = ''
 }
@@ -286,6 +287,7 @@ async function handleDeleteOrg() {
       confirm-label="Permanently delete"
       loading-label="Deleting…"
       variant="danger"
+      :close-on-backdrop="false"
       :loading="isDeleting"
       :confirm-disabled="!canConfirmDelete"
       show-danger-icon

--- a/app/pages/dashboard/settings/index.vue
+++ b/app/pages/dashboard/settings/index.vue
@@ -111,6 +111,11 @@ const canConfirmDelete = computed(() => {
   return !!name && deleteConfirmText.value === name
 })
 
+function closeDeleteConfirm() {
+  showDeleteConfirm.value = false
+  deleteConfirmText.value = ''
+}
+
 async function handleDeleteOrg() {
   if (!canDeleteOrg.value || !canConfirmDelete.value) return
   isDeleting.value = true
@@ -272,44 +277,35 @@ async function handleDeleteOrg() {
           </button>
         </div>
 
-        <!-- Delete confirmation -->
-        <Transition
-          enter-active-class="transition-all duration-200"
-          leave-active-class="transition-all duration-200"
-          enter-from-class="opacity-0 -translate-y-2"
-          leave-to-class="opacity-0 -translate-y-2"
-        >
-          <div v-if="showDeleteConfirm" class="ui-alert ui-alert-danger mt-5 space-y-3">
-            <p class="text-sm text-surface-700 dark:text-surface-300">
-              Type <strong class="text-surface-900 dark:text-surface-100 font-semibold">{{ activeOrg?.name }}</strong> to confirm deletion:
-            </p>
-            <input
-              v-model="deleteConfirmText"
-              type="text"
-              class="ui-field"
-              :placeholder="activeOrg?.name"
-            />
-            <div class="flex items-center gap-2">
-              <button
-                :disabled="!canConfirmDelete || isDeleting"
-                class="ui-button ui-button-danger disabled:opacity-50 disabled:cursor-not-allowed"
-                @click="handleDeleteOrg"
-              >
-                <Loader2 v-if="isDeleting" class="size-4 animate-spin" />
-                <Trash2 v-else class="size-4" />
-                {{ isDeleting ? 'Deleting…' : 'Permanently delete' }}
-              </button>
-              <button
-                class="ui-button ui-button-secondary"
-                @click="showDeleteConfirm = false; deleteConfirmText = ''"
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
-        </Transition>
       </div>
     </section>
+
+    <ConfirmDialog
+      v-if="showDeleteConfirm"
+      title="Delete organization"
+      confirm-label="Permanently delete"
+      loading-label="Deleting…"
+      variant="danger"
+      :loading="isDeleting"
+      :confirm-disabled="!canConfirmDelete"
+      show-danger-icon
+      panel-class="max-w-md p-6"
+      aria-label="Delete organization"
+      @close="closeDeleteConfirm"
+      @confirm="handleDeleteOrg"
+    >
+      <p class="text-sm text-surface-600 dark:text-surface-400 mb-4">
+        Type <strong class="text-surface-900 dark:text-surface-100 font-semibold">{{ activeOrg?.name }}</strong> to confirm deletion. This action cannot be undone.
+      </p>
+      <label for="delete-org-confirm" class="sr-only">Confirm organization name</label>
+      <input
+        id="delete-org-confirm"
+        v-model="deleteConfirmText"
+        type="text"
+        class="ui-field"
+        :placeholder="activeOrg?.name"
+      />
+    </ConfirmDialog>
 
     <!-- Read-only notice for non-admin users -->
     <div v-if="!isUpdateOrgPermissionLoading && !canUpdateOrg" class="ui-alert ui-alert-info mt-6">

--- a/tests/unit/app-modal-primitives.test.ts
+++ b/tests/unit/app-modal-primitives.test.ts
@@ -50,6 +50,7 @@ describe('dashboard modal primitives', () => {
       'app/pages/dashboard/emails/templates/index.vue',
       'app/pages/dashboard/interviews/[id].vue',
       'app/pages/dashboard/interviews/index.vue',
+      'app/pages/dashboard/settings/index.vue',
     ]
 
     for (const file of directModalFiles) {
@@ -109,6 +110,7 @@ describe('dashboard modal primitives', () => {
       'app/pages/dashboard/interviews/[id].vue',
       'app/components/CandidateDetailSidebar.vue',
       'app/components/JobSubNavActions.vue',
+      'app/pages/dashboard/settings/index.vue',
     ]
 
     for (const file of migratedFiles) {

--- a/tests/unit/theme-neutrality.test.ts
+++ b/tests/unit/theme-neutrality.test.ts
@@ -589,7 +589,7 @@ describe('brand-neutral theme variables', () => {
     const recipeUsage = [
       {
         path: 'app/pages/dashboard/settings/index.vue',
-        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-field', 'ui-alert-danger', 'ui-button-primary', 'ui-button-danger', 'ui-button-danger-outline', 'ui-button-secondary'],
+        recipes: ['ui-settings-page', 'ui-settings-page-header', 'ui-settings-panel', 'ui-settings-panel-header', 'ui-settings-panel-body', 'ui-field', 'ui-button-primary', 'ui-button-danger-outline', 'ConfirmDialog'],
       },
       {
         path: 'app/pages/dashboard/settings/account.vue',


### PR DESCRIPTION
Migrates organization delete confirmation on settings page from inline alert to shared ConfirmDialog. Preserves typed org-name confirmation, loading state, and danger styling.

Closes #212