### PR TITLE
feat: add Nitro SWR cache to dashboard list APIs (#307)

### DIFF
--- a/server/api/applications/[id].patch.ts
+++ b/server/api/applications/[id].patch.ts
@@ -92,6 +92,8 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  await invalidateOrgScopedDashboardCache(event)
+
   return updated
 })
 

--- a/server/api/applications/[id]/properties/[propId].put.ts
+++ b/server/api/applications/[id]/properties/[propId].put.ts
@@ -14,11 +14,15 @@ export default defineEventHandler(async (event) => {
   const { id, propId } = await getValidatedRouterParams(event, entityPropertyParamsSchema.parse)
   const { value } = await readValidatedBody(event, setPropertyValueSchema.parse)
 
-  return setEntityPropertyValue({
+  const result = await setEntityPropertyValue({
     organizationId: orgId,
     entityType: 'application',
     entityId: id,
     propId,
     value,
   })
+
+  await invalidateOrgScopedDashboardCache(event)
+
+  return result
 })

--- a/server/api/applications/index.get.ts
+++ b/server/api/applications/index.get.ts
@@ -12,7 +12,7 @@ import { matchingEntityIdsForPropertyFilters, parsePropertyFiltersParam } from '
  * List applications for the current organization.
  * Filterable by jobId, candidateId, status, and custom property filters. Paginated.
  */
-export default defineEventHandler(async (event) => {
+export default defineCachedEventHandler(async (event) => {
   const session = await requirePermission(event, { application: ['read'] })
   const orgId = session.session.activeOrganizationId
 
@@ -90,4 +90,4 @@ export default defineEventHandler(async (event) => {
   }))
 
   return paginatedListResponse(enriched, total, query.page, query.limit)
-})
+}, orgScopedCacheOptions)

--- a/server/api/applications/index.post.ts
+++ b/server/api/applications/index.post.ts
@@ -80,6 +80,8 @@ export default defineEventHandler(async (event) => {
     metadata: { candidateId: body.candidateId, jobId: body.jobId },
   })
 
+  await invalidateOrgScopedDashboardCache(event)
+
   setResponseStatus(event, 201)
   return created
 })

--- a/server/api/candidates/[id].delete.ts
+++ b/server/api/candidates/[id].delete.ts
@@ -49,6 +49,8 @@ export default defineEventHandler(async (event) => {
     metadata: { deletedDocumentCount: documentsToDelete.length },
   })
 
+  await invalidateOrgScopedDashboardCache(event)
+
   setResponseStatus(event, 204)
   return null
 })

--- a/server/api/candidates/[id].patch.ts
+++ b/server/api/candidates/[id].patch.ts
@@ -57,5 +57,7 @@ export default defineEventHandler(async (event) => {
     metadata: { name: `${updated.firstName} ${updated.lastName}` },
   })
 
+  await invalidateOrgScopedDashboardCache(event)
+
   return updated
 })

--- a/server/api/candidates/[id]/properties/[propId].put.ts
+++ b/server/api/candidates/[id]/properties/[propId].put.ts
@@ -13,11 +13,15 @@ export default defineEventHandler(async (event) => {
   const { id, propId } = await getValidatedRouterParams(event, entityPropertyParamsSchema.parse)
   const { value } = await readValidatedBody(event, setPropertyValueSchema.parse)
 
-  return setEntityPropertyValue({
+  const result = await setEntityPropertyValue({
     organizationId: orgId,
     entityType: 'candidate',
     entityId: id,
     propId,
     value,
   })
+
+  await invalidateOrgScopedDashboardCache(event)
+
+  return result
 })

--- a/server/api/candidates/index.get.ts
+++ b/server/api/candidates/index.get.ts
@@ -7,7 +7,7 @@ import {
 } from '../../utils/properties'
 import { matchingEntityIdsForPropertyFilters, parsePropertyFiltersParam } from '../../utils/propertyFilters'
 
-export default defineEventHandler(async (event) => {
+export default defineCachedEventHandler(async (event) => {
   const session = await requirePermission(event, { candidate: ['read'] })
   const orgId = session.session.activeOrganizationId
 
@@ -92,4 +92,4 @@ export default defineEventHandler(async (event) => {
   const enriched = data.map((c) => ({ ...c, properties: propertyMap.get(c.id) ?? [] }))
 
   return paginatedListResponse(enriched, total, query.page, query.limit)
-})
+}, orgScopedCacheOptions)

--- a/server/api/candidates/index.post.ts
+++ b/server/api/candidates/index.post.ts
@@ -68,6 +68,8 @@ export default defineEventHandler(async (event) => {
     candidate_id: created.id,
   })
 
+  await invalidateOrgScopedDashboardCache(event)
+
   setResponseStatus(event, 201)
   return created
 })

--- a/server/api/dashboard/stats.get.ts
+++ b/server/api/dashboard/stats.get.ts
@@ -137,11 +137,4 @@ export default defineCachedEventHandler(async (event) => {
     recentApplications,
     topJobs,
   }
-}, {
-  maxAge: 30,
-  swr: true,
-  // Nitro cached handlers strip request headers unless they are listed here.
-  // The auth/permission check needs cookie and bearer sessions, and the cached
-  // response must stay scoped to the caller's session.
-  varies: ['cookie', 'authorization'],
-})
+}, orgScopedCacheOptions)

--- a/server/api/interviews/[id]/index.delete.ts
+++ b/server/api/interviews/[id]/index.delete.ts
@@ -71,6 +71,8 @@ export default defineEventHandler(async (event) => {
     resourceId: id,
   })
 
+  await invalidateOrgScopedDashboardCache(event)
+
   setResponseStatus(event, 204)
   return null
 })

--- a/server/api/interviews/[id]/index.patch.ts
+++ b/server/api/interviews/[id]/index.patch.ts
@@ -184,5 +184,7 @@ export default defineEventHandler(async (event) => {
     },
   })
 
+  await invalidateOrgScopedDashboardCache(event)
+
   return updated
 })

--- a/server/api/interviews/index.get.ts
+++ b/server/api/interviews/index.get.ts
@@ -2,7 +2,7 @@ import { and, count, desc, eq, gte, lte } from 'drizzle-orm'
 import { interview, application, candidate, job } from '../../database/schema'
 import { interviewQuerySchema } from '../../utils/schemas/interview'
 
-export default defineEventHandler(async (event) => {
+export default defineCachedEventHandler(async (event) => {
   const session = await requirePermission(event, { interview: ['read'] })
   const orgId = session.session.activeOrganizationId
 
@@ -74,4 +74,4 @@ export default defineEventHandler(async (event) => {
   ])
 
   return { data, total, page: query.page, limit: query.limit }
-})
+}, orgScopedCacheOptions)

--- a/server/api/interviews/index.post.ts
+++ b/server/api/interviews/index.post.ts
@@ -161,6 +161,8 @@ export default defineEventHandler(async (event) => {
     has_calendar_sync: !!calendarEventId,
   })
 
+  await invalidateOrgScopedDashboardCache(event)
+
   setResponseStatus(event, 201)
   return {
     ...created,

--- a/server/api/jobs/[id].delete.ts
+++ b/server/api/jobs/[id].delete.ts
@@ -24,6 +24,8 @@ export default defineEventHandler(async (event) => {
     resourceId: id,
   })
 
+  await invalidateOrgScopedDashboardCache(event)
+
   setResponseStatus(event, 204)
   return null
 })

--- a/server/api/jobs/[id].patch.ts
+++ b/server/api/jobs/[id].patch.ts
@@ -98,5 +98,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  await invalidateOrgScopedDashboardCache(event)
+
   return updated
 })

--- a/server/api/jobs/index.get.ts
+++ b/server/api/jobs/index.get.ts
@@ -4,7 +4,7 @@ import { emptyPipelineCounts, type PipelineCounts } from '~~/shared/application-
 import { paginatedListResponse, paginationOffset } from '../../utils/schemas/common'
 import { jobQuerySchema } from '../../utils/schemas/job'
 
-export default defineEventHandler(async (event) => {
+export default defineCachedEventHandler(async (event) => {
   const session = await requirePermission(event, { job: ['read'] })
   const orgId = session.session.activeOrganizationId
 
@@ -68,4 +68,4 @@ export default defineEventHandler(async (event) => {
   }))
 
   return paginatedListResponse(enrichedData, total, query.page, query.limit)
-})
+}, orgScopedCacheOptions)

--- a/server/api/jobs/index.post.ts
+++ b/server/api/jobs/index.post.ts
@@ -94,6 +94,8 @@ export default defineEventHandler(async (event) => {
     auto_score: created.autoScoreOnApply,
   })
 
+  await invalidateOrgScopedDashboardCache(event)
+
   setResponseStatus(event, 201)
   return created
 })

--- a/server/api/public/jobs/[slug]/apply.post.ts
+++ b/server/api/public/jobs/[slug]/apply.post.ts
@@ -783,6 +783,8 @@ export default defineEventHandler(async (event) => {
     is_returning_candidate: !!existingCandidate,
   })
 
+  await invalidateOrgScopedDashboardCacheForOrg(orgId)
+
   setResponseStatus(event, 201)
   return { success: true }
 })

--- a/server/utils/httpCache.ts
+++ b/server/utils/httpCache.ts
@@ -1,0 +1,12 @@
+/** Default TTL (seconds) for org-scoped dashboard list/stats Nitro SWR caches. */
+export const ORG_SCOPED_CACHE_MAX_AGE_SECONDS = 30
+
+/**
+ * Nitro `defineCachedEventHandler` defaults for authenticated, org-scoped read APIs.
+ * `varies` preserves cookie/bearer sessions so cache entries never cross tenants.
+ */
+export const orgScopedCacheOptions = {
+  maxAge: ORG_SCOPED_CACHE_MAX_AGE_SECONDS,
+  swr: true,
+  varies: ['cookie', 'authorization'] as const,
+}

--- a/server/utils/httpCache.ts
+++ b/server/utils/httpCache.ts
@@ -1,12 +1,61 @@
+import type { H3Event } from 'h3'
+import { hash } from 'ohash'
+import { resolveActiveOrganizationId } from './activeOrganization'
+
 /** Default TTL (seconds) for org-scoped dashboard list/stats Nitro SWR caches. */
 export const ORG_SCOPED_CACHE_MAX_AGE_SECONDS = 30
 
+export const ORG_SCOPED_DASHBOARD_CACHE_NAME = 'org-dashboard'
+
+const ORG_DASHBOARD_CACHE_VERSION_PREFIX = 'org-dashboard-cache-version:'
+
+function escapeCacheKeyPart(value: string): string {
+  return String(value).replace(/\W/g, '')
+}
+
+async function getOrgDashboardCacheVersion(orgId: string): Promise<number> {
+  const stored = await useStorage().getItem<number>(`${ORG_DASHBOARD_CACHE_VERSION_PREFIX}${orgId}`)
+  return typeof stored === 'number' && Number.isFinite(stored) ? stored : 0
+}
+
+/** Bump the org cache generation so new list/stats reads miss prior Nitro entries. */
+export async function bumpOrgDashboardCacheVersion(orgId: string): Promise<void> {
+  const current = await getOrgDashboardCacheVersion(orgId)
+  await useStorage().setItem(`${ORG_DASHBOARD_CACHE_VERSION_PREFIX}${orgId}`, current + 1)
+}
+
+/** Invalidate org-scoped dashboard list/stats caches for the active session org. */
+export async function invalidateOrgScopedDashboardCache(event: H3Event): Promise<void> {
+  const session = await auth.api.getSession({ headers: event.headers })
+  if (!session) return
+
+  const orgId = await resolveActiveOrganizationId(session)
+  if (!orgId) return
+
+  await bumpOrgDashboardCacheVersion(orgId)
+}
+
+/** Invalidate org-scoped dashboard caches when only the organization id is known (e.g. public apply). */
+export async function invalidateOrgScopedDashboardCacheForOrg(orgId: string): Promise<void> {
+  if (!orgId) return
+  await bumpOrgDashboardCacheVersion(orgId)
+}
+
 /**
  * Nitro `defineCachedEventHandler` defaults for authenticated, org-scoped read APIs.
- * `varies` preserves cookie/bearer sessions so cache entries never cross tenants.
+ * Cache keys include the active organization and a generation counter bumped on writes.
  */
 export const orgScopedCacheOptions = {
   maxAge: ORG_SCOPED_CACHE_MAX_AGE_SECONDS,
   swr: true,
   varies: ['cookie', 'authorization'] as const,
+  name: ORG_SCOPED_DASHBOARD_CACHE_NAME,
+  async getKey(event: H3Event) {
+    const session = await auth.api.getSession({ headers: event.headers })
+    const orgId = session ? await resolveActiveOrganizationId(session) : null
+    const orgPart = escapeCacheKeyPart(orgId ?? 'none')
+    const version = orgId ? await getOrgDashboardCacheVersion(orgId) : 0
+    const path = event.node.req.originalUrl || event.node.req.url || event.path
+    return `${orgPart}:v${version}:${hash(path)}`
+  },
 }

--- a/tests/unit/cli-parity-changed-files.test.ts
+++ b/tests/unit/cli-parity-changed-files.test.ts
@@ -38,6 +38,22 @@ describe('CLI parity changed-file guard', () => {
     })
   })
 
+  it('accepts CLI parity evidence for Epic 2 list API Nitro cache without contract changes', () => {
+    expect(evaluateCliParityEvidence([
+      'server/api/jobs/index.get.ts',
+      'server/api/candidates/index.get.ts',
+      'server/api/applications/index.get.ts',
+      'server/api/interviews/index.get.ts',
+      'server/api/dashboard/stats.get.ts',
+      'server/utils/httpCache.ts',
+      'tests/unit/list-api-cache.test.ts',
+      'tests/unit/cli-parity-changed-files.test.ts',
+    ])).toMatchObject({
+      ok: true,
+      message: 'CLI parity evidence found.',
+    })
+  })
+
   it('accepts CLI parity evidence for Epic 7 pagination and pipeline helpers without contract changes', () => {
     expect(evaluateCliParityEvidence([
       'server/api/candidates/index.get.ts',

--- a/tests/unit/dashboard-stats-cache.test.ts
+++ b/tests/unit/dashboard-stats-cache.test.ts
@@ -3,9 +3,15 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 describe('dashboard stats cache', () => {
-  const source = readFileSync(join(process.cwd(), 'server/api/dashboard/stats.get.ts'), 'utf8')
+  const stats = readFileSync(join(process.cwd(), 'server/api/dashboard/stats.get.ts'), 'utf8')
+  const httpCache = readFileSync(join(process.cwd(), 'server/utils/httpCache.ts'), 'utf8')
+
+  it('routes dashboard stats through the shared org-scoped cache helper', () => {
+    expect(stats).toContain('defineCachedEventHandler')
+    expect(stats).toContain('orgScopedCacheOptions')
+  })
 
   it('varies by cookie and bearer tokens so the cached handler preserves auth headers', () => {
-    expect(source).toContain("varies: ['cookie', 'authorization']")
+    expect(httpCache).toContain("varies: ['cookie', 'authorization']")
   })
 })

--- a/tests/unit/http-cache-invalidation.test.ts
+++ b/tests/unit/http-cache-invalidation.test.ts
@@ -18,6 +18,8 @@ const MUTATION_HANDLERS_WITH_INVALIDATION = [
   'server/api/interviews/[id]/index.patch.ts',
   'server/api/interviews/[id]/index.delete.ts',
   'server/api/public/jobs/[slug]/apply.post.ts',
+  'server/api/candidates/[id]/properties/[propId].put.ts',
+  'server/api/applications/[id]/properties/[propId].put.ts',
 ]
 
 describe('org-scoped dashboard cache invalidation on writes', () => {

--- a/tests/unit/http-cache-invalidation.test.ts
+++ b/tests/unit/http-cache-invalidation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+const MUTATION_HANDLERS_WITH_INVALIDATION = [
+  'server/api/jobs/index.post.ts',
+  'server/api/jobs/[id].patch.ts',
+  'server/api/jobs/[id].delete.ts',
+  'server/api/candidates/index.post.ts',
+  'server/api/candidates/[id].patch.ts',
+  'server/api/candidates/[id].delete.ts',
+  'server/api/applications/index.post.ts',
+  'server/api/applications/[id].patch.ts',
+  'server/api/interviews/index.post.ts',
+  'server/api/interviews/[id]/index.patch.ts',
+  'server/api/interviews/[id]/index.delete.ts',
+  'server/api/public/jobs/[slug]/apply.post.ts',
+]
+
+describe('org-scoped dashboard cache invalidation on writes', () => {
+  it.each(MUTATION_HANDLERS_WITH_INVALIDATION)('%s invalidates dashboard list caches', (file) => {
+    const source = readProjectFile(file)
+    const expectsEventInvalidation = !file.includes('public/jobs')
+    if (expectsEventInvalidation) {
+      expect(source, file).toContain('invalidateOrgScopedDashboardCache(event)')
+    } else {
+      expect(source, file).toContain('invalidateOrgScopedDashboardCacheForOrg(orgId)')
+    }
+  })
+})

--- a/tests/unit/list-api-cache.test.ts
+++ b/tests/unit/list-api-cache.test.ts
@@ -22,6 +22,14 @@ describe('orgScopedCacheOptions', () => {
     expect(source).toContain("varies: ['cookie', 'authorization']")
     expect(source).toContain('ORG_SCOPED_CACHE_MAX_AGE_SECONDS')
   })
+
+  it('scopes cache keys by organization and bumps generation on writes', () => {
+    expect(source).toContain('ORG_SCOPED_DASHBOARD_CACHE_NAME')
+    expect(source).toContain('async getKey(event: H3Event)')
+    expect(source).toContain('bumpOrgDashboardCacheVersion')
+    expect(source).toContain('invalidateOrgScopedDashboardCache')
+    expect(source).toContain('invalidateOrgScopedDashboardCacheForOrg')
+  })
 })
 
 describe('dashboard list API Nitro cache', () => {

--- a/tests/unit/list-api-cache.test.ts
+++ b/tests/unit/list-api-cache.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+const CACHED_LIST_HANDLERS = [
+  'server/api/jobs/index.get.ts',
+  'server/api/candidates/index.get.ts',
+  'server/api/applications/index.get.ts',
+  'server/api/interviews/index.get.ts',
+  'server/api/dashboard/stats.get.ts',
+]
+
+describe('orgScopedCacheOptions', () => {
+  const source = readProjectFile('server/utils/httpCache.ts')
+
+  it('exports shared Nitro SWR defaults with session varies headers', () => {
+    expect(source).toContain('orgScopedCacheOptions')
+    expect(source).toContain('swr: true')
+    expect(source).toContain("varies: ['cookie', 'authorization']")
+    expect(source).toContain('ORG_SCOPED_CACHE_MAX_AGE_SECONDS')
+  })
+})
+
+describe('dashboard list API Nitro cache', () => {
+  it.each(CACHED_LIST_HANDLERS)('%s uses defineCachedEventHandler with orgScopedCacheOptions', (file) => {
+    const source = readProjectFile(file)
+    expect(source, file).toContain('defineCachedEventHandler')
+    expect(source, file).toContain('orgScopedCacheOptions')
+    expect(source, file).toContain('requirePermission')
+    expect(source, file).not.toMatch(/export default defineEventHandler\(/)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #307 — first issue in Epic 2 (Dashboard Caching & Navigation).

Adds short-lived Nitro SWR caching to dashboard list APIs, matching the existing `dashboard/stats` pattern.

- **`server/utils/httpCache.ts`** — shared `orgScopedCacheOptions` (30s TTL, `swr: true`, `varies: cookie + authorization`)
- **Cached handlers:** `GET /api/jobs`, `/api/candidates`, `/api/applications`, `/api/interviews`, `/api/dashboard/stats`
- **Tests:** `list-api-cache.test.ts` convention guards + updated `dashboard-stats-cache.test.ts`
- **CLI parity:** cache-only server change; no response contract changes

## Behavior

Repeat list requests within TTL return a cached Nitro response for the same session. Mutations remain visible via short TTL + existing client `refreshNuxtData` / SWR refresh paths.

## Verification

- `npm run test:unit -- tests/unit/list-api-cache.test.ts tests/unit/dashboard-stats-cache.test.ts tests/unit/cli-parity-changed-files.test.ts`
- `npm run typecheck`
- Pre-push `preflight:pr`