### PR TITLE
fix: persist public application compliance responses

### DIFF
--- a/server/api/public/jobs/[slug]/apply.post.ts
+++ b/server/api/public/jobs/[slug]/apply.post.ts
@@ -494,6 +494,7 @@ export default defineEventHandler(async (event) => {
 
   if (newApplication && hasComplianceResponse(normalizedCompliance)) {
     await db.insert(applicationComplianceResponse).values({
+      id: crypto.randomUUID(),
       organizationId: orgId,
       applicationId: newApplication.id,
       candidateId,

--- a/tests/unit/cli-parity-changed-files.test.ts
+++ b/tests/unit/cli-parity-changed-files.test.ts
@@ -141,6 +141,17 @@ describe('CLI parity changed-file guard', () => {
     })
   })
 
+  it('accepts CLI parity evidence for public application compliance persistence without contract changes', () => {
+    expect(evaluateCliParityEvidence([
+      'server/api/public/jobs/[slug]/apply.post.ts',
+      'tests/unit/public-application-compliance.test.ts',
+      'tests/unit/cli-parity-changed-files.test.ts',
+    ])).toMatchObject({
+      ok: true,
+      message: 'CLI parity evidence found.',
+    })
+  })
+
   it('accepts CLI parity evidence for security/code-scanning route cleanups without contract changes', () => {
     expect(evaluateCliParityEvidence([
       'server/api/applications/[id]/analyze.post.ts',

--- a/tests/unit/public-application-compliance.test.ts
+++ b/tests/unit/public-application-compliance.test.ts
@@ -74,6 +74,13 @@ describe('public application compliance self-identification', () => {
     expect(handler).not.toContain('questionResponse).values(\\n      validResponses.map((r) => ({\\n        organizationId: orgId,\\n        applicationId: newApplication!.id,\\n        questionId: r.questionId,\\n        value: r.value,\\n        compliance')
   })
 
+  it('creates compliance responses with an explicit id for production tables without database defaults', () => {
+    const handler = readProjectFile('server/api/public/jobs/[slug]/apply.post.ts')
+    const complianceInsert = handler.match(/db\.insert\(applicationComplianceResponse\)\.values\(\{[\s\S]*?\n      \}\)/)?.[0] ?? ''
+
+    expect(complianceInsert).toContain('id: crypto.randomUUID()')
+  })
+
   it('renders voluntary questions on the public form without exposing answers in hiring surfaces', () => {
     const publicApply = readProjectFile('app/pages/jobs/[slug]/apply.vue')
     const applicationDetail = readProjectFile('app/pages/dashboard/applications/[id].vue')


### PR DESCRIPTION
## Summary
- Add an explicit ID when persisting voluntary compliance responses from public applications
- Add a regression test so the route stays compatible with production tables where the migration has no database default for the compliance response ID

## Verification
- Direct source regression check passed: compliance insert contains `id: crypto.randomUUID()`
- `git diff --check` passed

## Note
- Full Vitest did not run locally because `npm ci` is blocked by GitHub Packages auth for `@caffeinebounce/email`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application submission reliability by ensuring compliance responses receive a unique identifier when saved.

* **Tests**
  * Added coverage to verify unique identifiers are generated correctly during application submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->