### PR TITLE
perf: unify /api/jobs client cache keys

### DIFF
--- a/app/components/AppTopBar.vue
+++ b/app/components/AppTopBar.vue
@@ -73,15 +73,7 @@ const activeJobId = computed(() => {
   return idParam
 })
 
-const {
-  data: sidebarJobsData,
-} = useFetch('/api/jobs', {
-  key: 'sidebar-jobs-list',
-  query: { limit: 100 },
-  headers: useRequestHeaders(['cookie']),
-})
-
-const sidebarJobs = computed(() => sidebarJobsData.value?.data ?? [])
+const { jobs: sidebarJobs } = useSidebarJobs()
 
 const activeJobTitle = computed(() => {
   if (!activeJobId.value) return null

--- a/app/components/ApplicationLinkModal.vue
+++ b/app/components/ApplicationLinkModal.vue
@@ -38,14 +38,10 @@ if (import.meta.dev) {
 
 // ─── Job mode: list open roles for a candidate ────────────────────────────────
 
-const { data: jobData, status: jobFetchStatus } = useFetch('/api/jobs', {
-  key: 'application-link-job-list',
-  query: { status: 'open' },
-  headers: useRequestHeaders(['cookie']),
+const { jobs, fetchStatus: jobFetchStatus } = useJobs({
+  status: 'open',
   immediate: props.mode === 'job',
 })
-
-const jobs = computed(() => jobData.value?.data ?? [])
 
 // ─── Candidate mode: search candidates for a job ──────────────────────────────
 

--- a/app/composables/useJob.ts
+++ b/app/composables/useJob.ts
@@ -18,20 +18,7 @@ export function useJob(id: MaybeRefOrGetter<string>) {
   )
 
   function syncJobListCache(updatedJob: { id: string } & Record<string, unknown>) {
-    const { data: sidebarJobsData } = useNuxtData<{ data: Array<Record<string, unknown>> }>('sidebar-jobs-list')
-    if (!sidebarJobsData.value?.data) return
-
-    sidebarJobsData.value = {
-      ...sidebarJobsData.value,
-      data: sidebarJobsData.value.data.map((item) => {
-        if (item.id !== updatedJob.id) return item
-        return {
-          ...item,
-          ...updatedJob,
-          pipeline: item.pipeline,
-        }
-      }),
-    }
+    patchJobsListCaches(updatedJob)
   }
 
   /** Update job fields (partial) and refresh both detail and list caches */
@@ -65,8 +52,7 @@ export function useJob(id: MaybeRefOrGetter<string>) {
       })
       syncJobListCache(updated)
       await refresh()
-      await refreshNuxtData('jobs')
-      await refreshNuxtData('sidebar-jobs-list')
+      await refreshJobsListCaches()
       return updated
     } catch (error) {
       handlePreviewReadOnlyError(error)
@@ -82,8 +68,7 @@ export function useJob(id: MaybeRefOrGetter<string>) {
       handlePreviewReadOnlyError(error)
       throw error
     }
-    await refreshNuxtData('jobs')
-    await refreshNuxtData('sidebar-jobs-list')
+    await refreshJobsListCaches()
     await navigateTo(localePath('/dashboard/jobs'))
   }
 

--- a/app/composables/useJobs.ts
+++ b/app/composables/useJobs.ts
@@ -1,27 +1,108 @@
 import type { Ref } from 'vue'
 
+export type JobsListQuery = {
+  page?: number
+  limit?: number
+  status?: string
+}
+
+export type JobsListResponse = {
+  data: Array<Record<string, unknown>>
+  total: number
+  page?: number
+  limit?: number
+}
+
+/** Stable Nuxt payload key for a /api/jobs query object. */
+export function jobsListKey(query: JobsListQuery): string {
+  const normalized: JobsListQuery = {}
+  if (query.page && query.page !== 1) normalized.page = query.page
+  if (query.limit) normalized.limit = query.limit
+  if (query.status) normalized.status = query.status
+  return `jobs-${JSON.stringify(normalized)}`
+}
+
+function buildJobsListQuery(options?: {
+  page?: Ref<number | undefined> | number
+  limit?: Ref<number | undefined> | number
+  status?: Ref<string | undefined> | string
+}): ComputedRef<JobsListQuery> {
+  return computed(() => ({
+    ...(toValue(options?.page) && { page: toValue(options?.page) }),
+    ...(toValue(options?.limit) && { limit: toValue(options?.limit) }),
+    ...(toValue(options?.status) && { status: toValue(options?.status) }),
+  }))
+}
+
+function stampJobsListFetchedAt(data: JobsListResponse | null | undefined) {
+  if (data && !(data as JobsListResponse & { _fetchedAt?: number })._fetchedAt) {
+    (data as JobsListResponse & { _fetchedAt?: number })._fetchedAt = Date.now()
+  }
+}
+
+/** Patch every cached /api/jobs list payload that contains the updated job. */
+export function patchJobsListCaches(updatedJob: { id: string } & Record<string, unknown>) {
+  const nuxtApp = useNuxtApp()
+  const stores = [nuxtApp.payload.data, nuxtApp.static.data]
+
+  for (const store of stores) {
+    for (const key of Object.keys(store)) {
+      if (!key.startsWith('jobs-')) continue
+
+      const entry = store[key] as JobsListResponse | undefined
+      if (!entry?.data) continue
+
+      store[key] = {
+        ...entry,
+        data: entry.data.map((item) => {
+          if (item.id !== updatedJob.id) return item
+          return {
+            ...item,
+            ...updatedJob,
+            pipeline: item.pipeline,
+          }
+        }),
+      }
+    }
+  }
+}
+
+/** Refresh every cached /api/jobs list payload. */
+export async function refreshJobsListCaches() {
+  const nuxtApp = useNuxtApp()
+  const keys = new Set<string>([
+    ...Object.keys(nuxtApp.payload.data),
+    ...Object.keys(nuxtApp.static.data),
+  ])
+
+  const refreshKeys = [...keys].filter(key => key.startsWith('jobs-'))
+  await Promise.all(refreshKeys.map(key => refreshNuxtData(key)))
+}
+
 /**
  * Composable for managing the jobs list with filtering, pagination, and mutations.
- * Wraps `useFetch('/api/jobs')` with a singleton key for shared state.
+ * Wraps `useFetch('/api/jobs')` with canonical cache keys shared across dashboard consumers.
  */
 export function useJobs(options?: {
+  page?: Ref<number | undefined> | number
+  limit?: Ref<number | undefined> | number
   status?: Ref<string | undefined> | string
+  immediate?: boolean
 }) {
   const { handlePreviewReadOnlyError } = usePreviewReadOnly()
 
-  const query = computed(() => ({
-    ...(toValue(options?.status) && { status: toValue(options?.status) }),
-  }))
+  const query = buildJobsListQuery(options)
 
   const { data, status: fetchStatus, error, refresh } = useFetch('/api/jobs', {
-    key: computed(() => `jobs-${JSON.stringify(query.value)}`), // stable per filter combination
+    key: computed(() => jobsListKey(query.value)),
     query,
+    ...(options?.immediate === undefined ? {} : { immediate: options.immediate }),
     headers: useRequestHeaders(['cookie']),
     // 45s SWR cache — jobs lists are frequently visited and change infrequently within an org
     getCachedData(key, nuxtApp) {
       const cached = nuxtApp.payload.data[key]
       if (!cached) return undefined
-      const fetchedAt = (cached as any)._fetchedAt || 0
+      const fetchedAt = (cached as { _fetchedAt?: number })._fetchedAt || 0
       if (Date.now() - fetchedAt < 45_000) return cached
       return cached
     },
@@ -29,7 +110,7 @@ export function useJobs(options?: {
 
   if (import.meta.client) {
     watch(data, (val) => {
-      if (val && !(val as any)._fetchedAt) (val as any)._fetchedAt = Date.now()
+      stampJobsListFetchedAt(val)
     }, { immediate: true })
   }
 
@@ -55,6 +136,7 @@ export function useJobs(options?: {
         body: payload,
       })
       await refresh()
+      await refreshJobsListCaches()
       return created
     } catch (error) {
       handlePreviewReadOnlyError(error)
@@ -71,6 +153,7 @@ export function useJobs(options?: {
       throw error
     }
     await refresh()
+    await refreshJobsListCaches()
   }
 
   return {
@@ -82,4 +165,9 @@ export function useJobs(options?: {
     createJob,
     deleteJob,
   }
+}
+
+/** Shared sidebar/topbar jobs list (limit 100, all statuses). */
+export function useSidebarJobs() {
+  return useJobs({ limit: 100 })
 }

--- a/app/pages/dashboard/chatbot/[[id]].vue
+++ b/app/pages/dashboard/chatbot/[[id]].vue
@@ -87,14 +87,11 @@ onMounted(async () => {
 })
 
 // ── Jobs for the scope picker ──
-const { data: jobsData } = await useFetch('/api/jobs', {
-  key: 'chatbot-jobs',
-  query: { limit: 100 },
-  headers: useRequestHeaders(['cookie']),
-})
-const jobs = computed(() => (jobsData.value?.data ?? []) as Array<{ id: string; title: string; status: string }>)
+const { jobs } = useJobs({ limit: 100 })
 const selectedJob = computed(() =>
-  scope.value.kind === 'job' ? jobs.value.find((j) => j.id === scope.value.jobId) ?? null : null,
+  scope.value.kind === 'job'
+    ? (jobs.value as Array<{ id: string; title: string; status: string }>).find(j => j.id === scope.value.jobId) ?? null
+    : null,
 )
 
 const showScopePicker = ref(false)

--- a/app/pages/dashboard/source-tracking/index.vue
+++ b/app/pages/dashboard/source-tracking/index.vue
@@ -76,13 +76,8 @@ const {
   refresh: refreshLinks,
 } = useTrackingLinks()
 
-// Fetch jobs for filter dropdown
-const { data: jobsData } = useFetch('/api/jobs', {
-  key: 'source-tracking-jobs',
-  headers: useRequestHeaders(['cookie']),
-  query: { limit: 100 },
-})
-const jobs = computed(() => (jobsData.value as any)?.data ?? [])
+// Fetch jobs for filter dropdown (shares cache with topbar via canonical jobsListKey)
+const { jobs } = useJobs({ limit: 100 })
 
 const { allowed: canManageLinks } = usePermission({ sourceTracking: ['create'] })
 

--- a/tests/unit/job-cache-refresh.test.ts
+++ b/tests/unit/job-cache-refresh.test.ts
@@ -1,19 +1,57 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import { jobsListKey } from '../../app/composables/useJobs'
 
 function readProjectFile(path: string) {
   return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
 }
 
+const LEGACY_JOBS_CACHE_KEYS = ['sidebar-jobs-list', 'application-link-job-list', 'source-tracking-jobs', 'chatbot-jobs']
+
 describe('job cache refresh', () => {
-  it('keeps the topbar job status cache responsive after job mutations', () => {
+  it('uses a canonical jobsListKey for equivalent queries', () => {
+    expect(jobsListKey({})).toBe('jobs-{}')
+    expect(jobsListKey({ limit: 100 })).toBe('jobs-{"limit":100}')
+    expect(jobsListKey({ status: 'open' })).toBe('jobs-{"status":"open"}')
+    expect(jobsListKey({ limit: 100, status: 'open' })).toBe('jobs-{"limit":100,"status":"open"}')
+    expect(jobsListKey({})).toBe(jobsListKey({}))
+    expect(jobsListKey({ limit: 100 })).toBe(jobsListKey({ limit: 100 }))
+  })
+
+  it('routes topbar jobs through useJobs with the canonical key helper', () => {
     const topbar = readProjectFile('app/components/AppTopBar.vue')
+    const useJobsSource = readProjectFile('app/composables/useJobs.ts')
+
+    expect(topbar).toContain('useSidebarJobs')
+    expect(topbar).not.toContain('sidebar-jobs-list')
+    expect(useJobsSource).toContain('export function jobsListKey')
+    expect(useJobsSource).toMatch(/key:\s*computed\(\(\)\s*=>\s*jobsListKey/)
+  })
+
+  it('patches canonical jobs list caches after job mutations', () => {
     const useJob = readProjectFile('app/composables/useJob.ts')
 
-    expect(topbar).toContain("key: 'sidebar-jobs-list'")
-    expect(useJob).toContain("useNuxtData<{ data: Array<Record<string, unknown>> }>('sidebar-jobs-list')")
-    expect(useJob).toContain('syncJobListCache(updated)')
-    expect(useJob).toMatch(/refreshNuxtData\('sidebar-jobs-list'\)/)
+    expect(useJob).toContain('patchJobsListCaches')
+    expect(useJob).toContain('syncJobListCache')
+    expect(useJob).toContain('refreshJobsListCaches')
+    expect(useJob).not.toContain('sidebar-jobs-list')
+  })
+
+  it('does not keep legacy ad-hoc /api/jobs cache keys in dashboard consumers', () => {
+    const consumers = [
+      'app/components/AppTopBar.vue',
+      'app/components/ApplicationLinkModal.vue',
+      'app/pages/dashboard/source-tracking/index.vue',
+      'app/pages/dashboard/chatbot/[[id]].vue',
+    ]
+
+    for (const file of consumers) {
+      const source = readProjectFile(file)
+      for (const legacyKey of LEGACY_JOBS_CACHE_KEYS) {
+        expect(source, file).not.toContain(legacyKey)
+      }
+      expect(source, file).toMatch(/useJobs|useSidebarJobs/)
+    }
   })
 })


### PR DESCRIPTION
## Summary
Unifies `/api/jobs` client caching under canonical `jobsListKey()` helpers so dashboard consumers with equivalent queries share one Nuxt payload entry.

## Changes
- Export `jobsListKey`, `patchJobsListCaches`, and `refreshJobsListCaches` from `useJobs`
- Add `useSidebarJobs()` for the topbar (`limit: 100`)
- Migrate `AppTopBar`, `ApplicationLinkModal`, source tracking, and chatbot to `useJobs` / `useSidebarJobs`
- Update `useJob` mutations to patch and refresh all `jobs-*` cache keys
- Expand `job-cache-refresh` unit tests for the canonical key contract

## Verification
- `npm run test:unit` (1020 passed)
- `npm run typecheck`

Closes #305