### PR TITLE
perf: lazy-load job pipeline detail panels (#309)

### DIFF
--- a/app/components/job-pipeline/JobPipelineAiScorePanel.vue
+++ b/app/components/job-pipeline/JobPipelineAiScorePanel.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+const props = defineProps<{
+  applicationId: string
+}>()
+
+const emit = defineEmits<{
+  scored: []
+}>()
+</script>
+
+<template>
+  <ScoreBreakdown
+    :application-id="props.applicationId"
+    @scored="emit('scored')"
+  />
+</template>

--- a/app/components/job-pipeline/JobPipelineDocumentsPanel.vue
+++ b/app/components/job-pipeline/JobPipelineDocumentsPanel.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { Eye, Download, FileText, Paperclip } from 'lucide-vue-next'
+
+export type PipelineDocument = {
+  id: string
+  type: 'resume' | 'cover_letter' | 'other'
+  originalFilename: string
+  mimeType: string
+  createdAt: string | Date
+}
+
+const props = defineProps<{
+  documents: PipelineDocument[]
+}>()
+
+const emit = defineEmits<{
+  preview: [doc: PipelineDocument]
+}>()
+
+function formatDocumentType(value: PipelineDocument['type']) {
+  if (value === 'cover_letter') return 'Cover Letter'
+  if (value === 'resume') return 'Resume'
+  return 'Other'
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <h2 class="text-sm font-semibold text-surface-800 dark:text-surface-200 flex items-center gap-2 mb-3">
+      <Paperclip class="size-4 text-surface-400 dark:text-surface-500" />
+      Documents
+    </h2>
+    <div v-if="props.documents.length" class="space-y-3">
+      <div
+        v-for="doc in props.documents"
+        :key="doc.id"
+        class="flex flex-wrap items-center justify-between gap-3 ui-panel ui-dashboard-panel px-5 py-4 transition-colors hover:border-surface-300 dark:hover:border-surface-700"
+      >
+        <div class="flex items-center gap-3.5 min-w-0">
+          <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-surface-100 dark:bg-surface-800/60">
+            <FileText class="size-4.5 text-surface-500 dark:text-surface-400" />
+          </div>
+          <div class="min-w-0">
+            <p class="text-sm font-medium text-surface-800 dark:text-surface-100 truncate">
+              {{ doc.originalFilename }}
+            </p>
+            <p class="text-xs text-surface-500 dark:text-surface-400 mt-0.5">
+              {{ formatDocumentType(doc.type) }} · <TimelineDateLink :date="doc.createdAt">{{ new Date(doc.createdAt).toLocaleDateString() }}</TimelineDateLink>
+            </p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <button
+            class="inline-flex items-center gap-1.5 rounded-lg border border-surface-200 px-3 py-1.5 text-xs font-medium text-surface-600 hover:bg-surface-50 hover:border-surface-300 dark:border-surface-700 dark:text-surface-300 dark:hover:bg-surface-800 dark:hover:border-surface-600 transition-all duration-150"
+            @click="emit('preview', doc)"
+          >
+            <Eye class="size-3.5" />
+            Preview
+          </button>
+          <a
+            :href="`/api/documents/${doc.id}/download`"
+            class="inline-flex items-center gap-1.5 rounded-lg border border-surface-200 px-3 py-1.5 text-xs font-medium text-surface-600 hover:bg-surface-50 hover:border-surface-300 dark:border-surface-700 dark:text-surface-300 dark:hover:bg-surface-800 dark:hover:border-surface-600 transition-all duration-150"
+          >
+            <Download class="size-3.5" />
+            Download
+          </a>
+        </div>
+      </div>
+    </div>
+    <div v-else class="ui-panel ui-dashboard-panel p-10 text-center">
+      <div class="flex size-14 items-center justify-center rounded-2xl bg-surface-100 dark:bg-surface-800/60 mx-auto mb-3">
+        <FileText class="size-6 text-surface-400 dark:text-surface-500" />
+      </div>
+      <p class="text-sm font-medium text-surface-600 dark:text-surface-300">No documents uploaded</p>
+      <p class="mt-1 text-xs text-surface-400 dark:text-surface-500">Documents will appear here once uploaded.</p>
+    </div>
+  </div>
+</template>

--- a/app/components/job-pipeline/JobPipelineResponsesPanel.vue
+++ b/app/components/job-pipeline/JobPipelineResponsesPanel.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { MessageSquare } from 'lucide-vue-next'
+
+export type PipelineResponse = {
+  id: string
+  value: unknown
+  question: {
+    id: string
+    label: string
+    type: string
+    options: string[] | null
+  } | null
+}
+
+const props = defineProps<{
+  responses: PipelineResponse[]
+}>()
+
+function formatResponseValue(value: unknown): string {
+  if (Array.isArray(value)) return value.join(', ')
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  return String(value ?? '—')
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <h2 class="text-sm font-semibold text-surface-800 dark:text-surface-200 flex items-center gap-2 mb-3">
+      <MessageSquare class="size-4 text-surface-400 dark:text-surface-500" />
+      Responses
+    </h2>
+    <template v-if="props.responses.length">
+      <div class="space-y-3">
+        <div
+          v-for="response in props.responses"
+          :key="response.id"
+          class="ui-panel ui-dashboard-panel p-5"
+        >
+          <p class="text-xs font-semibold text-surface-400 dark:text-surface-500 uppercase tracking-wider mb-2">
+            {{ response.question?.label ?? 'Unknown question' }}
+          </p>
+          <p class="text-sm text-surface-700 dark:text-surface-200 leading-relaxed">
+            {{ formatResponseValue(response.value) }}
+          </p>
+        </div>
+      </div>
+    </template>
+    <div v-else class="ui-panel ui-dashboard-panel p-10 text-center">
+      <div class="flex size-14 items-center justify-center rounded-2xl bg-surface-100 dark:bg-surface-800/60 mx-auto mb-3">
+        <MessageSquare class="size-6 text-surface-400 dark:text-surface-500" />
+      </div>
+      <p class="text-sm font-medium text-surface-600 dark:text-surface-300">No responses</p>
+      <p class="mt-1 text-xs text-surface-400 dark:text-surface-500">Application form responses will appear here.</p>
+    </div>
+  </div>
+</template>

--- a/app/components/job-pipeline/JobPipelineTimelinePanel.vue
+++ b/app/components/job-pipeline/JobPipelineTimelinePanel.vue
@@ -28,6 +28,7 @@ const timelineItems = ref<TimelineEntry[]>([])
 const timelineLoading = ref(false)
 const timelineError = ref<string | null>(null)
 const timelineLoadedFor = ref<string | null>(null)
+const timelineRequestToken = ref(0)
 
 const timelineActionLabels: Record<string, string> = {
   created: 'Created',
@@ -64,19 +65,24 @@ function getTimelineActionStyle(action: string): TimelineActionStyle {
 }
 
 async function loadTimeline(candidateId: string) {
+  const requestToken = ++timelineRequestToken.value
   timelineLoading.value = true
   timelineError.value = null
   try {
     const result = await $fetch<{ items: TimelineEntry[] }>('/api/activity-log/candidate-timeline', {
       query: { candidateId },
     })
+    if (requestToken !== timelineRequestToken.value) return
     timelineItems.value = result.items
     timelineLoadedFor.value = candidateId
   } catch (err: any) {
+    if (requestToken !== timelineRequestToken.value) return
     timelineError.value = err?.data?.statusMessage ?? 'Failed to load timeline'
     timelineLoadedFor.value = null
   } finally {
-    timelineLoading.value = false
+    if (requestToken === timelineRequestToken.value) {
+      timelineLoading.value = false
+    }
   }
 }
 
@@ -92,9 +98,9 @@ watch(
     timelineItems.value = []
     timelineLoadedFor.value = null
     timelineError.value = null
+    timelineLoading.value = false
 
     if (!candidateId) return
-    if (timelineLoadedFor.value === candidateId) return
     void loadTimeline(candidateId)
   },
   { immediate: true },
@@ -163,7 +169,7 @@ watch(
               <ArrowRight class="size-2.5 text-surface-400 dark:text-surface-500 shrink-0" />
               <span v-if="item.metadata.to_status || item.metadata.toStatus" class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none" :class="getApplicationStatusBadgeClass(String(item.metadata.to_status ?? item.metadata.toStatus), 'soft')">{{ item.metadata.to_status ?? item.metadata.toStatus }}</span>
             </template>
-            <template v-else-if="item.action === 'scored' && item.metadata?.score">
+            <template v-else-if="item.action === 'scored' && item.metadata?.score != null">
               <span class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none bg-accent-100 text-accent-700 dark:bg-accent-900/60 dark:text-accent-300">{{ item.metadata.score }} pts</span>
             </template>
           </div>

--- a/app/components/job-pipeline/JobPipelineTimelinePanel.vue
+++ b/app/components/job-pipeline/JobPipelineTimelinePanel.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import {
+  Plus, Pencil, Trash2, ArrowRight, MessageSquare, Brain, Calendar, Clock, History,
+  AlertTriangle,
+} from 'lucide-vue-next'
+import { getApplicationStatusBadgeClass } from '~/utils/status-display'
+
+export interface TimelineEntry {
+  id: string
+  action: string
+  resourceType: string
+  resourceId: string
+  metadata: Record<string, unknown> | null
+  createdAt: string
+  actorName: string | null
+  actorEmail: string | null
+  resourceName: string | null
+  jobTitle: string | null
+  candidateName: string | null
+}
+
+const props = defineProps<{
+  candidateId?: string
+}>()
+
+const timelineItems = ref<TimelineEntry[]>([])
+const timelineLoading = ref(false)
+const timelineError = ref<string | null>(null)
+const timelineLoadedFor = ref<string | null>(null)
+
+const timelineActionLabels: Record<string, string> = {
+  created: 'Created',
+  updated: 'Updated',
+  deleted: 'Deleted',
+  status_changed: 'Status changed',
+  comment_added: 'Comment added',
+  scored: 'Scored',
+  scheduled: 'Scheduled',
+}
+
+function formatTimelineDate(dateStr: string) {
+  const d = new Date(dateStr)
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+interface TimelineActionStyle {
+  icon: typeof Plus
+  color: string
+  bg: string
+}
+
+function getTimelineActionStyle(action: string): TimelineActionStyle {
+  const map: Record<string, TimelineActionStyle> = {
+    created: { icon: Plus, color: 'text-success-600 dark:text-success-400', bg: 'bg-success-50 dark:bg-success-950/50' },
+    updated: { icon: Pencil, color: 'text-brand-600 dark:text-brand-400', bg: 'bg-brand-50 dark:bg-brand-950/50' },
+    deleted: { icon: Trash2, color: 'text-danger-600 dark:text-danger-400', bg: 'bg-danger-50 dark:bg-danger-950/50' },
+    status_changed: { icon: ArrowRight, color: 'text-blue-600 dark:text-blue-400', bg: 'bg-blue-50 dark:bg-blue-950/50' },
+    comment_added: { icon: MessageSquare, color: 'text-violet-600 dark:text-violet-400', bg: 'bg-violet-50 dark:bg-violet-950/50' },
+    scored: { icon: Brain, color: 'text-accent-600 dark:text-accent-400', bg: 'bg-accent-50 dark:bg-accent-950/50' },
+    scheduled: { icon: Calendar, color: 'text-brand-600 dark:text-brand-400', bg: 'bg-brand-50 dark:bg-brand-950/50' },
+  }
+  return map[action] ?? { icon: Clock, color: 'text-surface-500 dark:text-surface-400', bg: 'bg-surface-100 dark:bg-surface-800' }
+}
+
+async function loadTimeline(candidateId: string) {
+  timelineLoading.value = true
+  timelineError.value = null
+  try {
+    const result = await $fetch<{ items: TimelineEntry[] }>('/api/activity-log/candidate-timeline', {
+      query: { candidateId },
+    })
+    timelineItems.value = result.items
+    timelineLoadedFor.value = candidateId
+  } catch (err: any) {
+    timelineError.value = err?.data?.statusMessage ?? 'Failed to load timeline'
+    timelineLoadedFor.value = null
+  } finally {
+    timelineLoading.value = false
+  }
+}
+
+function retryTimeline() {
+  if (props.candidateId) {
+    void loadTimeline(props.candidateId)
+  }
+}
+
+watch(
+  () => props.candidateId,
+  (candidateId) => {
+    timelineItems.value = []
+    timelineLoadedFor.value = null
+    timelineError.value = null
+
+    if (!candidateId) return
+    if (timelineLoadedFor.value === candidateId) return
+    void loadTimeline(candidateId)
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <div class="space-y-3">
+    <h2 class="text-sm font-semibold text-surface-800 dark:text-surface-200 flex items-center gap-2 mb-3">
+      <History class="size-4 text-surface-400 dark:text-surface-500" />
+      Timeline
+    </h2>
+
+    <div v-if="timelineLoading" class="text-center py-12 text-surface-400">
+      <div class="size-6 rounded-full border-2 border-brand-200 border-t-brand-600 dark:border-brand-800 dark:border-t-brand-400 animate-spin mx-auto mb-3" />
+      Loading timeline…
+    </div>
+
+    <div
+      v-else-if="timelineError"
+      class="rounded-xl border border-danger-200/80 dark:border-danger-800/60 bg-danger-50 dark:bg-danger-950/40 p-5 text-center"
+    >
+      <AlertTriangle class="size-6 text-danger-400 mx-auto mb-2" />
+      <p class="text-sm text-danger-700 dark:text-danger-400">{{ timelineError }}</p>
+      <button
+        class="mt-3 text-sm text-brand-600 hover:text-brand-700 dark:text-brand-400 font-medium cursor-pointer"
+        @click="retryTimeline"
+      >
+        Retry
+      </button>
+    </div>
+
+    <div
+      v-else-if="timelineItems.length === 0"
+      class="ui-panel ui-dashboard-panel p-10 text-center"
+    >
+      <div class="flex size-14 items-center justify-center rounded-2xl bg-surface-100 dark:bg-surface-800/60 mx-auto mb-3">
+        <History class="size-6 text-surface-400 dark:text-surface-500" />
+      </div>
+      <p class="text-sm font-medium text-surface-600 dark:text-surface-300">No activity recorded yet.</p>
+      <p class="mt-1 text-xs text-surface-400 dark:text-surface-500">Activity for this candidate will appear here.</p>
+    </div>
+
+    <div v-else>
+      <div
+        v-for="(item, index) in timelineItems"
+        :key="item.id"
+        class="group flex items-start gap-3 py-1.5 px-1 transition-colors duration-150 hover:bg-surface-50 dark:hover:bg-surface-800/40 rounded-lg"
+      >
+        <div class="flex flex-col items-center shrink-0">
+          <div class="flex items-center justify-center size-6 rounded shrink-0" :class="getTimelineActionStyle(item.action).bg">
+            <component :is="getTimelineActionStyle(item.action).icon" class="size-3" :class="getTimelineActionStyle(item.action).color" />
+          </div>
+          <div
+            v-if="index < timelineItems.length - 1"
+            class="w-px flex-1 min-h-[10px] bg-surface-200 dark:bg-surface-800 mt-0.5"
+          />
+        </div>
+
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-1.5">
+            <span class="text-[13px] font-medium text-surface-900 dark:text-surface-100 shrink-0">{{ timelineActionLabels[item.action] ?? item.action }}</span>
+            <span class="text-[13px] text-surface-500 dark:text-surface-400">{{ item.resourceType }}</span>
+            <template v-if="item.action === 'status_changed' && item.metadata">
+              <span v-if="item.metadata.from_status || item.metadata.fromStatus" class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none" :class="getApplicationStatusBadgeClass(String(item.metadata.from_status ?? item.metadata.fromStatus), 'soft')">{{ item.metadata.from_status ?? item.metadata.fromStatus }}</span>
+              <ArrowRight class="size-2.5 text-surface-400 dark:text-surface-500 shrink-0" />
+              <span v-if="item.metadata.to_status || item.metadata.toStatus" class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none" :class="getApplicationStatusBadgeClass(String(item.metadata.to_status ?? item.metadata.toStatus), 'soft')">{{ item.metadata.to_status ?? item.metadata.toStatus }}</span>
+            </template>
+            <template v-else-if="item.action === 'scored' && item.metadata?.score">
+              <span class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none bg-accent-100 text-accent-700 dark:bg-accent-900/60 dark:text-accent-300">{{ item.metadata.score }} pts</span>
+            </template>
+          </div>
+          <div class="flex items-center gap-2 mt-0.5">
+            <span v-if="item.actorName || item.actorEmail" class="text-[11px] text-surface-400 dark:text-surface-500">{{ item.actorName ?? item.actorEmail }}</span>
+            <span class="text-[11px] text-surface-400 dark:text-surface-500 tabular-nums">{{ formatTimelineDate(item.createdAt) }}</span>
+            <span
+              v-if="item.jobTitle"
+              class="text-[10px] text-surface-400 dark:text-surface-500 bg-surface-100 dark:bg-surface-800 rounded px-1.5 py-0.5 truncate max-w-[140px]"
+            >
+              {{ item.jobTitle }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import {
   ArrowLeft, ArrowRight, Briefcase, Calendar, Clock, Hash, UserRound, MessageSquare,
-  FileText, Paperclip, Download, Eye, Phone, ExternalLink,
-  Pencil, Trash2, Globe, ChevronDown, X,
+  FileText, Download, Phone, ExternalLink,
+  Pencil, Globe, ChevronDown, X,
   Video, Building2, Code2, UsersRound, Save, Check, MapPin, Users, Plus,
   CheckCircle2, XCircle, AlertTriangle, ArrowUpDown, ListFilter,
   Maximize2, Minimize2, Brain, History, SlidersHorizontal,
@@ -19,6 +19,12 @@ import {
   getScoreTextClass,
 } from '~/utils/status-display'
 import { formatPhoneNumber } from '~/utils/phone-format'
+import { jobPipelineLazyPanels } from '~/utils/job-pipeline-lazy-panels'
+
+const JobPipelineAiScorePanel = jobPipelineLazyPanels.aiScore
+const JobPipelineDocumentsPanel = jobPipelineLazyPanels.documents
+const JobPipelineResponsesPanel = jobPipelineLazyPanels.responses
+const JobPipelineTimelinePanel = jobPipelineLazyPanels.timeline
 
 definePageMeta({
   layout: 'dashboard',
@@ -293,92 +299,46 @@ const currentSummary = computed(() => filteredApplications.value[currentIndex.va
 type DetailTab = 'overview' | 'interviews' | 'documents' | 'responses' | 'ai-analysis' | 'timeline' | 'properties'
 const detailTab = ref<DetailTab>('overview')
 
+// Defer heavy overview sections until idle or the user opens a dedicated tab
+const overviewHeavyReady = ref(false)
+
+function scheduleOverviewHeavy() {
+  if (typeof requestIdleCallback !== 'undefined') {
+    requestIdleCallback(() => {
+      overviewHeavyReady.value = true
+    }, { timeout: 2000 })
+    return
+  }
+
+  setTimeout(() => {
+    overviewHeavyReady.value = true
+  }, 0)
+}
+
+onMounted(() => {
+  scheduleOverviewHeavy()
+})
+
+watch(detailTab, (tab) => {
+  if (tab !== 'overview') {
+    overviewHeavyReady.value = true
+  }
+})
+
+const showOverviewHeavy = computed(() =>
+  detailTab.value !== 'overview' || overviewHeavyReady.value,
+)
+
 // Which sections to display based on active tab
 const showSection = computed(() => ({
   profile: detailTab.value === 'overview',
-  aiAnalysis: detailTab.value === 'overview' || detailTab.value === 'ai-analysis',
-  interviews: detailTab.value === 'overview' || detailTab.value === 'interviews',
-  documents: detailTab.value === 'overview' || detailTab.value === 'documents',
-  responses: detailTab.value === 'overview' || detailTab.value === 'responses',
+  aiAnalysis: detailTab.value === 'ai-analysis' || (detailTab.value === 'overview' && showOverviewHeavy.value),
+  interviews: detailTab.value === 'interviews' || (detailTab.value === 'overview' && showOverviewHeavy.value),
+  documents: detailTab.value === 'documents' || (detailTab.value === 'overview' && showOverviewHeavy.value),
+  responses: detailTab.value === 'responses' || (detailTab.value === 'overview' && showOverviewHeavy.value),
   properties: detailTab.value === 'overview' || detailTab.value === 'properties',
   timeline: detailTab.value === 'timeline',
 }))
-
-// ─────────────────────────────────────────────
-// Timeline
-// ─────────────────────────────────────────────
-
-interface TimelineEntry {
-  id: string
-  action: string
-  resourceType: string
-  resourceId: string
-  metadata: Record<string, unknown> | null
-  createdAt: string
-  actorName: string | null
-  actorEmail: string | null
-  resourceName: string | null
-  jobTitle: string | null
-  candidateName: string | null
-}
-
-const timelineItems = ref<TimelineEntry[]>([])
-const timelineLoading = ref(false)
-const timelineError = ref<string | null>(null)
-const timelineLoaded = ref(false)
-
-const timelineActionLabels: Record<string, string> = {
-  created: 'Created',
-  updated: 'Updated',
-  deleted: 'Deleted',
-  status_changed: 'Status changed',
-  comment_added: 'Comment added',
-  scored: 'Scored',
-  scheduled: 'Scheduled',
-}
-
-function formatTimelineDate(dateStr: string) {
-  const d = new Date(dateStr)
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
-}
-
-interface TimelineActionStyle {
-  icon: typeof Plus
-  color: string
-  bg: string
-}
-
-function getTimelineActionStyle(action: string): TimelineActionStyle {
-  const map: Record<string, TimelineActionStyle> = {
-    created: { icon: Plus, color: 'text-success-600 dark:text-success-400', bg: 'bg-success-50 dark:bg-success-950/50' },
-    updated: { icon: Pencil, color: 'text-brand-600 dark:text-brand-400', bg: 'bg-brand-50 dark:bg-brand-950/50' },
-    deleted: { icon: Trash2, color: 'text-danger-600 dark:text-danger-400', bg: 'bg-danger-50 dark:bg-danger-950/50' },
-    status_changed: { icon: ArrowRight, color: 'text-blue-600 dark:text-blue-400', bg: 'bg-blue-50 dark:bg-blue-950/50' },
-    comment_added: { icon: MessageSquare, color: 'text-violet-600 dark:text-violet-400', bg: 'bg-violet-50 dark:bg-violet-950/50' },
-    scored: { icon: Brain, color: 'text-accent-600 dark:text-accent-400', bg: 'bg-accent-50 dark:bg-accent-950/50' },
-    scheduled: { icon: Calendar, color: 'text-brand-600 dark:text-brand-400', bg: 'bg-brand-50 dark:bg-brand-950/50' },
-  }
-  return map[action] ?? { icon: Clock, color: 'text-surface-500 dark:text-surface-400', bg: 'bg-surface-100 dark:bg-surface-800' }
-}
-
-function describeTimelineItem(item: TimelineEntry): string {
-  const actor = item.actorName ?? item.actorEmail ?? 'System'
-  const action = timelineActionLabels[item.action] ?? item.action
-  const resource = item.resourceType
-
-  if (item.action === 'status_changed' && item.metadata) {
-    const from = item.metadata.from_status ?? item.metadata.fromStatus
-    const to = item.metadata.to_status ?? item.metadata.toStatus
-    if (from && to) return `${actor} changed ${resource} status from ${from} to ${to}`
-  }
-
-  if (item.action === 'scored' && item.metadata) {
-    const score = item.metadata.score
-    if (score != null) return `${actor} scored ${resource} — ${score} pts`
-  }
-
-  return `${actor} ${action.toLowerCase()} ${resource}`
-}
 
 // Section refs
 const overviewRef = ref<HTMLElement | null>(null)
@@ -464,42 +424,10 @@ watch(currentApplication, (val) => {
   }
 })
 
-watch(currentApplicationId, () => {
-  timelineItems.value = []
-  timelineLoaded.value = false
-  timelineError.value = null
-})
-
 watch(currentApplicationId, async (id) => {
   if (!id) return
   await executeDetailFetch()
 }, { immediate: true })
-
-async function loadTimeline() {
-  const candId = resolvedCurrentApplication.value?.candidate?.id
-  if (!candId) return
-  timelineLoading.value = true
-  timelineError.value = null
-  try {
-    const result = await $fetch<{ items: TimelineEntry[] }>('/api/activity-log/candidate-timeline', {
-      query: { candidateId: candId },
-    })
-    timelineItems.value = result.items
-    timelineLoaded.value = true
-  } catch (err: any) {
-    timelineError.value = err?.data?.statusMessage ?? 'Failed to load timeline'
-  } finally {
-    timelineLoading.value = false
-  }
-}
-
-const timelineCandidateId = computed(() => resolvedCurrentApplication.value?.candidate?.id)
-
-watch([detailTab, timelineCandidateId], () => {
-  if (detailTab.value === 'timeline' && !timelineLoaded.value && timelineCandidateId.value) {
-    loadTimeline()
-  }
-})
 
 useSeoMeta({
   title: computed(() =>
@@ -510,18 +438,6 @@ useSeoMeta({
 
 function formatStatusLabel(status: string) {
   return status.charAt(0).toUpperCase() + status.slice(1)
-}
-
-function formatResponseValue(value: unknown): string {
-  if (Array.isArray(value)) return value.join(', ')
-  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
-  return String(value ?? '—')
-}
-
-function formatDocumentType(value: SwipeDocument['type']) {
-  if (value === 'cover_letter') return 'Cover Letter'
-  if (value === 'resume') return 'Resume'
-  return 'Other'
 }
 
 function getCandidateInitials(firstName?: string, lastName?: string) {
@@ -607,10 +523,32 @@ async function handleInterviewScheduled() {
 // Interviews for this job
 // ─────────────────────────────────────────────
 
-const { data: jobInterviewsData, refresh: refreshJobInterviews } = useFetch<{ data: Interview[] }>('/api/interviews', {
+const jobInterviewsFetchStarted = ref(false)
+
+const {
+  data: jobInterviewsData,
+  refresh: refreshJobInterviews,
+  execute: executeJobInterviewsFetch,
+} = useFetch<{ data: Interview[] }>('/api/interviews', {
   key: `pipeline-job-interviews-${jobId}`,
   query: { jobId, limit: 100 },
   headers: useRequestHeaders(['cookie']),
+  immediate: false,
+  watch: false,
+})
+
+function ensureJobInterviewsLoaded() {
+  if (jobInterviewsFetchStarted.value) return
+  jobInterviewsFetchStarted.value = true
+  void executeJobInterviewsFetch()
+}
+
+watch(() => showSection.value.interviews, (show) => {
+  if (show) ensureJobInterviewsLoaded()
+}, { immediate: true })
+
+watch(interviewFilter, (filter) => {
+  if (filter !== 'all') ensureJobInterviewsLoaded()
 })
 
 const jobInterviews = computed(() => jobInterviewsData.value?.data ?? [])
@@ -1603,11 +1541,17 @@ function closeDocPreview() {
 
               <!-- AI SCORE BREAKDOWN -->
               <div v-if="showSection.aiAnalysis" class="w-full" :class="detailTab === 'overview' ? 'mt-5' : ''">
-                <ScoreBreakdown
-                  v-if="currentSummary"
-                  :application-id="currentSummary.id"
-                  @scored="refreshApps()"
-                />
+                <Suspense v-if="currentSummary">
+                  <JobPipelineAiScorePanel
+                    :application-id="currentSummary.id"
+                    @scored="refreshApps()"
+                  />
+                  <template #fallback>
+                    <div class="ui-panel ui-dashboard-panel p-8 text-center text-sm text-surface-400">
+                      Loading score breakdown…
+                    </div>
+                  </template>
+                </Suspense>
               </div>
 
               <!-- INTERVIEWS SECTION -->
@@ -1965,85 +1909,32 @@ function closeDocPreview() {
               </div>
 
               <!-- DOCUMENTS SECTION -->
-              <div v-if="showSection.documents" ref="documentsRef" class="space-y-3" :class="detailTab === 'overview' ? 'mt-10' : ''">
-                <h2 class="text-sm font-semibold text-surface-800 dark:text-surface-200 flex items-center gap-2 mb-3">
-                  <Paperclip class="size-4 text-surface-400 dark:text-surface-500" />
-                  Documents
-                </h2>
-                <div v-if="resolvedCurrentApplication?.candidate.documents?.length" class="space-y-3">
-                  <div
-                    v-for="doc in resolvedCurrentApplication.candidate.documents"
-                    :key="doc.id"
-                    class="flex flex-wrap items-center justify-between gap-3 ui-panel ui-dashboard-panel px-5 py-4 transition-colors hover:border-surface-300 dark:hover:border-surface-700"
-                  >
-                    <div class="flex items-center gap-3.5 min-w-0">
-                      <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-surface-100 dark:bg-surface-800/60">
-                        <FileText class="size-4.5 text-surface-500 dark:text-surface-400" />
-                      </div>
-                      <div class="min-w-0">
-                        <p class="text-sm font-medium text-surface-800 dark:text-surface-100 truncate">
-                          {{ doc.originalFilename }}
-                        </p>
-                        <p class="text-xs text-surface-500 dark:text-surface-400 mt-0.5">
-                          {{ formatDocumentType(doc.type) }} · <TimelineDateLink :date="doc.createdAt">{{ new Date(doc.createdAt).toLocaleDateString() }}</TimelineDateLink>
-                        </p>
-                      </div>
+              <div v-if="showSection.documents" ref="documentsRef" :class="detailTab === 'overview' ? 'mt-10' : ''">
+                <Suspense>
+                  <JobPipelineDocumentsPanel
+                    :documents="resolvedCurrentApplication?.candidate.documents ?? []"
+                    @preview="handleDocPreview"
+                  />
+                  <template #fallback>
+                    <div class="ui-panel ui-dashboard-panel p-8 text-center text-sm text-surface-400">
+                      Loading documents…
                     </div>
-                    <div class="flex items-center gap-2">
-                      <button
-                        class="inline-flex items-center gap-1.5 rounded-lg border border-surface-200 px-3 py-1.5 text-xs font-medium text-surface-600 hover:bg-surface-50 hover:border-surface-300 dark:border-surface-700 dark:text-surface-300 dark:hover:bg-surface-800 dark:hover:border-surface-600 transition-all duration-150"
-                        @click="handleDocPreview(doc)"
-                      >
-                        <Eye class="size-3.5" />
-                        Preview
-                      </button>
-                      <a
-                        :href="`/api/documents/${doc.id}/download`"
-                        class="inline-flex items-center gap-1.5 rounded-lg border border-surface-200 px-3 py-1.5 text-xs font-medium text-surface-600 hover:bg-surface-50 hover:border-surface-300 dark:border-surface-700 dark:text-surface-300 dark:hover:bg-surface-800 dark:hover:border-surface-600 transition-all duration-150"
-                      >
-                        <Download class="size-3.5" />
-                        Download
-                      </a>
-                    </div>
-                  </div>
-                </div>
-                <div v-else class="ui-panel ui-dashboard-panel p-10 text-center">
-                  <div class="flex size-14 items-center justify-center rounded-2xl bg-surface-100 dark:bg-surface-800/60 mx-auto mb-3">
-                    <FileText class="size-6 text-surface-400 dark:text-surface-500" />
-                  </div>
-                  <p class="text-sm font-medium text-surface-600 dark:text-surface-300">No documents uploaded</p>
-                  <p class="mt-1 text-xs text-surface-400 dark:text-surface-500">Documents will appear here once uploaded.</p>
-                </div>
+                  </template>
+                </Suspense>
               </div>
 
               <!-- RESPONSES SECTION -->
-              <div v-if="showSection.responses" ref="responsesRef" class="space-y-3" :class="detailTab === 'overview' ? 'mt-10' : ''">
-                <h2 class="text-sm font-semibold text-surface-800 dark:text-surface-200 flex items-center gap-2 mb-3">
-                  <MessageSquare class="size-4 text-surface-400 dark:text-surface-500" />
-                  Responses
-                </h2>                <template v-if="resolvedCurrentApplication?.responses?.length">
-                  <div class="space-y-3">
-                    <div
-                      v-for="response in resolvedCurrentApplication.responses"
-                      :key="response.id"
-                      class="ui-panel ui-dashboard-panel p-5"
-                    >
-                      <p class="text-xs font-semibold text-surface-400 dark:text-surface-500 uppercase tracking-wider mb-2">
-                        {{ response.question?.label ?? 'Unknown question' }}
-                      </p>
-                      <p class="text-sm text-surface-700 dark:text-surface-200 leading-relaxed">
-                        {{ formatResponseValue(response.value) }}
-                      </p>
+              <div v-if="showSection.responses" ref="responsesRef" :class="detailTab === 'overview' ? 'mt-10' : ''">
+                <Suspense>
+                  <JobPipelineResponsesPanel
+                    :responses="resolvedCurrentApplication?.responses ?? []"
+                  />
+                  <template #fallback>
+                    <div class="ui-panel ui-dashboard-panel p-8 text-center text-sm text-surface-400">
+                      Loading responses…
                     </div>
-                  </div>
-                </template>
-                <div v-else class="ui-panel ui-dashboard-panel p-10 text-center">
-                  <div class="flex size-14 items-center justify-center rounded-2xl bg-surface-100 dark:bg-surface-800/60 mx-auto mb-3">
-                    <MessageSquare class="size-6 text-surface-400 dark:text-surface-500" />
-                  </div>
-                  <p class="text-sm font-medium text-surface-600 dark:text-surface-300">No responses</p>
-                  <p class="mt-1 text-xs text-surface-400 dark:text-surface-500">Application form responses will appear here.</p>
-                </div>
+                  </template>
+                </Suspense>
               </div>
 
               <!-- PROPERTIES SECTION -->
@@ -2066,91 +1957,18 @@ function closeDocPreview() {
               </div>
 
               <!-- TIMELINE SECTION -->
-              <div v-if="showSection.timeline" class="space-y-3">
-                <h2 class="text-sm font-semibold text-surface-800 dark:text-surface-200 flex items-center gap-2 mb-3">
-                  <History class="size-4 text-surface-400 dark:text-surface-500" />
-                  Timeline
-                </h2>
-
-                <!-- Loading -->
-                <div v-if="timelineLoading" class="text-center py-12 text-surface-400">
-                  <div class="size-6 rounded-full border-2 border-brand-200 border-t-brand-600 dark:border-brand-800 dark:border-t-brand-400 animate-spin mx-auto mb-3" />
-                  Loading timeline…
-                </div>
-
-                <!-- Error -->
-                <div
-                  v-else-if="timelineError"
-                  class="rounded-xl border border-danger-200/80 dark:border-danger-800/60 bg-danger-50 dark:bg-danger-950/40 p-5 text-center"
-                >
-                  <AlertTriangle class="size-6 text-danger-400 mx-auto mb-2" />
-                  <p class="text-sm text-danger-700 dark:text-danger-400">{{ timelineError }}</p>
-                  <button
-                    class="mt-3 text-sm text-brand-600 hover:text-brand-700 dark:text-brand-400 font-medium cursor-pointer"
-                    @click="loadTimeline"
-                  >
-                    Retry
-                  </button>
-                </div>
-
-                <!-- Empty -->
-                <div
-                  v-else-if="timelineItems.length === 0"
-                  class="ui-panel ui-dashboard-panel p-10 text-center"
-                >
-                  <div class="flex size-14 items-center justify-center rounded-2xl bg-surface-100 dark:bg-surface-800/60 mx-auto mb-3">
-                    <History class="size-6 text-surface-400 dark:text-surface-500" />
-                  </div>
-                  <p class="text-sm font-medium text-surface-600 dark:text-surface-300">No activity recorded yet.</p>
-                  <p class="mt-1 text-xs text-surface-400 dark:text-surface-500">Activity for this candidate will appear here.</p>
-                </div>
-
-                <!-- Timeline list -->
-                <div v-else>
-                  <div
-                    v-for="(item, index) in timelineItems"
-                    :key="item.id"
-                    class="group flex items-start gap-3 py-1.5 px-1 transition-colors duration-150 hover:bg-surface-50 dark:hover:bg-surface-800/40 rounded-lg"
-                  >
-                    <!-- Left column: icon + connector -->
-                    <div class="flex flex-col items-center shrink-0">
-                      <div class="flex items-center justify-center size-6 rounded shrink-0" :class="getTimelineActionStyle(item.action).bg">
-                        <component :is="getTimelineActionStyle(item.action).icon" class="size-3" :class="getTimelineActionStyle(item.action).color" />
-                      </div>
-                      <div
-                        v-if="index < timelineItems.length - 1"
-                        class="w-px flex-1 min-h-[10px] bg-surface-200 dark:bg-surface-800 mt-0.5"
-                      />
+              <div v-if="showSection.timeline">
+                <Suspense>
+                  <JobPipelineTimelinePanel
+                    :candidate-id="resolvedCurrentApplication?.candidate?.id"
+                  />
+                  <template #fallback>
+                    <div class="ui-panel ui-dashboard-panel p-8 text-center text-sm text-surface-400">
+                      Loading timeline…
                     </div>
-
-                      <!-- Content -->
-                      <div class="min-w-0 flex-1">
-                        <div class="flex items-center gap-1.5">
-                          <span class="text-[13px] font-medium text-surface-900 dark:text-surface-100 shrink-0">{{ timelineActionLabels[item.action] ?? item.action }}</span>
-                          <span class="text-[13px] text-surface-500 dark:text-surface-400">{{ item.resourceType }}</span>
-                          <template v-if="item.action === 'status_changed' && item.metadata">
-                            <span v-if="item.metadata.from_status || item.metadata.fromStatus" class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none" :class="getApplicationStatusBadgeClass(String(item.metadata.from_status ?? item.metadata.fromStatus), 'soft')">{{ item.metadata.from_status ?? item.metadata.fromStatus }}</span>
-                            <ArrowRight class="size-2.5 text-surface-400 dark:text-surface-500 shrink-0" />
-                            <span v-if="item.metadata.to_status || item.metadata.toStatus" class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none" :class="getApplicationStatusBadgeClass(String(item.metadata.to_status ?? item.metadata.toStatus), 'soft')">{{ item.metadata.to_status ?? item.metadata.toStatus }}</span>
-                          </template>
-                          <template v-else-if="item.action === 'scored' && item.metadata?.score">
-                            <span class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none bg-accent-100 text-accent-700 dark:bg-accent-900/60 dark:text-accent-300">{{ item.metadata.score }} pts</span>
-                          </template>
-                        </div>
-                        <div class="flex items-center gap-2 mt-0.5">
-                          <span v-if="item.actorName || item.actorEmail" class="text-[11px] text-surface-400 dark:text-surface-500">{{ item.actorName ?? item.actorEmail }}</span>
-                          <span class="text-[11px] text-surface-400 dark:text-surface-500 tabular-nums">{{ formatTimelineDate(item.createdAt) }}</span>
-                          <span
-                            v-if="item.jobTitle"
-                            class="text-[10px] text-surface-400 dark:text-surface-500 bg-surface-100 dark:bg-surface-800 rounded px-1.5 py-0.5 truncate max-w-[140px]"
-                          >
-                            {{ item.jobTitle }}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
+                  </template>
+                </Suspense>
+              </div>
 
               </template>
             </div>

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -527,6 +527,7 @@ const jobInterviewsFetchStarted = ref(false)
 
 const {
   data: jobInterviewsData,
+  error: jobInterviewsError,
   refresh: refreshJobInterviews,
   execute: executeJobInterviewsFetch,
 } = useFetch<{ data: Interview[] }>('/api/interviews', {
@@ -537,18 +538,21 @@ const {
   watch: false,
 })
 
-function ensureJobInterviewsLoaded() {
+async function ensureJobInterviewsLoaded() {
   if (jobInterviewsFetchStarted.value) return
   jobInterviewsFetchStarted.value = true
-  void executeJobInterviewsFetch()
+  await executeJobInterviewsFetch()
+  if (jobInterviewsError.value) {
+    jobInterviewsFetchStarted.value = false
+  }
 }
 
 watch(() => showSection.value.interviews, (show) => {
-  if (show) ensureJobInterviewsLoaded()
+  if (show) void ensureJobInterviewsLoaded()
 }, { immediate: true })
 
 watch(interviewFilter, (filter) => {
-  if (filter !== 'all') ensureJobInterviewsLoaded()
+  if (filter !== 'all') void ensureJobInterviewsLoaded()
 })
 
 const jobInterviews = computed(() => jobInterviewsData.value?.data ?? [])

--- a/app/utils/job-pipeline-lazy-panels.ts
+++ b/app/utils/job-pipeline-lazy-panels.ts
@@ -1,0 +1,17 @@
+import { defineAsyncComponent, type Component } from 'vue'
+
+/** Async job pipeline detail panels — split from the route page to shrink the initial chunk. */
+export const jobPipelineLazyPanels = {
+  timeline: defineAsyncComponent(
+    () => import('~/components/job-pipeline/JobPipelineTimelinePanel.vue'),
+  ),
+  aiScore: defineAsyncComponent(
+    () => import('~/components/job-pipeline/JobPipelineAiScorePanel.vue'),
+  ),
+  documents: defineAsyncComponent(
+    () => import('~/components/job-pipeline/JobPipelineDocumentsPanel.vue'),
+  ),
+  responses: defineAsyncComponent(
+    () => import('~/components/job-pipeline/JobPipelineResponsesPanel.vue'),
+  ),
+} satisfies Record<string, Component>

--- a/tests/unit/job-pipeline-chunk.test.ts
+++ b/tests/unit/job-pipeline-chunk.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readProjectFile = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('job pipeline lazy panels', () => {
+  it('registers async panel loaders for timeline, scoring, documents, and responses', () => {
+    const source = readProjectFile('app/utils/job-pipeline-lazy-panels.ts')
+
+    expect(source).toContain('defineAsyncComponent')
+    expect(source).toContain('JobPipelineTimelinePanel.vue')
+    expect(source).toContain('JobPipelineAiScorePanel.vue')
+    expect(source).toContain('JobPipelineDocumentsPanel.vue')
+    expect(source).toContain('JobPipelineResponsesPanel.vue')
+  })
+
+  it('wires lazy panels, idle overview deferral, and deferred interviews on the pipeline page', () => {
+    const source = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+
+    expect(source).toContain('jobPipelineLazyPanels')
+    expect(source).toContain('JobPipelineAiScorePanel')
+    expect(source).toContain('JobPipelineDocumentsPanel')
+    expect(source).toContain('JobPipelineResponsesPanel')
+    expect(source).toContain('JobPipelineTimelinePanel')
+    expect(source).toContain('overviewHeavyReady')
+    expect(source).toContain('requestIdleCallback')
+    expect(source).toContain('executeJobInterviewsFetch')
+    expect(source).toContain('immediate: false')
+    expect(source).not.toContain('<ScoreBreakdown')
+    expect(source).not.toContain('loadTimeline(')
+    expect(source).not.toContain('timelineItems')
+  })
+
+  it('keeps core pipeline data composables on the route page', () => {
+    const source = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+
+    expect(source).toContain('useJob(jobId)')
+    expect(source).toContain('useApplications({ jobId, limit: 100 })')
+    expect(source).toContain('pipeline-application-${currentApplicationId.value}')
+    expect(source).toContain('cachedApplication')
+  })
+})

--- a/tests/unit/score-breakdown-button.test.ts
+++ b/tests/unit/score-breakdown-button.test.ts
@@ -41,13 +41,15 @@ describe('score breakdown actions', () => {
     expect(source).not.toContain('new Date(resolvedScoreData!.latestRun.createdAt).toLocaleString()')
   })
 
-  it('keeps re-score actions inside the score breakdown section', () => {
-    const source = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+  it('keeps re-score actions inside the lazy-loaded score breakdown panel', () => {
+    const pipelinePage = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+    const scorePanel = readProjectFile('app/components/job-pipeline/JobPipelineAiScorePanel.vue')
 
-    expect(source).toContain('<ScoreBreakdown')
-    expect(source).not.toContain('scoreIndividualCandidate')
-    expect(source).not.toContain('Score Candidate')
-    expect(source).not.toContain('inline-flex cursor-pointer items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium')
+    expect(pipelinePage).toContain('<JobPipelineAiScorePanel')
+    expect(scorePanel).toContain('<ScoreBreakdown')
+    expect(pipelinePage).not.toContain('scoreIndividualCandidate')
+    expect(pipelinePage).not.toContain('Score Candidate')
+    expect(pipelinePage).not.toContain('inline-flex cursor-pointer items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium')
   })
 
   it('formats the selected candidate score like the score breakdown value', () => {


### PR DESCRIPTION
## Summary

Closes #309 — Epic 2 job pipeline lazy panels.

- Extracts timeline, AI scoring, documents, and responses into async sub-panels under `app/components/job-pipeline/`
- Defers heavy overview sections (AI, interviews, documents, responses) until `requestIdleCallback` or the user opens a dedicated tab
- Defers `/api/interviews?jobId=` fetch until the interviews section is shown or the interview filter is used
- Adds `tests/unit/job-pipeline-chunk.test.ts` and updates score-breakdown wiring test

## Chunk impact

- Pipeline route page: **2306 → 2124 lines** (−182)
- New async client chunks (gzip): `ScoreBreakdown` ~4.1 kB, `JobPipelineTimelinePanel` ~2.6 kB, `JobPipelineDocumentsPanel` ~2.0 kB, `JobPipelineAiScorePanel` ~1.2 kB, `JobPipelineResponsesPanel` ~1.1 kB

## Verification

- `npm run test:unit` (including `job-pipeline-chunk.test.ts`, `pipeline-layout.test.ts`, `score-breakdown-button.test.ts`)
- `npm run typecheck`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Pipeline sections (AI score, documents, responses, timeline) now load lazily for faster initial page load and progressive rendering

* **New Features**
  * Dedicated panels for AI score breakdown, documents (preview/download, empty state), responses (formatted display), and candidate timeline (loading, retry, metadata)

* **UI Improvements**
  * Suspense/fallback loading states for deferred panels

* **Tests**
  * Unit tests added/updated to cover lazy panel wiring and behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->