### PR TITLE
fix: keep pipeline candidate cards contained

### DIFF
--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -1215,28 +1215,34 @@ function closeDocPreview() {
               </button>
             </div>
 
-            <button
+            <div
               v-for="(app, idx) in filteredApplications"
               :key="app.id"
-              class="pipeline-candidate-card group flex w-full cursor-pointer items-start gap-3 px-3.5 py-3 text-left transition-all duration-150"
+              class="pipeline-candidate-card group relative grid w-full grid-cols-[auto_minmax(0,1fr)] items-start gap-x-3 px-3.5 py-3 text-left transition-all duration-150"
               :class="currentIndex === idx
                 ? 'bg-brand-50/70 dark:bg-brand-950/20 border-l-[3px] border-l-brand-500 dark:border-l-brand-400'
                 : 'border-l-[3px] border-l-transparent hover:bg-surface-50/80 dark:hover:bg-surface-800/40'"
-              @click="selectCandidate(idx)"
             >
+              <button
+                type="button"
+                class="absolute inset-0 z-0 cursor-pointer border-0 bg-transparent focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-brand-500"
+                :aria-label="`Open candidate ${formatPersonName(app.candidateFirstName, app.candidateLastName)}`"
+                :aria-current="currentIndex === idx ? 'true' : undefined"
+                @click="selectCandidate(idx)"
+              ></button>
               <div
-                class="flex size-9 shrink-0 items-center justify-center rounded-full text-xs font-semibold transition-all duration-150"
+                class="pointer-events-none relative z-10 flex size-9 shrink-0 items-center justify-center rounded-full text-xs font-semibold transition-all duration-150"
                 :class="currentIndex === idx
                   ? 'bg-brand-500 text-white shadow-sm shadow-brand-500/20 dark:bg-brand-600 dark:shadow-brand-500/10'
                   : 'bg-surface-100 text-surface-600 group-hover:bg-brand-100 group-hover:text-brand-700 dark:bg-surface-800 dark:text-surface-300 dark:group-hover:bg-brand-950 dark:group-hover:text-brand-300'"
               >
                 {{ getCandidateInitials(app.candidateFirstName, app.candidateLastName) }}
               </div>
-              <div class="min-w-0 flex-1">
+              <div class="pointer-events-none relative z-10 min-w-0">
                 <p class="truncate text-sm font-medium text-surface-900 dark:text-surface-100">
                   {{ formatPersonName(app.candidateFirstName, app.candidateLastName) }}
                 </p>
-                <CopyEmailButton :email="app.candidateEmail" class="mt-0.5 max-w-full text-xs text-surface-500 dark:text-surface-400" />
+                <CopyEmailButton :email="app.candidateEmail" class="pointer-events-auto mt-0.5 max-w-full text-xs text-surface-500 dark:text-surface-400" />
                 <div class="mt-1.5 flex items-center gap-2">
                   <span
                     v-if="app.score != null"
@@ -1251,7 +1257,7 @@ function closeDocPreview() {
                   </span>
                 </div>
               </div>
-            </button>
+            </div>
           </div>
         </div>
 

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -1225,20 +1225,20 @@ function closeDocPreview() {
             >
               <button
                 type="button"
-                class="absolute inset-0 z-0 cursor-pointer border-0 bg-transparent focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-brand-500"
+                class="absolute inset-0 z-10 cursor-pointer border-0 bg-transparent focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-brand-500"
                 :aria-label="`Open candidate ${formatPersonName(app.candidateFirstName, app.candidateLastName)}`"
                 :aria-current="currentIndex === idx ? 'true' : undefined"
                 @click="selectCandidate(idx)"
               ></button>
               <div
-                class="pointer-events-none relative z-10 flex size-9 shrink-0 items-center justify-center rounded-full text-xs font-semibold transition-all duration-150"
+                class="pointer-events-none relative z-20 flex size-9 shrink-0 items-center justify-center rounded-full text-xs font-semibold transition-all duration-150"
                 :class="currentIndex === idx
                   ? 'bg-brand-500 text-white shadow-sm shadow-brand-500/20 dark:bg-brand-600 dark:shadow-brand-500/10'
                   : 'bg-surface-100 text-surface-600 group-hover:bg-brand-100 group-hover:text-brand-700 dark:bg-surface-800 dark:text-surface-300 dark:group-hover:bg-brand-950 dark:group-hover:text-brand-300'"
               >
                 {{ getCandidateInitials(app.candidateFirstName, app.candidateLastName) }}
               </div>
-              <div class="pointer-events-none relative z-10 min-w-0">
+              <div class="pointer-events-none relative z-20 min-w-0">
                 <p class="truncate text-sm font-medium text-surface-900 dark:text-surface-100">
                   {{ formatPersonName(app.candidateFirstName, app.candidateLastName) }}
                 </p>

--- a/tests/unit/job-pipeline-candidate-card-markup.test.ts
+++ b/tests/unit/job-pipeline-candidate-card-markup.test.ts
@@ -1,23 +1,70 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import { parse } from 'vue/compiler-sfc'
+
+interface TemplateNode {
+  type: number
+  tag?: string
+  props?: Array<{
+    type: number
+    name?: string
+    arg?: { content?: string }
+    exp?: { content?: string }
+  }>
+  children?: TemplateNode[]
+}
 
 function readProjectFile(path: string) {
   return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
 }
 
+function findElements(node: TemplateNode, predicate: (node: TemplateNode) => boolean): TemplateNode[] {
+  const matches = predicate(node) ? [node] : []
+
+  for (const child of node.children ?? []) {
+    matches.push(...findElements(child, predicate))
+  }
+
+  return matches
+}
+
 describe('job pipeline candidate card markup', () => {
   it('keeps candidate selection and email-copy controls as valid sibling buttons', () => {
     const source = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
-    const candidateList = source.match(/<!-- Scrollable list -->[\s\S]*?<!-- CENTER PANEL/)?.[0] ?? ''
-    const copyControlIndex = candidateList.indexOf('<CopyEmailButton')
-    const markupBeforeCopyControl = candidateList.slice(0, copyControlIndex)
-    const openButtonCount = markupBeforeCopyControl.match(/<button\b/g)?.length ?? 0
-    const closeButtonCount = markupBeforeCopyControl.match(/<\/button>/g)?.length ?? 0
+    const { descriptor, errors } = parse(source, { filename: 'app/pages/dashboard/jobs/[id]/index.vue' })
+    const template = descriptor.template?.ast as TemplateNode | undefined
 
-    expect(candidateList).not.toBe('')
-    expect(copyControlIndex).toBeGreaterThan(-1)
-    expect(openButtonCount - closeButtonCount).toBe(0)
-    expect(candidateList).toContain(':aria-label="`Open candidate ${formatPersonName(app.candidateFirstName, app.candidateLastName)}`"')
+    expect(errors).toEqual([])
+    expect(template).toBeDefined()
+
+    const candidateCard = findElements(template!, node =>
+      node.tag === 'div'
+      && node.props?.some(prop =>
+        prop.type === 7
+        && prop.name === 'for'
+        && prop.exp?.content.includes('filteredApplications'),
+      ),
+    )[0]
+
+    expect(candidateCard).toBeDefined()
+
+    const copyControls = findElements(candidateCard!, node => node.tag === 'CopyEmailButton')
+    const nativeButtons = findElements(candidateCard!, node => node.tag === 'button')
+    const buttonContainsCopyControl = nativeButtons.some(button =>
+      findElements(button, node => node.tag === 'CopyEmailButton').length > 0,
+    )
+    const selectionButton = nativeButtons.find(button =>
+      button.props?.some(prop =>
+        prop.type === 7
+        && prop.name === 'bind'
+        && prop.arg?.content === 'aria-label'
+        && prop.exp?.content.includes('Open candidate'),
+      ),
+    )
+
+    expect(copyControls).toHaveLength(1)
+    expect(buttonContainsCopyControl).toBe(false)
+    expect(selectionButton).toBeDefined()
   })
 })

--- a/tests/unit/job-pipeline-candidate-card-markup.test.ts
+++ b/tests/unit/job-pipeline-candidate-card-markup.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readProjectFile(path: string) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), 'utf-8')
+}
+
+describe('job pipeline candidate card markup', () => {
+  it('keeps candidate selection and email-copy controls as valid sibling buttons', () => {
+    const source = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+    const candidateList = source.match(/<!-- Scrollable list -->[\s\S]*?<!-- CENTER PANEL/)?.[0] ?? ''
+    const copyControlIndex = candidateList.indexOf('<CopyEmailButton')
+    const markupBeforeCopyControl = candidateList.slice(0, copyControlIndex)
+    const openButtonCount = markupBeforeCopyControl.match(/<button\b/g)?.length ?? 0
+    const closeButtonCount = markupBeforeCopyControl.match(/<\/button>/g)?.length ?? 0
+
+    expect(candidateList).not.toBe('')
+    expect(copyControlIndex).toBeGreaterThan(-1)
+    expect(openButtonCount - closeButtonCount).toBe(0)
+    expect(candidateList).toContain(':aria-label="`Open candidate ${formatPersonName(app.candidateFirstName, app.candidateLastName)}`"')
+  })
+})


### PR DESCRIPTION
## Summary

- replace the invalid nested candidate-row and copy-email buttons with valid sibling controls
- keep the full candidate card selectable while preserving the independent copy-email action
- add a regression test that prevents nested interactive markup from returning

## Validation run

- `npm run test:unit` (191 files, 1,118 tests)
- `npm run typecheck`
- `npm run check:conventions`
- `npm run build`
- pre-push `npm run preflight:pr`

## Known risks or skipped checks

- Hosted browser verification is pending the deploy preview/production deployment.
- Existing Nuxt/Volar and duplicate-import warnings remain unchanged.

## Release/version notes

- No changeset or version bump required; this is an application UI bug fix.

<!-- openclaw-review-loop:
channel=codex
agent=codex
sessionKey=
providerThreadId=
origin=external-ui
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved candidate cards with clearer screen reader labels and current-selection indicators.
  * Made the entire candidate card consistently clickable on desktop.

* **UI Improvements**
  * Updated the candidate list layout for more reliable card interactions and presentation.

* **Tests**
  * Added coverage to verify candidate card markup, accessibility labeling, and interactive element structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->