### PR TITLE
perf: extend client SWR to uncached dashboard fetches

### DIFF
--- a/app/components/CandidateDetailDrawer.vue
+++ b/app/components/CandidateDetailDrawer.vue
@@ -75,7 +75,7 @@ const { transitionToStatus } = useApplicationStatusActions({
   updateStatus: updateTransitionTargetStatus,
   afterTransition: async () => {
     await refresh()
-    await refreshNuxtData('applications')
+    await refreshApplicationsListCaches()
     toast.success('Application status updated')
   },
 })

--- a/app/components/JobSubNavActions.vue
+++ b/app/components/JobSubNavActions.vue
@@ -87,7 +87,7 @@ const showApplyModal = ref(false)
 
 function handleCandidateApplied() {
   showApplyModal.value = false
-  refreshNuxtData(`pipeline-apps-${props.jobId}`)
+  refreshApplicationsListCaches()
 }
 
 // ─── Bulk AI scoring ──────────────────────────────────────────────────────────
@@ -121,7 +121,7 @@ async function scoreAllCandidates() {
       }
       scoringProgress.value.done++
     }
-    await refreshNuxtData(`pipeline-apps-${props.jobId}`)
+    await refreshApplicationsListCaches()
     if (failed === 0) {
       toast.success('Scoring complete', `${applicationIds.length} candidate${applicationIds.length === 1 ? '' : 's'} scored successfully.`)
     } else {

--- a/app/composables/useApplication.ts
+++ b/app/composables/useApplication.ts
@@ -28,15 +28,18 @@ export function useApplication(id: MaybeRefOrGetter<string>) {
     {
       key: computed(() => `application-${applicationId.value}`),
       headers: useRequestHeaders(['cookie']),
+      getCachedData: getSwrCachedData,
     },
   )
+
+  watchFetchSwrStamp(application)
 
   /** Update application fields (status, notes, score) and refresh caches */
   async function updateApplication(payload: ApplicationUpdatePayload) {
     try {
       const updated = await patchApplication(applicationId.value, payload)
       await refresh()
-      await refreshNuxtData('applications')
+      await refreshApplicationsListCaches()
       return updated
     } catch (error) {
       handlePreviewReadOnlyError(error)

--- a/app/composables/useApplicationScoring.ts
+++ b/app/composables/useApplicationScoring.ts
@@ -27,10 +27,7 @@ export function useApplicationScoring() {
       if (options.refreshApplication !== false) {
         await options.refresh?.()
       }
-      await refreshNuxtData('applications')
-      if (options.jobId) {
-        await refreshNuxtData(`pipeline-apps-${options.jobId}`)
-      }
+      await refreshApplicationsListCaches()
 
       track('individual_scoring_completed', {
         application_id: applicationId,

--- a/app/composables/useApplications.ts
+++ b/app/composables/useApplications.ts
@@ -2,11 +2,46 @@ import type { Ref } from 'vue'
 import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
 import type { PropertyFilter } from '~~/shared/properties'
 
+export type ApplicationsListQuery = {
+  page?: number
+  limit?: number
+  jobId?: string
+  candidateId?: string
+  status?: string
+  propertyFilters?: string
+}
+
+/** Stable Nuxt payload key for a /api/applications query object. */
+export function applicationsListKey(query: ApplicationsListQuery): string {
+  const normalized: ApplicationsListQuery = {}
+  if (query.page && query.page !== 1) normalized.page = query.page
+  if (query.limit) normalized.limit = query.limit
+  if (query.jobId) normalized.jobId = query.jobId
+  if (query.candidateId) normalized.candidateId = query.candidateId
+  if (query.status) normalized.status = query.status
+  if (query.propertyFilters) normalized.propertyFilters = query.propertyFilters
+  return `applications-${JSON.stringify(normalized)}`
+}
+
+/** Refresh every cached /api/applications list payload. */
+export async function refreshApplicationsListCaches() {
+  const nuxtApp = useNuxtApp()
+  const keys = new Set<string>([
+    ...Object.keys(nuxtApp.payload.data),
+    ...Object.keys(nuxtApp.static.data),
+  ])
+
+  const refreshKeys = [...keys].filter(key => key.startsWith('applications-'))
+  await Promise.all(refreshKeys.map(key => refreshNuxtData(key)))
+}
+
 /**
  * Composable for managing the applications list with filtering, pagination, and mutations.
- * Wraps `useFetch('/api/applications')` with a singleton key for shared state.
+ * Wraps `useFetch('/api/applications')` with canonical cache keys and client SWR.
  */
 export function useApplications(options?: {
+  page?: Ref<number | undefined> | number
+  limit?: Ref<number | undefined> | number
   jobId?: Ref<string | undefined> | string
   candidateId?: Ref<string | undefined> | string
   status?: Ref<string | undefined> | string
@@ -17,6 +52,8 @@ export function useApplications(options?: {
   const query = computed(() => {
     const pf = toValue(options?.propertyFilters)
     return {
+      ...(toValue(options?.page) && { page: toValue(options?.page) }),
+      ...(toValue(options?.limit) && { limit: toValue(options?.limit) }),
       ...(toValue(options?.jobId) && { jobId: toValue(options?.jobId) }),
       ...(toValue(options?.candidateId) && { candidateId: toValue(options?.candidateId) }),
       ...(toValue(options?.status) && { status: toValue(options?.status) }),
@@ -25,10 +62,13 @@ export function useApplications(options?: {
   })
 
   const { data, status: fetchStatus, error, refresh } = useFetch('/api/applications', {
-    key: 'applications',
+    key: computed(() => applicationsListKey(query.value)),
     query,
     headers: useRequestHeaders(['cookie']),
+    getCachedData: getSwrCachedData,
   })
+
+  watchFetchSwrStamp(data)
 
   const applications = computed(() => data.value?.data ?? [])
   const total = computed(() => data.value?.total ?? 0)
@@ -45,6 +85,7 @@ export function useApplications(options?: {
         body: payload,
       })
       await refresh()
+      await refreshApplicationsListCaches()
       return created
     } catch (error) {
       handlePreviewReadOnlyError(error)

--- a/app/composables/useCandidate.ts
+++ b/app/composables/useCandidate.ts
@@ -19,8 +19,11 @@ export function useCandidate(id: MaybeRefOrGetter<string>) {
     {
       key: computed(() => `candidate-${candidateId.value}`),
       headers: useRequestHeaders(['cookie']),
+      getCachedData: getSwrCachedData,
     },
   )
+
+  watchFetchSwrStamp(candidate)
 
   /** Update candidate fields (partial) and refresh both detail and list caches */
   async function updateCandidate(payload: Partial<{
@@ -56,7 +59,7 @@ export function useCandidate(id: MaybeRefOrGetter<string>) {
     }
     await invalidateCandidatesListCache()
     clearNuxtData(`candidate-${candidateId.value}`)
-    clearNuxtData('applications')
+    clearNuxtData(key => key.startsWith('applications-'))
     await navigateTo(localePath('/dashboard/candidates'))
   }
 

--- a/app/composables/useCandidates.ts
+++ b/app/composables/useCandidates.ts
@@ -30,21 +30,10 @@ export function useCandidates(options?: {
     key: computed(() => `candidates-${JSON.stringify(query.value)}`),
     query,
     headers: useRequestHeaders(['cookie']),
-    // 45s SWR cache for candidate lists (very frequently accessed in dashboard)
-    getCachedData(key, nuxtApp) {
-      const cached = nuxtApp.payload.data[key]
-      if (!cached) return undefined
-      const fetchedAt = (cached as any)._fetchedAt || 0
-      if (Date.now() - fetchedAt < 45_000) return cached
-      return cached
-    },
+    getCachedData: getSwrCachedData,
   })
 
-  if (import.meta.client) {
-    watch(data, (val) => {
-      if (val && !(val as any)._fetchedAt) (val as any)._fetchedAt = Date.now()
-    }, { immediate: true })
-  }
+  watchFetchSwrStamp(data)
 
   const candidates = computed(() => data.value?.data ?? [])
   const total = computed(() => data.value?.total ?? 0)

--- a/app/composables/useDashboard.ts
+++ b/app/composables/useDashboard.ts
@@ -7,31 +7,10 @@ export function useDashboard() {
   const { data, status: fetchStatus, error, refresh } = useFetch('/api/dashboard/stats', {
     key: 'dashboard-stats',
     headers: useRequestHeaders(['cookie']),
-    // SWR-style client caching (45s stale-while-revalidate).
-    // Serves cached data instantly on navigation/refresh within the TTL, then refreshes in background.
-    // Key is stable per-org thanks to the dashboard stats endpoint being org-scoped.
-    getCachedData(key, nuxtApp) {
-      const cached = nuxtApp.payload.data[key]
-      if (!cached) return undefined
-
-      // Use a non-enumerable property we attach on first successful fetch (see below)
-      const fetchedAt = (cached as any)._fetchedAt || 0
-      if (Date.now() - fetchedAt < 45_000) {
-        return cached
-      }
-      // Return stale data so UI is instant; the useFetch will still run and update the payload
-      return cached
-    },
+    getCachedData: getSwrCachedData,
   })
 
-  // On successful client fetch, stamp the payload for the cache helper (runs once per key lifetime)
-  if (import.meta.client) {
-    watch(data, (val) => {
-      if (val && !(val as any)._fetchedAt) {
-        ;(val as any)._fetchedAt = Date.now()
-      }
-    }, { immediate: true })
-  }
+  watchFetchSwrStamp(data)
 
   /** Summary counts (open jobs, candidates, applications, unreviewed) */
   const counts = computed(() => data.value?.counts ?? {

--- a/app/composables/useFetchSwr.ts
+++ b/app/composables/useFetchSwr.ts
@@ -39,7 +39,7 @@ export function getSwrCachedData<T>(
     return cached
   }
 
-  return cached
+  return undefined
 }
 
 /** Watch a useFetch data ref and stamp successful payloads on the client. */

--- a/app/composables/useFetchSwr.ts
+++ b/app/composables/useFetchSwr.ts
@@ -1,0 +1,47 @@
+import type { Ref } from 'vue'
+
+export const DEFAULT_FETCH_SWR_TTL_MS = 45_000
+
+export type SwrStamped = {
+  _fetchedAt?: number
+}
+
+/** Stamp the first successful fetch time on a useFetch payload entry. */
+export function attachFetchSwrStamp<T>(data: T | null | undefined) {
+  if (!data) return
+  const stamped = data as T & SwrStamped
+  if (!stamped._fetchedAt) {
+    stamped._fetchedAt = Date.now()
+  }
+}
+
+type SwrCacheContext = {
+  cause?: unknown
+}
+
+/** Serve cached useFetch payload instantly within TTL, then allow background refresh. */
+export function getSwrCachedData<T>(
+  key: string,
+  nuxtApp: ReturnType<typeof useNuxtApp>,
+  _context?: SwrCacheContext,
+  ttlMs = DEFAULT_FETCH_SWR_TTL_MS,
+): T | undefined {
+  const cached = nuxtApp.payload.data[key] as (T & SwrStamped) | undefined
+  if (!cached) return undefined
+
+  const fetchedAt = cached._fetchedAt || 0
+  if (Date.now() - fetchedAt < ttlMs) {
+    return cached
+  }
+
+  return cached
+}
+
+/** Watch a useFetch data ref and stamp successful payloads on the client. */
+export function watchFetchSwrStamp<T>(data: Ref<T | null | undefined>) {
+  if (import.meta.client) {
+    watch(data, (val) => {
+      attachFetchSwrStamp(val)
+    }, { immediate: true })
+  }
+}

--- a/app/composables/useFetchSwr.ts
+++ b/app/composables/useFetchSwr.ts
@@ -16,16 +16,21 @@ export function attachFetchSwrStamp<T>(data: T | null | undefined) {
 }
 
 type SwrCacheContext = {
-  cause?: unknown
+  cause?: 'initial' | 'refresh:hook' | 'refresh:manual' | 'watch'
 }
 
 /** Serve cached useFetch payload instantly within TTL, then allow background refresh. */
 export function getSwrCachedData<T>(
   key: string,
   nuxtApp: ReturnType<typeof useNuxtApp>,
-  _context?: SwrCacheContext,
+  context?: SwrCacheContext,
   ttlMs = DEFAULT_FETCH_SWR_TTL_MS,
 ): T | undefined {
+  // Explicit refreshes must hit the network — returning cache here would noop refresh().
+  if (context?.cause === 'refresh:manual' || context?.cause === 'refresh:hook') {
+    return undefined
+  }
+
   const cached = nuxtApp.payload.data[key] as (T & SwrStamped) | undefined
   if (!cached) return undefined
 

--- a/app/composables/useInterviews.ts
+++ b/app/composables/useInterviews.ts
@@ -102,21 +102,10 @@ export function useInterviews(options?: {
     key: fetchKey,
     query,
     headers: useRequestHeaders(['cookie']),
-    // 45s SWR for interview lists (used on dashboard home + dedicated pages)
-    getCachedData(key, nuxtApp) {
-      const cached = nuxtApp.payload.data[key]
-      if (!cached) return undefined
-      const fetchedAt = (cached as any)._fetchedAt || 0
-      if (Date.now() - fetchedAt < 45_000) return cached
-      return cached
-    },
+    getCachedData: getSwrCachedData,
   })
 
-  if (import.meta.client) {
-    watch(data, (val) => {
-      if (val && !(val as any)._fetchedAt) (val as any)._fetchedAt = Date.now()
-    }, { immediate: true })
-  }
+  watchFetchSwrStamp(data)
 
   const interviews = computed(() => data.value?.data ?? [])
   const total = computed(() => data.value?.total ?? 0)

--- a/app/composables/useJob.ts
+++ b/app/composables/useJob.ts
@@ -14,8 +14,11 @@ export function useJob(id: MaybeRefOrGetter<string>) {
     {
       key: computed(() => `job-${jobId.value}`),
       headers: useRequestHeaders(['cookie']),
+      getCachedData: getSwrCachedData,
     },
   )
+
+  watchFetchSwrStamp(job)
 
   function syncJobListCache(updatedJob: { id: string } & Record<string, unknown>) {
     patchJobsListCaches(updatedJob)

--- a/app/composables/useJobs.ts
+++ b/app/composables/useJobs.ts
@@ -34,12 +34,6 @@ function buildJobsListQuery(options?: {
   }))
 }
 
-function stampJobsListFetchedAt(data: JobsListResponse | null | undefined) {
-  if (data && !(data as JobsListResponse & { _fetchedAt?: number })._fetchedAt) {
-    (data as JobsListResponse & { _fetchedAt?: number })._fetchedAt = Date.now()
-  }
-}
-
 /** Patch every cached /api/jobs list payload that contains the updated job. */
 export function patchJobsListCaches(updatedJob: { id: string } & Record<string, unknown>) {
   const nuxtApp = useNuxtApp()
@@ -98,21 +92,10 @@ export function useJobs(options?: {
     query,
     ...(options?.immediate === undefined ? {} : { immediate: options.immediate }),
     headers: useRequestHeaders(['cookie']),
-    // 45s SWR cache — jobs lists are frequently visited and change infrequently within an org
-    getCachedData(key, nuxtApp) {
-      const cached = nuxtApp.payload.data[key]
-      if (!cached) return undefined
-      const fetchedAt = (cached as { _fetchedAt?: number })._fetchedAt || 0
-      if (Date.now() - fetchedAt < 45_000) return cached
-      return cached
-    },
+    getCachedData: getSwrCachedData,
   })
 
-  if (import.meta.client) {
-    watch(data, (val) => {
-      stampJobsListFetchedAt(val)
-    }, { immediate: true })
-  }
+  watchFetchSwrStamp(data)
 
   const jobs = computed(() => data.value?.data ?? [])
   const total = computed(() => data.value?.total ?? 0)

--- a/app/composables/useOrgSettings.ts
+++ b/app/composables/useOrgSettings.ts
@@ -8,7 +8,10 @@ export function useOrgSettings() {
   const { data, status, refresh } = useFetch('/api/org-settings', {
     key: 'org-settings',
     headers: useRequestHeaders(['cookie']),
+    getCachedData: getSwrCachedData,
   })
+
+  watchFetchSwrStamp(data)
 
   const nameDisplayFormat = computed(() => data.value?.nameDisplayFormat ?? 'first_last')
   const dateFormat = computed(() => data.value?.dateFormat ?? 'mdy')

--- a/app/composables/useSourceTracking.ts
+++ b/app/composables/useSourceTracking.ts
@@ -152,21 +152,10 @@ export function useTrackingLinks(options?: {
     key: fetchKey,
     headers: useRequestHeaders(['cookie']),
     query: linksQuery,
-    // 45s SWR for source-tracking links (heavy dashboard page)
-    getCachedData(key, nuxtApp) {
-      const cached = nuxtApp.payload.data[key]
-      if (!cached) return undefined
-      const fetchedAt = (cached as any)._fetchedAt || 0
-      if (Date.now() - fetchedAt < 45_000) return cached
-      return cached
-    },
+    getCachedData: getSwrCachedData,
   })
 
-  if (import.meta.client) {
-    watch(data, (val) => {
-      if (val && !(val as any)._fetchedAt) (val as any)._fetchedAt = Date.now()
-    }, { immediate: true })
-  }
+  watchFetchSwrStamp(data)
 
   const links = computed<TrackingLink[]>(() => data.value?.data ?? [])
   const total = computed(() => data.value?.total ?? 0)

--- a/app/pages/dashboard/candidates/[id].vue
+++ b/app/pages/dashboard/candidates/[id].vue
@@ -187,7 +187,7 @@ const { transitionToStatus } = useApplicationStatusActions({
   updateStatus: updateTransitionTargetStatus,
   afterTransition: async () => {
     await refresh()
-    await refreshNuxtData('applications')
+    await refreshApplicationsListCaches()
     toast.success('Application status updated')
   },
 })

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -44,20 +44,14 @@ const { job: jobData, status: jobFetchStatus, error: jobError } = useJob(jobId)
 // ─────────────────────────────────────────────
 
 const {
-  data: appData,
-  status: appFetchStatus,
+  applications,
+  fetchStatus: appFetchStatus,
   error: appError,
   refresh: refreshApps,
-} = useFetch('/api/applications', {
-  key: `pipeline-apps-${jobId}`,
-  query: { jobId, limit: 100 },
-  headers: useRequestHeaders(['cookie']),
-})
+} = useApplications({ jobId, limit: 100 })
 
 const PIPELINE_STATUSES = ['new', 'screening', 'interview', 'offer', 'hired', 'rejected'] as const
 type PipelineStatus = typeof PIPELINE_STATUSES[number]
-
-const applications = computed(() => appData.value?.data ?? [])
 
 // Read initial pipeline stage from URL query param (?stage=screening)
 const initialStage = PIPELINE_STATUSES.includes(route.query.stage as any)

--- a/tests/unit/candidate-cache-refresh.test.ts
+++ b/tests/unit/candidate-cache-refresh.test.ts
@@ -11,7 +11,9 @@ describe('candidate cache refresh', () => {
     const useCandidates = readProjectFile('app/composables/useCandidates.ts')
 
     expect(useCandidates).toContain('`candidates-${JSON.stringify(query.value)}`')
+    expect(useCandidates).toContain('getSwrCachedData')
     expect(useCandidate).toContain("key.startsWith('candidates-')")
+    expect(useCandidate).toContain('getSwrCachedData')
     expect(useCandidate).not.toContain("refreshNuxtData('candidates')")
   })
 })

--- a/tests/unit/fetch-swr.test.ts
+++ b/tests/unit/fetch-swr.test.ts
@@ -26,6 +26,14 @@ describe('useFetchSwr', () => {
     expect(getSwrCachedData('applications-{}', nuxtApp)).toBe(cached)
     expect(getSwrCachedData('missing', nuxtApp)).toBeUndefined()
   })
+
+  it('skips cache on explicit refresh causes so mutations refetch fresh data', () => {
+    const cached = { data: [{ id: '1' }], _fetchedAt: Date.now() }
+    const nuxtApp = { payload: { data: { 'candidate-1': cached } } } as any
+
+    expect(getSwrCachedData('candidate-1', nuxtApp, { cause: 'refresh:manual' })).toBeUndefined()
+    expect(getSwrCachedData('candidate-1', nuxtApp, { cause: 'refresh:hook' })).toBeUndefined()
+  })
 })
 
 describe('applications cache contract', () => {

--- a/tests/unit/fetch-swr.test.ts
+++ b/tests/unit/fetch-swr.test.ts
@@ -25,6 +25,10 @@ describe('useFetchSwr', () => {
 
     expect(getSwrCachedData('applications-{}', nuxtApp)).toBe(cached)
     expect(getSwrCachedData('missing', nuxtApp)).toBeUndefined()
+
+    const stale = { data: [{ id: '1' }], _fetchedAt: Date.now() - DEFAULT_FETCH_SWR_TTL_MS - 1 }
+    nuxtApp.payload.data['applications-stale'] = stale
+    expect(getSwrCachedData('applications-stale', nuxtApp)).toBeUndefined()
   })
 
   it('skips cache on explicit refresh causes so mutations refetch fresh data', () => {

--- a/tests/unit/fetch-swr.test.ts
+++ b/tests/unit/fetch-swr.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { attachFetchSwrStamp, getSwrCachedData, DEFAULT_FETCH_SWR_TTL_MS } from '../../app/composables/useFetchSwr'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('useFetchSwr', () => {
+  it('exports shared SWR helpers with a 45s default TTL', () => {
+    expect(DEFAULT_FETCH_SWR_TTL_MS).toBe(45_000)
+    expect(typeof attachFetchSwrStamp).toBe('function')
+    expect(typeof getSwrCachedData).toBe('function')
+  })
+
+  it('stamps fetchedAt on first attach', () => {
+    const payload = { data: [] }
+    attachFetchSwrStamp(payload)
+    expect((payload as { _fetchedAt?: number })._fetchedAt).toBeTypeOf('number')
+  })
+
+  it('returns cached payload entries through getSwrCachedData', () => {
+    const cached = { data: [{ id: '1' }], _fetchedAt: Date.now() }
+    const nuxtApp = { payload: { data: { 'applications-{}': cached } } } as any
+
+    expect(getSwrCachedData('applications-{}', nuxtApp)).toBe(cached)
+    expect(getSwrCachedData('missing', nuxtApp)).toBeUndefined()
+  })
+})
+
+describe('applications cache contract', () => {
+  it('uses computed applications list keys instead of a static applications key', () => {
+    const useApplications = readProjectFile('app/composables/useApplications.ts')
+
+    expect(useApplications).toContain('applicationsListKey')
+    expect(useApplications).toContain('getSwrCachedData')
+    expect(useApplications).toContain('watchFetchSwrStamp')
+    expect(useApplications).not.toContain("key: 'applications'")
+    expect(useApplications).toMatch(/key:\s*computed\(\(\)\s*=>\s*applicationsListKey/)
+  })
+
+  it('routes application cache refreshes through the applications list helper', () => {
+    const useApplication = readProjectFile('app/composables/useApplication.ts')
+    const useApplicationScoring = readProjectFile('app/composables/useApplicationScoring.ts')
+
+    expect(useApplication).toContain('refreshApplicationsListCaches')
+    expect(useApplicationScoring).toContain('refreshApplicationsListCaches')
+    expect(useApplication).not.toContain("refreshNuxtData('applications')")
+  })
+})
+
+describe('org settings SWR', () => {
+  it('uses shared SWR helpers for org-settings fetch', () => {
+    const useOrgSettings = readProjectFile('app/composables/useOrgSettings.ts')
+
+    expect(useOrgSettings).toContain('getSwrCachedData')
+    expect(useOrgSettings).toContain('watchFetchSwrStamp')
+  })
+})
+
+describe('job pipeline applications fetch', () => {
+  it('routes pipeline applications through useApplications instead of pipeline-apps keys', () => {
+    const pipelinePage = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+
+    expect(pipelinePage).toContain('useApplications')
+    expect(pipelinePage).not.toContain('pipeline-apps-')
+  })
+})
+
+describe('detail composable SWR', () => {
+  const detailComposables = [
+    'app/composables/useJob.ts',
+    'app/composables/useApplication.ts',
+    'app/composables/useCandidate.ts',
+  ]
+
+  it.each(detailComposables)('%s wires shared SWR helpers', (file) => {
+    const source = readProjectFile(file)
+    expect(source).toContain('getSwrCachedData')
+    expect(source).toContain('watchFetchSwrStamp')
+  })
+})


### PR DESCRIPTION
## Summary
Extracts shared `useFetchSwr` helpers and applies the existing 45s stale-while-revalidate pattern to high-frequency dashboard fetches that were still cold on revisit.

## Changes
- Add `useFetchSwr.ts` with `getSwrCachedData`, `attachFetchSwrStamp`, and `watchFetchSwrStamp`
- Fix `useApplications` to use computed `applicationsListKey` + SWR; add `refreshApplicationsListCaches`
- Add SWR to `useJob`, `useApplication`, `useCandidate`, and `useOrgSettings`
- Migrate job pipeline page to `useApplications({ jobId, limit: 100 })` (drops `pipeline-apps-*` keys)
- DRY existing SWR blocks in `useDashboard`, `useJobs`, `useCandidates`, `useInterviews`, and `useSourceTracking`
- Add `tests/unit/fetch-swr.test.ts` and extend cache contract tests

## Verification
- `npm run test:unit` (1030 passed)
- `npm run typecheck`

Closes #304