### PR TITLE
perf: centralize dashboard session fetching in useAuthSession

### DIFF
--- a/app/components/AppTopBar.vue
+++ b/app/components/AppTopBar.vue
@@ -13,7 +13,7 @@ import { getJobStatusBadgeClass, getJobStatusLabel } from '~/utils/status-displa
 const route = useRoute()
 const localePath = useLocalePath()
 const getRouteBaseName = useRouteBaseName()
-const { data: session } = await authClient.useSession(useFetch)
+const { session } = await useAuthSession()
 const isSigningOut = ref(false)
 
 const showFeedbackModal = ref(false)

--- a/app/composables/useAuthSession.ts
+++ b/app/composables/useAuthSession.ts
@@ -12,9 +12,12 @@
  *   for fast repeated checks during navigation.
  * - Easy to extend later with stronger SWR / TTL if needed.
  *
- * Usage in middleware (async context):
+ * Usage in middleware, layouts, and shell components (async context):
  *   const { session } = await useAuthSession()
  *   if (!session.value) { ... }
+ *
+ * Do not call `authClient.useSession(useFetch)` outside this composable in
+ * dashboard shell code (`dashboard`/`settings` layouts, `AppTopBar`, PostHog identity).
  */
 import { authClient } from '~/utils/auth-client'
 

--- a/app/composables/usePostHogIdentity.ts
+++ b/app/composables/usePostHogIdentity.ts
@@ -23,7 +23,7 @@ export async function usePostHogIdentity() {
 
   if (!$posthogIdentifyUser) return
 
-  const { data: session } = await authClient.useSession(useFetch)
+  const { session } = await useAuthSession()
   const activeOrgState = authClient.useActiveOrganization()
 
   const { hasConsented } = useAnalyticsConsent()

--- a/app/layouts/dashboard.vue
+++ b/app/layouts/dashboard.vue
@@ -5,7 +5,7 @@ import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
 const route = useRoute()
 const isFullbleed = computed(() => !!route.meta.fullbleed)
 
-const { data: session } = await authClient.useSession(useFetch)
+const { session } = await useAuthSession()
 
 const config = useRuntimeConfig()
 const { activeOrg } = useCurrentOrg()

--- a/app/layouts/settings.vue
+++ b/app/layouts/settings.vue
@@ -2,7 +2,7 @@
 import { Eye } from 'lucide-vue-next'
 import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
 
-const { data: session } = await authClient.useSession(useFetch)
+const { session } = await useAuthSession()
 
 const config = useRuntimeConfig()
 const { activeOrg } = useCurrentOrg()

--- a/tests/unit/auth-session-dedup.test.ts
+++ b/tests/unit/auth-session-dedup.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('auth session deduplication', () => {
+  const dashboardShellFiles = [
+    'app/layouts/dashboard.vue',
+    'app/layouts/settings.vue',
+    'app/components/AppTopBar.vue',
+    'app/composables/usePostHogIdentity.ts',
+  ]
+
+  it('routes dashboard shell session reads through useAuthSession', () => {
+    for (const file of dashboardShellFiles) {
+      const source = readProjectFile(file)
+
+      expect(source, file).toContain('useAuthSession')
+      expect(source, file).not.toContain('authClient.useSession(useFetch)')
+    }
+  })
+
+  it('keeps useFetch-integrated session ownership in useAuthSession', () => {
+    const source = readProjectFile('app/composables/useAuthSession.ts')
+
+    expect(source).toContain('authClient.useSession(useFetch)')
+    expect(source).toContain('export async function useAuthSession')
+  })
+})

--- a/tests/unit/auth-session-dedup.test.ts
+++ b/tests/unit/auth-session-dedup.test.ts
@@ -13,19 +13,22 @@ describe('auth session deduplication', () => {
     'app/composables/usePostHogIdentity.ts',
   ]
 
+  const useAuthSessionCallPattern = /await\s+useAuthSession\s*\(/
+  const directSessionFetchPattern = /await\s+authClient\.useSession\s*\(\s*useFetch\s*\)/
+
   it('routes dashboard shell session reads through useAuthSession', () => {
     for (const file of dashboardShellFiles) {
       const source = readProjectFile(file)
 
-      expect(source, file).toContain('useAuthSession')
-      expect(source, file).not.toContain('authClient.useSession(useFetch)')
+      expect(source, file).toMatch(useAuthSessionCallPattern)
+      expect(source, file).not.toMatch(directSessionFetchPattern)
     }
   })
 
   it('keeps useFetch-integrated session ownership in useAuthSession', () => {
     const source = readProjectFile('app/composables/useAuthSession.ts')
 
-    expect(source).toContain('authClient.useSession(useFetch)')
-    expect(source).toContain('export async function useAuthSession')
+    expect(source).toMatch(directSessionFetchPattern)
+    expect(source).toMatch(/export async function useAuthSession/)
   })
 })


### PR DESCRIPTION
Epic 1 / #306 — removes duplicate `authClient.useSession(useFetch)` calls from the dashboard shell so session resolution flows through the single `useAuthSession` composable.

## Changes
- `usePostHogIdentity`, `dashboard` layout, `settings` layout, and `AppTopBar` now call `useAuthSession()`
- Documented ownership in `useAuthSession` JSDoc
- Added `tests/unit/auth-session-dedup.test.ts` convention guard

## Verification
```bash
npm run test:unit -- tests/unit/auth-session-dedup.test.ts tests/unit/auth-session.test.ts
```

Closes #306