### PR TITLE
fix: repair candidate location schema

### DIFF
--- a/server/api/readyz.get.ts
+++ b/server/api/readyz.get.ts
@@ -3,7 +3,15 @@ export default defineEventHandler(async (event) => {
 
   try {
     const [row] = await db.execute<{ ready: boolean }>(
-      "SELECT to_regclass('public.user') IS NOT NULL AS ready",
+      `SELECT
+        to_regclass('public.user') IS NOT NULL
+        AND (
+          SELECT count(*) = 2
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND table_name = 'candidate'
+            AND column_name IN ('country', 'state')
+        ) AS ready`,
     )
 
     if (!row?.ready) {

--- a/server/database/migrations/0049_candidate_location_repair.sql
+++ b/server/database/migrations/0049_candidate_location_repair.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "candidate" ADD COLUMN IF NOT EXISTS "country" text;
+--> statement-breakpoint
+ALTER TABLE "candidate" ADD COLUMN IF NOT EXISTS "state" text;

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1779692400000,
       "tag": "0048_salary_display_on_listing",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1784052416000,
+      "tag": "0049_candidate_location_repair",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/unit/application-location.test.ts
+++ b/tests/unit/application-location.test.ts
@@ -44,6 +44,23 @@ describe('built-in applicant location', () => {
     expect(dbSchema).toContain("state: text('state')")
   })
 
+  it('repairs deployed databases that missed the candidate location migration', () => {
+    const migration = readProjectFile('server/database/migrations/0049_candidate_location_repair.sql')
+    const journal = readProjectFile('server/database/migrations/meta/_journal.json')
+
+    expect(migration).toContain('ALTER TABLE "candidate" ADD COLUMN IF NOT EXISTS "country" text')
+    expect(migration).toContain('ALTER TABLE "candidate" ADD COLUMN IF NOT EXISTS "state" text')
+    expect(journal).toContain('"tag": "0049_candidate_location_repair"')
+  })
+
+  it('keeps readiness false when required candidate location columns are missing', () => {
+    const readiness = readProjectFile('server/api/readyz.get.ts')
+
+    expect(readiness).toContain('information_schema.columns')
+    expect(readiness).toContain("column_name IN ('country', 'state')")
+    expect(readiness).toContain('count(*) = 2')
+  })
+
   it('keeps the legacy location prompt out of custom questions', () => {
     const seed = readProjectFile('server/scripts/seed-factory.ts')
     const publicJob = readProjectFile('server/api/public/jobs/[slug].get.ts')

--- a/tests/unit/cli-parity-changed-files.test.ts
+++ b/tests/unit/cli-parity-changed-files.test.ts
@@ -141,6 +141,19 @@ describe('CLI parity changed-file guard', () => {
     })
   })
 
+  it('accepts CLI parity evidence for application schema readiness repairs without contract changes', () => {
+    expect(evaluateCliParityEvidence([
+      'server/api/readyz.get.ts',
+      'server/database/migrations/0049_candidate_location_repair.sql',
+      'server/database/migrations/meta/_journal.json',
+      'tests/unit/application-location.test.ts',
+      'tests/unit/cli-parity-changed-files.test.ts',
+    ])).toMatchObject({
+      ok: true,
+      message: 'CLI parity evidence found.',
+    })
+  })
+
   it('accepts CLI parity evidence for security/code-scanning route cleanups without contract changes', () => {
     expect(evaluateCliParityEvidence([
       'server/api/applications/[id]/analyze.post.ts',


### PR DESCRIPTION
## Summary

- Add an idempotent repair migration for the missing `candidate.country` and `candidate.state` production columns.
- Make `/api/readyz` fail closed when those submission-critical columns are missing.
- Add regression and CLI-parity evidence tests for the migration and readiness contract.

The live Render error was PostgreSQL `42703`: application submission selected `candidate.country`, but the production migration ledger had advanced past the older location migration without applying it.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Validation

- [x] `npm run preflight:pr` — 1,116 unit tests, typecheck, CLI smoke, production env validation, and production build passed
- [x] `npm run check:conventions`
- [x] Applied migration `0049` to production with the admin connection
- [x] Re-ran the formerly failing candidate select through the production app role; it resolves successfully
- [x] Verified both columns exist and the strengthened readiness query returns `ready: true`
- [x] Multi-tenant scoping and auth behavior are unchanged
- [x] Documentation is not required for this additive schema repair

## CLI parity

- [x] Checked workflow payloads, response shapes, auth requirements, and resource coverage
- [x] No CLI route coverage or command change is needed; `/api/readyz` remains an operational endpoint
- [x] Added focused CLI-parity evidence in `tests/unit/cli-parity-changed-files.test.ts`

## Keyboard / accessibility acceptance

No UI or interactive controls changed.

## Known risks or skipped checks

- No synthetic application was written to production; verification used the exact failing select with `LIMIT 0` to avoid creating candidate data.
- The migration is additive, nullable, and idempotent.

## Release/version notes

- Patch release behavior through the conventional `fix:` title.
- No changeset is needed.

## DCO

- [x] All commits are signed off.

<!-- openclaw-review-loop:
channel=codex
agent=codex
sessionKey=
providerThreadId=
origin=external-ui
-->
