### PR TITLE
feat: add indexed application content search [codex]

### DIFF
--- a/app/composables/useApplications.ts
+++ b/app/composables/useApplications.ts
@@ -26,16 +26,11 @@ export function applicationsListKey(query: ApplicationsListQuery): string {
   return `applications-${JSON.stringify(normalized)}`
 }
 
-/** Refresh every cached /api/applications list payload. */
-export async function refreshApplicationsListCaches() {
-  const nuxtApp = useNuxtApp()
-  const keys = new Set<string>([
-    ...Object.keys(nuxtApp.payload.data),
-    ...Object.keys(nuxtApp.static.data),
-  ])
-
-  const refreshKeys = [...keys].filter(key => key.startsWith('applications-'))
-  await Promise.all(refreshKeys.map(key => refreshNuxtData(key)))
+/** Invalidate inactive application-list payloads without refetching historical searches. */
+export function refreshApplicationsListCaches(activeKeyToPreserve?: string) {
+  clearNuxtData(key =>
+    key.startsWith('applications-') && key !== activeKeyToPreserve,
+  )
 }
 
 /**
@@ -115,7 +110,7 @@ export function useApplications(options?: {
         body: payload,
       })
       await refresh()
-      await refreshApplicationsListCaches()
+      refreshApplicationsListCaches(dataKey.value)
       return created
     } catch (error) {
       handlePreviewReadOnlyError(error)

--- a/app/composables/useApplications.ts
+++ b/app/composables/useApplications.ts
@@ -1,5 +1,6 @@
 import type { Ref } from 'vue'
 import { usePreviewReadOnly } from '~/composables/usePreviewReadOnly'
+import { remainingPageBatches } from '~~/shared/pagination'
 import type { PropertyFilter } from '~~/shared/properties'
 
 export type ApplicationsListQuery = {
@@ -8,6 +9,7 @@ export type ApplicationsListQuery = {
   jobId?: string
   candidateId?: string
   status?: string
+  search?: string
   propertyFilters?: string
 }
 
@@ -19,6 +21,7 @@ export function applicationsListKey(query: ApplicationsListQuery): string {
   if (query.jobId) normalized.jobId = query.jobId
   if (query.candidateId) normalized.candidateId = query.candidateId
   if (query.status) normalized.status = query.status
+  if (query.search) normalized.search = query.search
   if (query.propertyFilters) normalized.propertyFilters = query.propertyFilters
   return `applications-${JSON.stringify(normalized)}`
 }
@@ -37,7 +40,8 @@ export async function refreshApplicationsListCaches() {
 
 /**
  * Composable for managing the applications list with filtering, pagination, and mutations.
- * Wraps `useFetch('/api/applications')` with canonical cache keys and client SWR.
+ * Uses canonical cache keys and client SWR. Pipeline callers can request every
+ * page while the ordinary list contract remains paginated.
  */
 export function useApplications(options?: {
   page?: Ref<number | undefined> | number
@@ -45,7 +49,9 @@ export function useApplications(options?: {
   jobId?: Ref<string | undefined> | string
   candidateId?: Ref<string | undefined> | string
   status?: Ref<string | undefined> | string
+  search?: Ref<string | undefined> | string
   propertyFilters?: Ref<PropertyFilter[] | undefined> | PropertyFilter[]
+  allPages?: boolean
 }) {
   const { handlePreviewReadOnlyError } = usePreviewReadOnly()
 
@@ -57,14 +63,38 @@ export function useApplications(options?: {
       ...(toValue(options?.jobId) && { jobId: toValue(options?.jobId) }),
       ...(toValue(options?.candidateId) && { candidateId: toValue(options?.candidateId) }),
       ...(toValue(options?.status) && { status: toValue(options?.status) }),
+      ...(toValue(options?.search) && { search: toValue(options?.search) }),
       ...(pf && pf.length > 0 && { propertyFilters: JSON.stringify(pf) }),
     }
   })
 
-  const { data, status: fetchStatus, error, refresh } = useFetch('/api/applications', {
-    key: computed(() => applicationsListKey(query.value)),
-    query,
-    headers: useRequestHeaders(['cookie']),
+  const requestFetch = useRequestFetch()
+  const dataKey = computed(() => {
+    const baseKey = applicationsListKey(query.value)
+    return options?.allPages ? `${baseKey}-all-pages` : baseKey
+  })
+
+  const { data, status: fetchStatus, error, refresh } = useAsyncData(dataKey, async () => {
+    const firstQuery = options?.allPages
+      ? { ...query.value, page: 1 }
+      : query.value
+    const firstPage = await requestFetch('/api/applications', { query: firstQuery })
+
+    if (!options?.allPages || firstPage.data.length >= firstPage.total) {
+      return firstPage
+    }
+
+    const allApplications = [...firstPage.data]
+
+    for (const pageNumbers of remainingPageBatches(firstPage.total, firstPage.limit)) {
+      const pages = await Promise.all(pageNumbers.map(page => requestFetch('/api/applications', {
+        query: { ...query.value, page, limit: firstPage.limit },
+      })))
+      allApplications.push(...pages.flatMap(page => page.data))
+    }
+
+    return { ...firstPage, data: allApplications }
+  }, {
     getCachedData: getSwrCachedData,
   })
 

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -50,9 +50,17 @@ const { job: jobData, status: jobFetchStatus, error: jobError } = useJob(jobId)
 // ─────────────────────────────────────────────
 
 const applicationSearch = ref('')
+const normalizedApplicationSearch = computed(() => applicationSearch.value.trim())
+const isApplicationSearchTooShort = computed(() =>
+  normalizedApplicationSearch.value.length > 0
+  && normalizedApplicationSearch.value.length < 3,
+)
 const debouncedApplicationSearch = useDebouncedRef(applicationSearch, {
   delay: 300,
-  transform: value => value.trim() || undefined,
+  transform: (value) => {
+    const normalized = value.trim()
+    return normalized.length >= 3 ? normalized : undefined
+  },
   initial: undefined as string | undefined,
 })
 
@@ -925,8 +933,11 @@ const isLoading = computed(() => {
 })
 
 const isApplicationSearchPending = computed(() =>
-  applicationSearch.value.trim() !== (debouncedApplicationSearch.value ?? '')
-  || (Boolean(debouncedApplicationSearch.value) && appFetchStatus.value === 'pending'),
+  !isApplicationSearchTooShort.value
+  && (
+    normalizedApplicationSearch.value !== (debouncedApplicationSearch.value ?? '')
+    || (appFetchStatus.value === 'pending' && !isMutating.value)
+  ),
 )
 
 // ─────────────────────────────────────────────
@@ -1060,7 +1071,14 @@ function closeDocPreview() {
             @open-change="closePanels"
           />
           <span
-            v-if="isApplicationSearchPending"
+            v-if="isApplicationSearchTooShort"
+            class="shrink-0 text-[11px] text-surface-400 dark:text-surface-500"
+            role="status"
+          >
+            Type 3+ characters
+          </span>
+          <span
+            v-else-if="isApplicationSearchPending"
             class="inline-flex shrink-0 items-center gap-1.5 text-[11px] text-surface-400 dark:text-surface-500"
             role="status"
           >

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -49,12 +49,21 @@ const { job: jobData, status: jobFetchStatus, error: jobError } = useJob(jobId)
 // Applications data
 // ─────────────────────────────────────────────
 
+const applicationSearch = ref('')
+const debouncedApplicationSearch = useDebouncedRef(applicationSearch, {
+  delay: 300,
+  transform: value => value.trim() || undefined,
+  initial: undefined as string | undefined,
+})
+
 const {
+  data: applicationsData,
   applications,
+  total: applicationTotal,
   fetchStatus: appFetchStatus,
   error: appError,
   refresh: refreshApps,
-} = useApplications({ jobId, limit: 100 })
+} = useApplications({ jobId, limit: 100, search: debouncedApplicationSearch, allPages: true })
 
 const PIPELINE_STATUSES = ['new', 'screening', 'interview', 'offer', 'hired', 'rejected'] as const
 type PipelineStatus = typeof PIPELINE_STATUSES[number]
@@ -69,8 +78,8 @@ const focusedApplications = computed(() =>
   applications.value.filter((application) => application.status === focusStatus.value),
 )
 
-// Search within the focused list
-const searchTerm = ref('')
+// Narrow candidate-only search lives alongside the other focused-list filters.
+const candidateSearch = ref('')
 
 // ─────────────────────────────────────────────
 // Filters & Sorting
@@ -96,9 +105,15 @@ const { floatingStyle: sortPanelStyle } = useFloatingMenu({
   zIndex: 80,
 })
 
-const hasActiveFilters = computed(() => scoreFilter.value !== 'all' || interviewFilter.value !== 'all' || propertyFilters.value.length > 0)
+const hasActiveFilters = computed(() =>
+  candidateSearch.value.trim().length > 0
+  || scoreFilter.value !== 'all'
+  || interviewFilter.value !== 'all'
+  || propertyFilters.value.length > 0,
+)
 const activeFilterCount = computed(() => {
   let count = 0
+  if (candidateSearch.value.trim()) count++
   if (scoreFilter.value !== 'all') count++
   if (interviewFilter.value !== 'all') count++
   count += propertyFilters.value.length
@@ -106,6 +121,7 @@ const activeFilterCount = computed(() => {
 })
 
 function clearFilters() {
+  candidateSearch.value = ''
   scoreFilter.value = 'all'
   interviewFilter.value = 'all'
   propertyFilters.value = []
@@ -152,9 +168,9 @@ function closePanels() {
 const filteredApplications = computed(() => {
   let result = focusedApplications.value
 
-  // Text search
-  if (searchTerm.value.trim()) {
-    const term = searchTerm.value.toLowerCase()
+  // Candidate-only filter. The page-level application search is handled by the API.
+  if (candidateSearch.value.trim()) {
+    const term = candidateSearch.value.trim().toLowerCase()
     result = result.filter((app) => {
       const name = `${app.candidateFirstName} ${app.candidateLastName}`.toLowerCase()
       const email = (app.candidateEmail ?? '').toLowerCase()
@@ -278,7 +294,6 @@ watch(filteredApplications, (apps) => {
 
 watch(focusStatus, () => {
   currentIndex.value = 0
-  searchTerm.value = ''
   propertyFilters.value = []
   closePanels()
 })
@@ -905,8 +920,14 @@ onBeforeUnmount(() => {
 })
 
 const isLoading = computed(() => {
-  return jobFetchStatus.value === 'pending' || appFetchStatus.value === 'pending'
+  return jobFetchStatus.value === 'pending'
+    || (appFetchStatus.value === 'pending' && applicationsData.value == null && !debouncedApplicationSearch.value)
 })
+
+const isApplicationSearchPending = computed(() =>
+  applicationSearch.value.trim() !== (debouncedApplicationSearch.value ?? '')
+  || (Boolean(debouncedApplicationSearch.value) && appFetchStatus.value === 'pending'),
+)
 
 // ─────────────────────────────────────────────
 // Document preview
@@ -1026,6 +1047,38 @@ function closeDocPreview() {
         </div>
       </div>
 
+      <!-- Application-wide content search -->
+      <div class="shrink-0 border-b border-white/10 bg-white/[0.015] px-3 py-2 sm:px-5">
+        <div class="flex min-w-0 items-center gap-3">
+          <GooeySearchInput
+            v-model="applicationSearch"
+            aria-label="Search application content"
+            class="w-full max-w-2xl"
+            placeholder="Search applications, resumes, notes, answers…"
+            reserve-expanded-space
+            size="sm"
+            @open-change="closePanels"
+          />
+          <span
+            v-if="isApplicationSearchPending"
+            class="inline-flex shrink-0 items-center gap-1.5 text-[11px] text-surface-400 dark:text-surface-500"
+            role="status"
+          >
+            <span class="size-3 animate-spin rounded-full border border-current border-t-transparent" />
+            <span class="hidden sm:inline">Searching</span>
+          </span>
+          <span
+            v-else-if="debouncedApplicationSearch"
+            class="shrink-0 text-[11px] tabular-nums text-surface-400 dark:text-surface-500"
+          >
+            {{ applicationTotal }} match{{ applicationTotal === 1 ? '' : 'es' }}
+          </span>
+          <span class="hidden shrink-0 text-[10px] text-surface-400 dark:text-surface-500 xl:inline">
+            Searches profiles, resumes, answers, properties, interviews, comments, sources, and AI evidence
+          </span>
+        </div>
+      </div>
+
       <!-- ═══════════════════════════════════════ -->
       <!-- THREE-PANEL LAYOUT                       -->
       <!-- ═══════════════════════════════════════ -->
@@ -1035,19 +1088,8 @@ function closeDocPreview() {
         <div
           class="hidden md:flex md:w-72 md:shrink-0 flex-col border-r border-white/10 bg-white/[0.015] ui-dashboard-panel"
         >
-          <!-- Search + Sort + Filter controls -->
+          <!-- Sort + Filter controls -->
           <div class="shrink-0 px-3.5 pt-3 pb-2 space-y-2 dark:border-surface-800">
-            <!-- Search input -->
-            <GooeySearchInput
-              v-model="searchTerm"
-              aria-label="Search candidates"
-              class="w-full"
-              placeholder="Search candidates…"
-              reserve-expanded-space
-              size="sm"
-              @open-change="closePanels"
-            />
-
             <!-- Sort & Filter row -->
             <div class="flex items-center gap-1.5">
               <!-- Sort dropdown -->
@@ -1102,6 +1144,9 @@ function closeDocPreview() {
               <!-- Filter button -->
               <button
                 class="relative flex h-8 min-h-8 cursor-pointer items-center justify-center gap-1 rounded-md border px-2 py-0 transition-all duration-150"
+                :aria-expanded="showFilterPanel"
+                :aria-label="activeFilterCount > 0 ? `Filter candidates, ${activeFilterCount} active` : 'Filter candidates'"
+                :title="activeFilterCount > 0 ? `${activeFilterCount} active filter${activeFilterCount === 1 ? '' : 's'}` : 'Filter candidates'"
                 :class="showFilterPanel || hasActiveFilters
                   ? 'border-brand-300 bg-brand-50/50 text-brand-700 dark:border-brand-600 dark:bg-brand-950/30 dark:text-brand-300'
                   : 'border-surface-200/80 bg-surface-50/50 text-surface-600 hover:border-surface-300 hover:bg-surface-50 dark:border-surface-700/80 dark:bg-surface-800/40 dark:text-surface-300 dark:hover:border-surface-600 dark:hover:bg-surface-800'"
@@ -1130,6 +1175,19 @@ function closeDocPreview() {
                 v-if="showFilterPanel"
                 class="rounded-lg border border-white/12 bg-white/[0.025] p-2.5 space-y-2.5"
               >
+                <!-- Candidate filter -->
+                <div>
+                  <p class="mb-1 text-[10px] font-semibold uppercase tracking-wider text-surface-400 dark:text-surface-500">Candidate</p>
+                  <GooeySearchInput
+                    v-model="candidateSearch"
+                    aria-label="Search candidates"
+                    class="w-full"
+                    placeholder="Filter by name or email…"
+                    reserve-expanded-space
+                    size="sm"
+                  />
+                </div>
+
                 <!-- Score filter -->
                 <div>
                   <p class="text-[10px] font-semibold uppercase tracking-wider text-surface-400 dark:text-surface-500 mb-1">Score</p>
@@ -1193,7 +1251,7 @@ function closeDocPreview() {
           <div class="shrink-0 px-3.5 pb-2 flex items-center justify-between">
             <span class="text-xs font-medium text-surface-500 dark:text-surface-400">
               {{ filteredApplications.length }} candidate{{ filteredApplications.length === 1 ? '' : 's' }}
-              <span v-if="searchTerm.trim() || hasActiveFilters" class="text-surface-400 dark:text-surface-500">
+              <span v-if="debouncedApplicationSearch || hasActiveFilters" class="text-surface-400 dark:text-surface-500">
                 {{ hasActiveFilters ? ' filtered' : ' matching' }}
               </span>
             </span>
@@ -1275,7 +1333,7 @@ function closeDocPreview() {
               <UserRound class="size-7 text-surface-400 dark:text-surface-500" />
             </div>
             <p class="flex flex-wrap items-center justify-center gap-2 text-base font-semibold text-surface-700 dark:text-surface-200">
-              <span>No candidates in</span>
+              <span>{{ debouncedApplicationSearch ? 'No matching applications in' : 'No candidates in' }}</span>
               <span
                 class="factory-pipeline-empty-status-chip ui-filter-chip factory-pipeline-status-chip inline-flex h-8 min-h-8 items-center gap-2 px-3 text-xs !font-light uppercase leading-none tracking-normal"
                 :class="[`factory-pipeline-status-chip-${focusStatus}`]"
@@ -1293,7 +1351,9 @@ function closeDocPreview() {
               </span>
             </p>
             <p class="mt-1.5 text-sm text-surface-500 dark:text-surface-400 max-w-xs">
-              Switch to another pipeline stage to review candidates.
+              {{ debouncedApplicationSearch
+                ? 'Try another search or select a pipeline stage with matches.'
+                : 'Switch to another pipeline stage to review candidates.' }}
             </p>
           </div>
 

--- a/packages/careers-cli/src/commands/applications.ts
+++ b/packages/careers-cli/src/commands/applications.ts
@@ -13,6 +13,22 @@ export function registerApplicationsCommands(program: Command, runtime: CliRunti
     description: 'List applications',
     method: 'GET',
     path: '/api/applications',
+    options: [
+      { flags: '--page <number>', description: 'Page number' },
+      { flags: '--limit <number>', description: 'Page size' },
+      { flags: '--job-id <id>', description: 'Filter by job ID' },
+      { flags: '--candidate-id <id>', description: 'Filter by candidate ID' },
+      { flags: '--status <status>', description: 'Filter by pipeline status' },
+      { flags: '--search <query>', description: 'Search application content, including resumes' },
+    ],
+    query: (options) => ({
+      page: options.page as string | undefined,
+      limit: options.limit as string | undefined,
+      jobId: options.jobId as string | undefined,
+      candidateId: options.candidateId as string | undefined,
+      status: options.status as string | undefined,
+      search: options.search as string | undefined,
+    }),
   })
 
   registerJsonCommand(runtime, applications, {

--- a/server/api/applications/index.get.ts
+++ b/server/api/applications/index.get.ts
@@ -1,6 +1,6 @@
-import { eq, and, desc, inArray } from 'drizzle-orm'
+import { and, desc, eq, inArray, sql } from 'drizzle-orm'
 import type { z } from 'zod'
-import { application, candidate, job } from '../../database/schema'
+import { application, applicationSearchDocument, candidate, job } from '../../database/schema'
 import {
   paginatedListResponse,
   paginationOffset,
@@ -11,11 +11,12 @@ import {
   matchingEntityIdsForPropertyFilters,
   parsePropertyFiltersParam,
 } from '../../utils/propertyFilters'
+import { applicationContentSearchCondition } from '../../utils/applicationSearch'
 
 /**
  * GET /api/applications
  * List applications for the current organization.
- * Filterable by jobId, candidateId, status, and custom property filters. Paginated.
+ * Filterable by jobId, candidateId, status, full application content, and custom properties. Paginated.
  */
 const getCachedApplications = defineOrgScopedCachedFunction(
   'applications-list',
@@ -32,6 +33,10 @@ const getCachedApplications = defineOrgScopedCachedFunction(
     if (query.status) {
       conditions.push(eq(application.status, query.status))
     }
+    if (query.search) {
+      const searchCondition = applicationContentSearchCondition(query.search, orgId)
+      if (searchCondition) conditions.push(searchCondition)
+    }
 
     const propertyFilters = parsePropertyFiltersParam(query.propertyFilters)
     if (propertyFilters.length > 0) {
@@ -47,33 +52,66 @@ const getCachedApplications = defineOrgScopedCachedFunction(
     }
 
     const where = and(...conditions)
+    const rows = await db
+      .select({
+        id: application.id,
+        status: application.status,
+        score: application.score,
+        notes: application.notes,
+        createdAt: application.createdAt,
+        updatedAt: application.updatedAt,
+        candidateId: application.candidateId,
+        candidateFirstName: candidate.firstName,
+        candidateLastName: candidate.lastName,
+        candidateEmail: candidate.email,
+        jobId: application.jobId,
+        jobTitle: job.title,
+        jobStatus: job.status,
+        totalCount: sql<number>`count(*) over()::int`,
+      })
+      .from(application)
+      .innerJoin(candidate, and(
+        eq(candidate.id, application.candidateId),
+        eq(candidate.organizationId, orgId),
+      ))
+      .innerJoin(job, and(
+        eq(job.id, application.jobId),
+        eq(job.organizationId, orgId),
+      ))
+      .leftJoin(applicationSearchDocument, and(
+        eq(applicationSearchDocument.applicationId, application.id),
+        eq(applicationSearchDocument.organizationId, orgId),
+      ))
+      .where(where)
+      .orderBy(desc(application.createdAt))
+      .limit(query.limit)
+      .offset(offset)
 
-    const [data, total] = await Promise.all([
-      db
-        .select({
-          id: application.id,
-          status: application.status,
-          score: application.score,
-          notes: application.notes,
-          createdAt: application.createdAt,
-          updatedAt: application.updatedAt,
-          candidateId: application.candidateId,
-          candidateFirstName: candidate.firstName,
-          candidateLastName: candidate.lastName,
-          candidateEmail: candidate.email,
-          jobId: application.jobId,
-          jobTitle: job.title,
-          jobStatus: job.status,
-        })
+    // A window count avoids re-running the content search for every normal page.
+    // Preserve the paginated API contract for an out-of-range page with one
+    // fallback count query, a path the pipeline never uses.
+    let total = rows[0]?.totalCount ?? 0
+    if (rows.length === 0 && query.page > 1) {
+      const [fallbackTotal] = await db
+        .select({ count: sql<number>`count(*)::int` })
         .from(application)
-        .innerJoin(candidate, eq(candidate.id, application.candidateId))
-        .innerJoin(job, eq(job.id, application.jobId))
+        .innerJoin(candidate, and(
+          eq(candidate.id, application.candidateId),
+          eq(candidate.organizationId, orgId),
+        ))
+        .innerJoin(job, and(
+          eq(job.id, application.jobId),
+          eq(job.organizationId, orgId),
+        ))
+        .leftJoin(applicationSearchDocument, and(
+          eq(applicationSearchDocument.applicationId, application.id),
+          eq(applicationSearchDocument.organizationId, orgId),
+        ))
         .where(where)
-        .orderBy(desc(application.createdAt))
-        .limit(query.limit)
-        .offset(offset),
-      db.$count(application, where),
-    ])
+      total = fallbackTotal?.count ?? 0
+    }
+
+    const data = rows.map(({ totalCount: _totalCount, ...row }) => row)
 
     // Bulk-attach properties for the current page (org-global + per-job)
     const ids = data.map(a => a.id)

--- a/server/database/migrations/0053_application_search_document.sql
+++ b/server/database/migrations/0053_application_search_document.sql
@@ -1,0 +1,411 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE TABLE "application_search_document" (
+  "application_id" text PRIMARY KEY NOT NULL REFERENCES "application"("id") ON DELETE cascade,
+  "organization_id" text NOT NULL REFERENCES "organization"("id") ON DELETE cascade,
+  "job_id" text NOT NULL REFERENCES "job"("id") ON DELETE cascade,
+  "candidate_id" text NOT NULL REFERENCES "candidate"("id") ON DELETE cascade,
+  "search_text" text NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX "application_search_document_org_idx"
+  ON "application_search_document" USING btree ("organization_id");
+CREATE INDEX "application_search_document_job_idx"
+  ON "application_search_document" USING btree ("job_id");
+CREATE INDEX "application_search_document_candidate_idx"
+  ON "application_search_document" USING btree ("candidate_id");
+
+-- Rebuild one application's denormalized recruiter-search document. Voluntary
+-- compliance/self-identification responses are deliberately not included.
+CREATE OR REPLACE FUNCTION refresh_application_search_document(target_application_id text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  INSERT INTO application_search_document (
+    application_id,
+    organization_id,
+    job_id,
+    candidate_id,
+    search_text,
+    updated_at
+  )
+  SELECT
+    a.id,
+    a.organization_id,
+    a.job_id,
+    a.candidate_id,
+    btrim(concat_ws(' ',
+      a.id, a.organization_id, a.candidate_id, a.job_id, a.status, a.score,
+      a.notes, a.cover_letter_text, a.created_at, a.updated_at,
+      c.id, c.first_name, c.last_name, c.display_name, c.email, c.phone,
+      c.country, c.state, c.date_of_birth, c.gender, c.quick_notes,
+      c.created_at, c.updated_at,
+      j.id, j.title, j.slug,
+      (
+        SELECT string_agg(concat_ws(' ',
+          d.id, d.type, d.original_filename, d.mime_type, d.size_bytes,
+          d.parsed_content::text, d.created_at
+        ), ' ')
+        FROM document d
+        WHERE d.organization_id = a.organization_id
+          AND d.candidate_id = a.candidate_id
+      ),
+      (
+        SELECT string_agg(concat_ws(' ',
+          qr.id, jq.id, jq.type, jq.label, jq.description, jq.options::text,
+          qr.value::text, qr.created_at
+        ), ' ')
+        FROM question_response qr
+        INNER JOIN job_question jq
+          ON jq.id = qr.question_id
+          AND jq.organization_id = a.organization_id
+        WHERE qr.organization_id = a.organization_id
+          AND qr.application_id = a.id
+      ),
+      (
+        SELECT string_agg(concat_ws(' ',
+          pv.id, pd.id, pd.job_id, pd.entity_type, pd.type, pd.name,
+          pd.description, pd.config::text, pv.value::text,
+          pv.created_at, pv.updated_at
+        ), ' ')
+        FROM property_value pv
+        INNER JOIN property_definition pd
+          ON pd.id = pv.property_definition_id
+          AND pd.organization_id = a.organization_id
+        WHERE pv.organization_id = a.organization_id
+          AND (
+            (pv.entity_type = 'application' AND pv.entity_id = a.id)
+            OR (pv.entity_type = 'candidate' AND pv.entity_id = a.candidate_id)
+          )
+      ),
+      (
+        SELECT string_agg(concat_ws(' ',
+          i.id, i.title, i.type, i.status, i.scheduled_at, i.duration,
+          i.location, i.notes, i.interviewers::text, i.invitation_sent_at,
+          i.candidate_response, i.candidate_responded_at,
+          i.calendar_event_provider, i.google_calendar_event_id,
+          i.google_calendar_event_link, i.timezone, i.created_at, i.updated_at
+        ), ' ')
+        FROM interview i
+        WHERE i.organization_id = a.organization_id
+          AND i.application_id = a.id
+      ),
+      (
+        SELECT string_agg(concat_ws(' ', cm.id, cm.body, cm.created_at, cm.updated_at), ' ')
+        FROM comment cm
+        WHERE cm.organization_id = a.organization_id
+          AND (
+            (cm.target_type = 'application' AND cm.target_id = a.id)
+            OR (cm.target_type = 'candidate' AND cm.target_id = a.candidate_id)
+          )
+      ),
+      (
+        SELECT string_agg(concat_ws(' ',
+          cs.id, cs.criterion_key, sc.name, sc.description, sc.category,
+          sc.max_score, sc.weight, cs.max_score, cs.applicant_score,
+          cs.confidence, cs.evidence, cs.strengths::text, cs.gaps::text,
+          cs.created_at
+        ), ' ')
+        FROM criterion_score cs
+        LEFT JOIN scoring_criterion sc
+          ON sc.organization_id = a.organization_id
+          AND sc.job_id = a.job_id
+          AND sc.key = cs.criterion_key
+        WHERE cs.organization_id = a.organization_id
+          AND cs.application_id = a.id
+      ),
+      (
+        SELECT string_agg(concat_ws(' ',
+          ar.id, ar.status, ar.provider, ar.model, ar.criteria_snapshot::text,
+          ar.composite_score, ar.raw_response::text, ar.error_message, ar.created_at
+        ), ' ')
+        FROM analysis_run ar
+        WHERE ar.organization_id = a.organization_id
+          AND ar.application_id = a.id
+      ),
+      (
+        SELECT string_agg(concat_ws(' ',
+          arcs.id, arcs.criterion_key, arcs.max_score, arcs.applicant_score,
+          arcs.confidence, arcs.evidence, arcs.strengths::text,
+          arcs.gaps::text, arcs.created_at
+        ), ' ')
+        FROM analysis_run_criterion_score arcs
+        WHERE arcs.organization_id = a.organization_id
+          AND arcs.application_id = a.id
+      ),
+      (
+        SELECT string_agg(concat_ws(' ',
+          arf.id, arf.sentiment, arf.comment, arf.created_at
+        ), ' ')
+        FROM analysis_run_feedback arf
+        WHERE arf.organization_id = a.organization_id
+          AND arf.application_id = a.id
+      ),
+      (
+        SELECT string_agg(concat_ws(' ',
+          aps.id, aps.channel, aps.utm_source, aps.utm_medium,
+          aps.utm_campaign, aps.utm_term, aps.utm_content,
+          aps.referrer_domain, aps.created_at, tl.id, tl.job_id, tl.channel,
+          tl.name, tl.code, tl.utm_source, tl.utm_medium, tl.utm_campaign,
+          tl.utm_term, tl.utm_content
+        ), ' ')
+        FROM application_source aps
+        LEFT JOIN tracking_link tl
+          ON tl.id = aps.tracking_link_id
+          AND tl.organization_id = a.organization_id
+        WHERE aps.organization_id = a.organization_id
+          AND aps.application_id = a.id
+      )
+    )),
+    now()
+  FROM application a
+  INNER JOIN candidate c
+    ON c.id = a.candidate_id
+    AND c.organization_id = a.organization_id
+  INNER JOIN job j
+    ON j.id = a.job_id
+    AND j.organization_id = a.organization_id
+  WHERE a.id = target_application_id
+  ON CONFLICT (application_id) DO UPDATE SET
+    organization_id = EXCLUDED.organization_id,
+    job_id = EXCLUDED.job_id,
+    candidate_id = EXCLUDED.candidate_id,
+    search_text = EXCLUDED.search_text,
+    updated_at = EXCLUDED.updated_at;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION refresh_application_search_for_candidate(target_candidate_id text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  target_id text;
+BEGIN
+  FOR target_id IN
+    SELECT id FROM application WHERE candidate_id = target_candidate_id
+  LOOP
+    PERFORM refresh_application_search_document(target_id);
+  END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION refresh_application_search_for_job(target_job_id text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  target_id text;
+BEGIN
+  FOR target_id IN
+    SELECT id FROM application WHERE job_id = target_job_id
+  LOOP
+    PERFORM refresh_application_search_document(target_id);
+  END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION refresh_application_search_for_entity(
+  target_entity_type text,
+  target_entity_id text
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF target_entity_type = 'application' THEN
+    PERFORM refresh_application_search_document(target_entity_id);
+  ELSIF target_entity_type = 'candidate' THEN
+    PERFORM refresh_application_search_for_candidate(target_entity_id);
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION refresh_application_search_for_property_definition(target_definition_id text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  property_record record;
+BEGIN
+  FOR property_record IN
+    SELECT DISTINCT entity_type::text AS entity_type, entity_id
+    FROM property_value
+    WHERE property_definition_id = target_definition_id
+  LOOP
+    PERFORM refresh_application_search_for_entity(property_record.entity_type, property_record.entity_id);
+  END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION refresh_application_search_for_tracking_link(target_tracking_link_id text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  target_id text;
+BEGIN
+  FOR target_id IN
+    SELECT application_id
+    FROM application_source
+    WHERE tracking_link_id = target_tracking_link_id
+  LOOP
+    PERFORM refresh_application_search_document(target_id);
+  END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION application_search_refresh_trigger()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_TABLE_NAME = 'application' THEN
+    IF TG_OP <> 'DELETE' THEN
+      PERFORM refresh_application_search_document(NEW.id);
+    END IF;
+  ELSIF TG_TABLE_NAME = 'candidate' THEN
+    IF TG_OP <> 'INSERT' THEN
+      PERFORM refresh_application_search_for_candidate(OLD.id);
+    END IF;
+    IF TG_OP <> 'DELETE' AND (TG_OP <> 'UPDATE' OR NEW.id IS DISTINCT FROM OLD.id) THEN
+      PERFORM refresh_application_search_for_candidate(NEW.id);
+    END IF;
+  ELSIF TG_TABLE_NAME = 'document' THEN
+    IF TG_OP <> 'INSERT' THEN
+      PERFORM refresh_application_search_for_candidate(OLD.candidate_id);
+    END IF;
+    IF TG_OP <> 'DELETE' AND (TG_OP <> 'UPDATE' OR NEW.candidate_id IS DISTINCT FROM OLD.candidate_id) THEN
+      PERFORM refresh_application_search_for_candidate(NEW.candidate_id);
+    END IF;
+  ELSIF TG_TABLE_NAME = 'job' THEN
+    IF TG_OP = 'DELETE' THEN
+      PERFORM refresh_application_search_for_job(OLD.id);
+    ELSE
+      PERFORM refresh_application_search_for_job(NEW.id);
+      IF TG_OP = 'UPDATE' AND NEW.id IS DISTINCT FROM OLD.id THEN
+        PERFORM refresh_application_search_for_job(OLD.id);
+      END IF;
+    END IF;
+  ELSIF TG_TABLE_NAME IN ('job_question', 'scoring_criterion') THEN
+    IF TG_OP = 'DELETE' THEN
+      PERFORM refresh_application_search_for_job(OLD.job_id);
+    ELSE
+      PERFORM refresh_application_search_for_job(NEW.job_id);
+      IF TG_OP = 'UPDATE' AND NEW.job_id IS DISTINCT FROM OLD.job_id THEN
+        PERFORM refresh_application_search_for_job(OLD.job_id);
+      END IF;
+    END IF;
+  ELSIF TG_TABLE_NAME IN (
+    'question_response', 'interview', 'criterion_score',
+    'analysis_run', 'analysis_run_criterion_score', 'analysis_run_feedback',
+    'application_source'
+  ) THEN
+    IF TG_OP <> 'INSERT' THEN
+      PERFORM refresh_application_search_document(OLD.application_id);
+    END IF;
+    IF TG_OP <> 'DELETE' AND (TG_OP <> 'UPDATE' OR NEW.application_id IS DISTINCT FROM OLD.application_id) THEN
+      PERFORM refresh_application_search_document(NEW.application_id);
+    END IF;
+  ELSIF TG_TABLE_NAME = 'comment' THEN
+    IF TG_OP <> 'INSERT' THEN
+      PERFORM refresh_application_search_for_entity(OLD.target_type::text, OLD.target_id);
+    END IF;
+    IF TG_OP <> 'DELETE' AND (
+      TG_OP <> 'UPDATE'
+      OR NEW.target_type IS DISTINCT FROM OLD.target_type
+      OR NEW.target_id IS DISTINCT FROM OLD.target_id
+    ) THEN
+      PERFORM refresh_application_search_for_entity(NEW.target_type::text, NEW.target_id);
+    END IF;
+  ELSIF TG_TABLE_NAME = 'property_value' THEN
+    IF TG_OP <> 'INSERT' THEN
+      PERFORM refresh_application_search_for_entity(OLD.entity_type::text, OLD.entity_id);
+    END IF;
+    IF TG_OP <> 'DELETE' AND (
+      TG_OP <> 'UPDATE'
+      OR NEW.entity_type IS DISTINCT FROM OLD.entity_type
+      OR NEW.entity_id IS DISTINCT FROM OLD.entity_id
+    ) THEN
+      PERFORM refresh_application_search_for_entity(NEW.entity_type::text, NEW.entity_id);
+    END IF;
+  ELSIF TG_TABLE_NAME = 'property_definition' THEN
+    IF TG_OP <> 'INSERT' THEN
+      PERFORM refresh_application_search_for_property_definition(OLD.id);
+    END IF;
+    IF TG_OP <> 'DELETE' AND (TG_OP <> 'UPDATE' OR NEW.id IS DISTINCT FROM OLD.id) THEN
+      PERFORM refresh_application_search_for_property_definition(NEW.id);
+    END IF;
+  ELSIF TG_TABLE_NAME = 'tracking_link' THEN
+    IF TG_OP <> 'INSERT' THEN
+      PERFORM refresh_application_search_for_tracking_link(OLD.id);
+    END IF;
+    IF TG_OP <> 'DELETE' AND (TG_OP <> 'UPDATE' OR NEW.id IS DISTINCT FROM OLD.id) THEN
+      PERFORM refresh_application_search_for_tracking_link(NEW.id);
+    END IF;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER application_search_application_changed
+  AFTER INSERT OR UPDATE OR DELETE ON application
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_candidate_changed
+  AFTER INSERT OR UPDATE OR DELETE ON candidate
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_document_changed
+  AFTER INSERT OR UPDATE OR DELETE ON document
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_job_changed
+  AFTER INSERT OR UPDATE OR DELETE ON job
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_job_question_changed
+  AFTER INSERT OR UPDATE OR DELETE ON job_question
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_question_response_changed
+  AFTER INSERT OR UPDATE OR DELETE ON question_response
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_property_definition_changed
+  AFTER INSERT OR UPDATE OR DELETE ON property_definition
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_property_value_changed
+  AFTER INSERT OR UPDATE OR DELETE ON property_value
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_interview_changed
+  AFTER INSERT OR UPDATE OR DELETE ON interview
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_comment_changed
+  AFTER INSERT OR UPDATE OR DELETE ON comment
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_scoring_criterion_changed
+  AFTER INSERT OR UPDATE OR DELETE ON scoring_criterion
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_criterion_score_changed
+  AFTER INSERT OR UPDATE OR DELETE ON criterion_score
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_analysis_run_changed
+  AFTER INSERT OR UPDATE OR DELETE ON analysis_run
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_analysis_run_criterion_changed
+  AFTER INSERT OR UPDATE OR DELETE ON analysis_run_criterion_score
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_analysis_feedback_changed
+  AFTER INSERT OR UPDATE OR DELETE ON analysis_run_feedback
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_application_source_changed
+  AFTER INSERT OR UPDATE OR DELETE ON application_source
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+CREATE TRIGGER application_search_tracking_link_changed
+  AFTER INSERT OR UPDATE OR DELETE ON tracking_link
+  FOR EACH ROW EXECUTE FUNCTION application_search_refresh_trigger();
+
+-- Backfill before creating the larger GIN index so existing deployments migrate
+-- in one pass without maintaining the index row-by-row.
+SELECT refresh_application_search_document(id) FROM application;
+
+CREATE INDEX "application_search_document_text_trgm_idx"
+  ON "application_search_document" USING gin ("search_text" gin_trgm_ops);

--- a/server/database/migrations/0053_application_search_document.sql
+++ b/server/database/migrations/0053_application_search_document.sql
@@ -16,6 +16,15 @@ CREATE INDEX "application_search_document_job_idx"
 CREATE INDEX "application_search_document_candidate_idx"
   ON "application_search_document" USING btree ("candidate_id");
 
+-- Queue refreshes by transaction so bulk writes rebuild each affected search
+-- document once at commit instead of once per changed source row.
+CREATE TABLE "application_search_refresh_queue" (
+  "transaction_id" bigint NOT NULL,
+  "application_id" text NOT NULL,
+  CONSTRAINT "application_search_refresh_queue_pk"
+    PRIMARY KEY ("transaction_id", "application_id")
+);
+
 -- Rebuild one application's denormalized recruiter-search document. Voluntary
 -- compliance/self-identification responses are deliberately not included.
 CREATE OR REPLACE FUNCTION refresh_application_search_document(target_application_id text)
@@ -51,6 +60,18 @@ BEGIN
         FROM document d
         WHERE d.organization_id = a.organization_id
           AND d.candidate_id = a.candidate_id
+          AND (
+            d.application_id = a.id
+            OR (
+              d.application_id IS NULL
+              AND NOT EXISTS (
+                SELECT 1
+                FROM document associated_document
+                WHERE associated_document.organization_id = a.organization_id
+                  AND associated_document.application_id = a.id
+              )
+            )
+          )
       ),
       (
         SELECT string_agg(concat_ws(' ',
@@ -75,6 +96,7 @@ BEGIN
           ON pd.id = pv.property_definition_id
           AND pd.organization_id = a.organization_id
         WHERE pv.organization_id = a.organization_id
+          AND (pd.job_id IS NULL OR pd.job_id = a.job_id)
           AND (
             (pv.entity_type = 'application' AND pv.entity_id = a.id)
             OR (pv.entity_type = 'candidate' AND pv.entity_id = a.candidate_id)
@@ -177,37 +199,70 @@ BEGIN
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION refresh_application_search_for_candidate(target_candidate_id text)
+CREATE OR REPLACE FUNCTION queue_application_search_document(target_application_id text)
 RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF target_application_id IS NOT NULL THEN
+    INSERT INTO application_search_refresh_queue (transaction_id, application_id)
+    VALUES (txid_current(), target_application_id)
+    ON CONFLICT DO NOTHING;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION flush_application_search_document_queue()
+RETURNS trigger
 LANGUAGE plpgsql
 AS $$
 DECLARE
   target_id text;
 BEGIN
   FOR target_id IN
-    SELECT id FROM application WHERE candidate_id = target_candidate_id
+    DELETE FROM application_search_refresh_queue
+    WHERE transaction_id = NEW.transaction_id
+    RETURNING application_id
   LOOP
     PERFORM refresh_application_search_document(target_id);
   END LOOP;
+
+  RETURN NULL;
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION refresh_application_search_for_job(target_job_id text)
+CREATE CONSTRAINT TRIGGER application_search_refresh_queue_flush
+  AFTER INSERT ON application_search_refresh_queue
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW EXECUTE FUNCTION flush_application_search_document_queue();
+
+CREATE OR REPLACE FUNCTION queue_application_search_for_candidate(target_candidate_id text)
 RETURNS void
 LANGUAGE plpgsql
 AS $$
-DECLARE
-  target_id text;
 BEGIN
-  FOR target_id IN
-    SELECT id FROM application WHERE job_id = target_job_id
-  LOOP
-    PERFORM refresh_application_search_document(target_id);
-  END LOOP;
+  INSERT INTO application_search_refresh_queue (transaction_id, application_id)
+  SELECT txid_current(), id
+  FROM application
+  WHERE candidate_id = target_candidate_id
+  ON CONFLICT DO NOTHING;
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION refresh_application_search_for_entity(
+CREATE OR REPLACE FUNCTION queue_application_search_for_job(target_job_id text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  INSERT INTO application_search_refresh_queue (transaction_id, application_id)
+  SELECT txid_current(), id
+  FROM application
+  WHERE job_id = target_job_id
+  ON CONFLICT DO NOTHING;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION queue_application_search_for_entity(
   target_entity_type text,
   target_entity_id text
 )
@@ -216,44 +271,42 @@ LANGUAGE plpgsql
 AS $$
 BEGIN
   IF target_entity_type = 'application' THEN
-    PERFORM refresh_application_search_document(target_entity_id);
+    PERFORM queue_application_search_document(target_entity_id);
   ELSIF target_entity_type = 'candidate' THEN
-    PERFORM refresh_application_search_for_candidate(target_entity_id);
+    PERFORM queue_application_search_for_candidate(target_entity_id);
   END IF;
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION refresh_application_search_for_property_definition(target_definition_id text)
+CREATE OR REPLACE FUNCTION queue_application_search_for_property_definition(target_definition_id text)
 RETURNS void
 LANGUAGE plpgsql
 AS $$
-DECLARE
-  property_record record;
 BEGIN
-  FOR property_record IN
-    SELECT DISTINCT entity_type::text AS entity_type, entity_id
-    FROM property_value
-    WHERE property_definition_id = target_definition_id
-  LOOP
-    PERFORM refresh_application_search_for_entity(property_record.entity_type, property_record.entity_id);
-  END LOOP;
+  INSERT INTO application_search_refresh_queue (transaction_id, application_id)
+  SELECT DISTINCT txid_current(), a.id
+  FROM property_value pv
+  INNER JOIN application a
+    ON a.organization_id = pv.organization_id
+    AND (
+      (pv.entity_type = 'application' AND pv.entity_id = a.id)
+      OR (pv.entity_type = 'candidate' AND pv.entity_id = a.candidate_id)
+    )
+  WHERE pv.property_definition_id = target_definition_id
+  ON CONFLICT DO NOTHING;
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION refresh_application_search_for_tracking_link(target_tracking_link_id text)
+CREATE OR REPLACE FUNCTION queue_application_search_for_tracking_link(target_tracking_link_id text)
 RETURNS void
 LANGUAGE plpgsql
 AS $$
-DECLARE
-  target_id text;
 BEGIN
-  FOR target_id IN
-    SELECT application_id
-    FROM application_source
-    WHERE tracking_link_id = target_tracking_link_id
-  LOOP
-    PERFORM refresh_application_search_document(target_id);
-  END LOOP;
+  INSERT INTO application_search_refresh_queue (transaction_id, application_id)
+  SELECT txid_current(), application_id
+  FROM application_source
+  WHERE tracking_link_id = target_tracking_link_id
+  ON CONFLICT DO NOTHING;
 END;
 $$;
 
@@ -264,38 +317,38 @@ AS $$
 BEGIN
   IF TG_TABLE_NAME = 'application' THEN
     IF TG_OP <> 'DELETE' THEN
-      PERFORM refresh_application_search_document(NEW.id);
+      PERFORM queue_application_search_document(NEW.id);
     END IF;
   ELSIF TG_TABLE_NAME = 'candidate' THEN
     IF TG_OP <> 'INSERT' THEN
-      PERFORM refresh_application_search_for_candidate(OLD.id);
+      PERFORM queue_application_search_for_candidate(OLD.id);
     END IF;
     IF TG_OP <> 'DELETE' AND (TG_OP <> 'UPDATE' OR NEW.id IS DISTINCT FROM OLD.id) THEN
-      PERFORM refresh_application_search_for_candidate(NEW.id);
+      PERFORM queue_application_search_for_candidate(NEW.id);
     END IF;
   ELSIF TG_TABLE_NAME = 'document' THEN
     IF TG_OP <> 'INSERT' THEN
-      PERFORM refresh_application_search_for_candidate(OLD.candidate_id);
+      PERFORM queue_application_search_for_candidate(OLD.candidate_id);
     END IF;
     IF TG_OP <> 'DELETE' AND (TG_OP <> 'UPDATE' OR NEW.candidate_id IS DISTINCT FROM OLD.candidate_id) THEN
-      PERFORM refresh_application_search_for_candidate(NEW.candidate_id);
+      PERFORM queue_application_search_for_candidate(NEW.candidate_id);
     END IF;
   ELSIF TG_TABLE_NAME = 'job' THEN
     IF TG_OP = 'DELETE' THEN
-      PERFORM refresh_application_search_for_job(OLD.id);
+      PERFORM queue_application_search_for_job(OLD.id);
     ELSE
-      PERFORM refresh_application_search_for_job(NEW.id);
+      PERFORM queue_application_search_for_job(NEW.id);
       IF TG_OP = 'UPDATE' AND NEW.id IS DISTINCT FROM OLD.id THEN
-        PERFORM refresh_application_search_for_job(OLD.id);
+        PERFORM queue_application_search_for_job(OLD.id);
       END IF;
     END IF;
   ELSIF TG_TABLE_NAME IN ('job_question', 'scoring_criterion') THEN
     IF TG_OP = 'DELETE' THEN
-      PERFORM refresh_application_search_for_job(OLD.job_id);
+      PERFORM queue_application_search_for_job(OLD.job_id);
     ELSE
-      PERFORM refresh_application_search_for_job(NEW.job_id);
+      PERFORM queue_application_search_for_job(NEW.job_id);
       IF TG_OP = 'UPDATE' AND NEW.job_id IS DISTINCT FROM OLD.job_id THEN
-        PERFORM refresh_application_search_for_job(OLD.job_id);
+        PERFORM queue_application_search_for_job(OLD.job_id);
       END IF;
     END IF;
   ELSIF TG_TABLE_NAME IN (
@@ -304,46 +357,46 @@ BEGIN
     'application_source'
   ) THEN
     IF TG_OP <> 'INSERT' THEN
-      PERFORM refresh_application_search_document(OLD.application_id);
+      PERFORM queue_application_search_document(OLD.application_id);
     END IF;
     IF TG_OP <> 'DELETE' AND (TG_OP <> 'UPDATE' OR NEW.application_id IS DISTINCT FROM OLD.application_id) THEN
-      PERFORM refresh_application_search_document(NEW.application_id);
+      PERFORM queue_application_search_document(NEW.application_id);
     END IF;
   ELSIF TG_TABLE_NAME = 'comment' THEN
     IF TG_OP <> 'INSERT' THEN
-      PERFORM refresh_application_search_for_entity(OLD.target_type::text, OLD.target_id);
+      PERFORM queue_application_search_for_entity(OLD.target_type::text, OLD.target_id);
     END IF;
     IF TG_OP <> 'DELETE' AND (
       TG_OP <> 'UPDATE'
       OR NEW.target_type IS DISTINCT FROM OLD.target_type
       OR NEW.target_id IS DISTINCT FROM OLD.target_id
     ) THEN
-      PERFORM refresh_application_search_for_entity(NEW.target_type::text, NEW.target_id);
+      PERFORM queue_application_search_for_entity(NEW.target_type::text, NEW.target_id);
     END IF;
   ELSIF TG_TABLE_NAME = 'property_value' THEN
     IF TG_OP <> 'INSERT' THEN
-      PERFORM refresh_application_search_for_entity(OLD.entity_type::text, OLD.entity_id);
+      PERFORM queue_application_search_for_entity(OLD.entity_type::text, OLD.entity_id);
     END IF;
     IF TG_OP <> 'DELETE' AND (
       TG_OP <> 'UPDATE'
       OR NEW.entity_type IS DISTINCT FROM OLD.entity_type
       OR NEW.entity_id IS DISTINCT FROM OLD.entity_id
     ) THEN
-      PERFORM refresh_application_search_for_entity(NEW.entity_type::text, NEW.entity_id);
+      PERFORM queue_application_search_for_entity(NEW.entity_type::text, NEW.entity_id);
     END IF;
   ELSIF TG_TABLE_NAME = 'property_definition' THEN
     IF TG_OP <> 'INSERT' THEN
-      PERFORM refresh_application_search_for_property_definition(OLD.id);
+      PERFORM queue_application_search_for_property_definition(OLD.id);
     END IF;
     IF TG_OP <> 'DELETE' AND (TG_OP <> 'UPDATE' OR NEW.id IS DISTINCT FROM OLD.id) THEN
-      PERFORM refresh_application_search_for_property_definition(NEW.id);
+      PERFORM queue_application_search_for_property_definition(NEW.id);
     END IF;
   ELSIF TG_TABLE_NAME = 'tracking_link' THEN
     IF TG_OP <> 'INSERT' THEN
-      PERFORM refresh_application_search_for_tracking_link(OLD.id);
+      PERFORM queue_application_search_for_tracking_link(OLD.id);
     END IF;
     IF TG_OP <> 'DELETE' AND (TG_OP <> 'UPDATE' OR NEW.id IS DISTINCT FROM OLD.id) THEN
-      PERFORM refresh_application_search_for_tracking_link(NEW.id);
+      PERFORM queue_application_search_for_tracking_link(NEW.id);
     END IF;
   END IF;
 

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1784203200000,
       "tag": "0052_job_valid_through_end_of_day",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1784206800000,
+      "tag": "0053_application_search_document",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database/schema/app.ts
+++ b/server/database/schema/app.ts
@@ -8,6 +8,8 @@ import {
   pgEnum,
   index,
   uniqueIndex,
+  bigint,
+  primaryKey,
   numeric,
 } from 'drizzle-orm/pg-core'
 import { relations, sql } from 'drizzle-orm'
@@ -208,6 +210,14 @@ export const applicationSearchDocument = pgTable('application_search_document', 
   index('application_search_document_org_idx').on(t.organizationId),
   index('application_search_document_job_idx').on(t.jobId),
   index('application_search_document_candidate_idx').on(t.candidateId),
+]))
+
+/** Transaction-local work queue used to deduplicate search-document refreshes. */
+export const applicationSearchRefreshQueue = pgTable('application_search_refresh_queue', {
+  transactionId: bigint('transaction_id', { mode: 'bigint' }).notNull(),
+  applicationId: text('application_id').notNull(),
+}, (t) => ([
+  primaryKey({ columns: [t.transactionId, t.applicationId] }),
 ]))
 
 // ─────────────────────────────────────────────

--- a/server/database/schema/app.ts
+++ b/server/database/schema/app.ts
@@ -193,6 +193,23 @@ export const document = pgTable('document', {
   index('document_application_id_idx').on(t.applicationId),
 ]))
 
+/**
+ * Denormalized, trigger-maintained application content used by recruiter search.
+ * The database migration owns the refresh functions and trigram index.
+ */
+export const applicationSearchDocument = pgTable('application_search_document', {
+  applicationId: text('application_id').primaryKey().references(() => application.id, { onDelete: 'cascade' }),
+  organizationId: text('organization_id').notNull().references(() => organization.id, { onDelete: 'cascade' }),
+  jobId: text('job_id').notNull().references(() => job.id, { onDelete: 'cascade' }),
+  candidateId: text('candidate_id').notNull().references(() => candidate.id, { onDelete: 'cascade' }),
+  searchText: text('search_text').notNull(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+}, (t) => ([
+  index('application_search_document_org_idx').on(t.organizationId),
+  index('application_search_document_job_idx').on(t.jobId),
+  index('application_search_document_candidate_idx').on(t.candidateId),
+]))
+
 // ─────────────────────────────────────────────
 // Custom Application Form Questions
 // ─────────────────────────────────────────────

--- a/server/utils/applicationSearch.ts
+++ b/server/utils/applicationSearch.ts
@@ -1,0 +1,20 @@
+import { sql, type SQL } from 'drizzle-orm'
+import { applicationSearchDocument } from '../database/schema'
+
+/** Escape PostgreSQL LIKE metacharacters before wrapping a search term in `%`. */
+export function applicationSearchPattern(search: string): string | null {
+  const normalized = search.trim()
+  if (!normalized) return null
+  return `%${normalized.replace(/[%_\\]/g, '\\$&')}%`
+}
+
+/** Build the indexed, tenant-scoped application-content search predicate. */
+export function applicationContentSearchCondition(search: string, organizationId: string): SQL | undefined {
+  const pattern = applicationSearchPattern(search)
+  if (!pattern) return undefined
+
+  return sql`(
+    ${applicationSearchDocument.organizationId} = ${organizationId}
+    AND ${applicationSearchDocument.searchText} ILIKE ${pattern} ESCAPE '\\'
+  )`
+}

--- a/server/utils/applicationSearch.ts
+++ b/server/utils/applicationSearch.ts
@@ -1,10 +1,10 @@
-import { sql, type SQL } from 'drizzle-orm'
+import { and, eq, ilike, type SQL } from 'drizzle-orm'
 import { applicationSearchDocument } from '../database/schema'
 
 /** Escape PostgreSQL LIKE metacharacters before wrapping a search term in `%`. */
 export function applicationSearchPattern(search: string): string | null {
   const normalized = search.trim()
-  if (!normalized) return null
+  if (normalized.length < 3) return null
   return `%${normalized.replace(/[%_\\]/g, '\\$&')}%`
 }
 
@@ -13,8 +13,8 @@ export function applicationContentSearchCondition(search: string, organizationId
   const pattern = applicationSearchPattern(search)
   if (!pattern) return undefined
 
-  return sql`(
-    ${applicationSearchDocument.organizationId} = ${organizationId}
-    AND ${applicationSearchDocument.searchText} ILIKE ${pattern} ESCAPE '\\'
-  )`
+  return and(
+    eq(applicationSearchDocument.organizationId, organizationId),
+    ilike(applicationSearchDocument.searchText, pattern),
+  )
 }

--- a/server/utils/schemas/application.ts
+++ b/server/utils/schemas/application.ts
@@ -28,7 +28,7 @@ export const applicationQuerySchema = paginationQuerySchema().extend({
   candidateId: z.string().min(1).optional(),
   status: z.enum(APPLICATION_STATUSES).optional(),
   /** Full application-content search, including parsed candidate documents. */
-  search: z.string().trim().max(200).optional(),
+  search: z.string().trim().min(3, 'Search must be at least 3 characters').max(200).optional(),
   /** JSON-encoded array of { propertyDefinitionId, op, value } filters */
   propertyFilters: z.string().optional(),
 })

--- a/server/utils/schemas/application.ts
+++ b/server/utils/schemas/application.ts
@@ -27,6 +27,8 @@ export const applicationQuerySchema = paginationQuerySchema().extend({
   jobId: z.string().min(1).optional(),
   candidateId: z.string().min(1).optional(),
   status: z.enum(APPLICATION_STATUSES).optional(),
+  /** Full application-content search, including parsed candidate documents. */
+  search: z.string().trim().max(200).optional(),
   /** JSON-encoded array of { propertyDefinitionId, op, value } filters */
   propertyFilters: z.string().optional(),
 })

--- a/shared/pagination.ts
+++ b/shared/pagination.ts
@@ -1,0 +1,16 @@
+/** Build bounded-concurrency batches for every API page after page one. */
+export function remainingPageBatches(total: number, limit: number, concurrency = 4): number[][] {
+  if (total <= limit || limit <= 0 || concurrency <= 0) return []
+
+  const remainingPages = Array.from(
+    { length: Math.ceil(total / limit) - 1 },
+    (_, index) => index + 2,
+  )
+  const batches: number[][] = []
+
+  for (let index = 0; index < remainingPages.length; index += concurrency) {
+    batches.push(remainingPages.slice(index, index + concurrency))
+  }
+
+  return batches
+}

--- a/shared/pagination.ts
+++ b/shared/pagination.ts
@@ -1,6 +1,15 @@
 /** Build bounded-concurrency batches for every API page after page one. */
 export function remainingPageBatches(total: number, limit: number, concurrency = 4): number[][] {
-  if (total <= limit || limit <= 0 || concurrency <= 0) return []
+  const batchSize = Math.floor(concurrency)
+  if (
+    !Number.isFinite(total)
+    || !Number.isFinite(limit)
+    || !Number.isFinite(concurrency)
+    || total <= 0
+    || limit <= 0
+    || batchSize <= 0
+    || total <= limit
+  ) return []
 
   const remainingPages = Array.from(
     { length: Math.ceil(total / limit) - 1 },
@@ -8,8 +17,8 @@ export function remainingPageBatches(total: number, limit: number, concurrency =
   )
   const batches: number[][] = []
 
-  for (let index = 0; index < remainingPages.length; index += concurrency) {
-    batches.push(remainingPages.slice(index, index + concurrency))
+  for (let index = 0; index < remainingPages.length; index += batchSize) {
+    batches.push(remainingPages.slice(index, index + batchSize))
   }
 
   return batches

--- a/tests/unit/application-content-search.test.ts
+++ b/tests/unit/application-content-search.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { describe, expect, it } from 'vitest'
+import {
+  applicationContentSearchCondition,
+  applicationSearchPattern,
+} from '../../server/utils/applicationSearch'
+import { applicationQuerySchema } from '../../server/utils/schemas/application'
+import { remainingPageBatches } from '../../shared/pagination'
+
+const readProjectFile = (path: string) => readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('application content search', () => {
+  it('normalizes validated search input and escapes LIKE metacharacters', () => {
+    expect(applicationQuerySchema.parse({ search: '  product designer  ' }).search).toBe('product designer')
+    expect(applicationSearchPattern('  100%_remote\\role  ')).toBe('%100\\%\\_remote\\\\role%')
+    expect(applicationSearchPattern('   ')).toBeNull()
+    expect(() => applicationQuerySchema.parse({ search: 'x'.repeat(201) })).toThrow()
+  })
+
+  it('compiles an indexed, tenant-scoped application search predicate', () => {
+    const source = readProjectFile('server/utils/applicationSearch.ts')
+    const route = readProjectFile('server/api/applications/index.get.ts')
+    const migration = readProjectFile('server/database/migrations/0049_application_search_document.sql')
+    const condition = applicationContentSearchCondition('quantum upholstery', 'org_search')
+    const compiled = new PgDialect().sqlToQuery(condition!)
+
+    expect(route).toContain('applicationContentSearchCondition(query.search, orgId)')
+    expect(route).toContain('eq(candidate.organizationId, orgId)')
+    expect(route).toContain('eq(job.organizationId, orgId)')
+    expect(route).toContain('count(*) over()::int')
+    expect(source).toContain('${applicationSearchDocument.searchText} ILIKE')
+    expect(compiled.sql).toContain('"application_search_document"."search_text" ILIKE')
+    expect(compiled.params).toEqual(['org_search', '%quantum upholstery%'])
+    expect(migration).toContain('gin_trgm_ops')
+    expect(migration).toContain('d.parsed_content::text')
+    expect(migration).toContain('CREATE TRIGGER application_search_document_changed')
+    expect(migration).toContain('CREATE TRIGGER application_search_analysis_feedback_changed')
+    expect(migration).not.toContain('application_compliance_response')
+  })
+
+  it('loads every page in bounded batches instead of stopping at 100 applications', () => {
+    expect(remainingPageBatches(100, 100)).toEqual([])
+    expect(remainingPageBatches(250, 100)).toEqual([[2, 3]])
+    expect(remainingPageBatches(1_001, 100)).toEqual([
+      [2, 3, 4, 5],
+      [6, 7, 8, 9],
+      [10, 11],
+    ])
+
+    const composable = readProjectFile('app/composables/useApplications.ts')
+    const page = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+    expect(composable).toContain('remainingPageBatches(firstPage.total, firstPage.limit)')
+    expect(page).toContain('allPages: true')
+  })
+
+  it('places broad application search above the pipeline and candidate search inside filters', () => {
+    const page = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
+    const broadSearch = page.indexOf('aria-label="Search application content"')
+    const threePanelLayout = page.indexOf('<!-- THREE-PANEL LAYOUT')
+    const filterPanel = page.indexOf('<!-- Filter panel -->')
+    const candidateSearch = page.indexOf('aria-label="Search candidates"')
+
+    expect(broadSearch).toBeGreaterThan(-1)
+    expect(broadSearch).toBeLessThan(threePanelLayout)
+    expect(candidateSearch).toBeGreaterThan(filterPanel)
+    expect(page).toContain('search: debouncedApplicationSearch')
+    expect(page).toContain('placeholder="Filter by name or email…"')
+    expect(page).not.toContain('v-model="searchTerm"')
+  })
+})

--- a/tests/unit/application-content-search.test.ts
+++ b/tests/unit/application-content-search.test.ts
@@ -16,13 +16,15 @@ describe('application content search', () => {
     expect(applicationQuerySchema.parse({ search: '  product designer  ' }).search).toBe('product designer')
     expect(applicationSearchPattern('  100%_remote\\role  ')).toBe('%100\\%\\_remote\\\\role%')
     expect(applicationSearchPattern('   ')).toBeNull()
+    expect(applicationSearchPattern('ab')).toBeNull()
+    expect(() => applicationQuerySchema.parse({ search: 'ab' })).toThrow('Search must be at least 3 characters')
     expect(() => applicationQuerySchema.parse({ search: 'x'.repeat(201) })).toThrow()
   })
 
   it('compiles an indexed, tenant-scoped application search predicate', () => {
     const source = readProjectFile('server/utils/applicationSearch.ts')
     const route = readProjectFile('server/api/applications/index.get.ts')
-    const migration = readProjectFile('server/database/migrations/0049_application_search_document.sql')
+    const migration = readProjectFile('server/database/migrations/0053_application_search_document.sql')
     const condition = applicationContentSearchCondition('quantum upholstery', 'org_search')
     const compiled = new PgDialect().sqlToQuery(condition!)
 
@@ -30,11 +32,15 @@ describe('application content search', () => {
     expect(route).toContain('eq(candidate.organizationId, orgId)')
     expect(route).toContain('eq(job.organizationId, orgId)')
     expect(route).toContain('count(*) over()::int')
-    expect(source).toContain('${applicationSearchDocument.searchText} ILIKE')
-    expect(compiled.sql).toContain('"application_search_document"."search_text" ILIKE')
+    expect(source).toContain('ilike(applicationSearchDocument.searchText')
+    expect(compiled.sql).toMatch(/"application_search_document"\."search_text" ilike/i)
     expect(compiled.params).toEqual(['org_search', '%quantum upholstery%'])
     expect(migration).toContain('gin_trgm_ops')
     expect(migration).toContain('d.parsed_content::text')
+    expect(migration).toContain('d.application_id = a.id')
+    expect(migration).toContain('pd.job_id IS NULL OR pd.job_id = a.job_id')
+    expect(migration).toContain('CREATE CONSTRAINT TRIGGER application_search_refresh_queue_flush')
+    expect(migration).toContain('ON CONFLICT DO NOTHING')
     expect(migration).toContain('CREATE TRIGGER application_search_document_changed')
     expect(migration).toContain('CREATE TRIGGER application_search_analysis_feedback_changed')
     expect(migration).not.toContain('application_compliance_response')
@@ -42,6 +48,10 @@ describe('application content search', () => {
 
   it('loads every page in bounded batches instead of stopping at 100 applications', () => {
     expect(remainingPageBatches(100, 100)).toEqual([])
+    expect(remainingPageBatches(Number.NaN, 100)).toEqual([])
+    expect(remainingPageBatches(250, Number.NaN)).toEqual([])
+    expect(remainingPageBatches(250, 100, Number.NaN)).toEqual([])
+    expect(remainingPageBatches(250, 100, 0.5)).toEqual([])
     expect(remainingPageBatches(250, 100)).toEqual([[2, 3]])
     expect(remainingPageBatches(1_001, 100)).toEqual([
       [2, 3, 4, 5],
@@ -67,6 +77,7 @@ describe('application content search', () => {
     expect(candidateSearch).toBeGreaterThan(filterPanel)
     expect(page).toContain('search: debouncedApplicationSearch')
     expect(page).toContain('placeholder="Filter by name or email…"')
+    expect(page).toContain('Type 3+ characters')
     expect(page).not.toContain('v-model="searchTerm"')
   })
 })

--- a/tests/unit/cli-applications-commands.test.ts
+++ b/tests/unit/cli-applications-commands.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { runCli } from '../../packages/careers-cli/src/program'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('CLI application commands', () => {
+  it('passes application filters and content search to the list API', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'factory-careers-cli-applications-'))
+    tempDirs.push(dir)
+    const configPath = join(dir, 'config.json')
+    writeFileSync(configPath, JSON.stringify({
+      activeProfile: 'prod',
+      profiles: {
+        prod: { baseUrl: 'https://careers.example.com', token: 'secret-token' },
+      },
+    }))
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe('https://careers.example.com/api/applications?page=2&limit=25&jobId=job_1&candidateId=candidate_1&status=screening&search=quantum+upholstery')
+      expect(init?.method).toBe('GET')
+      expect(init?.headers).toMatchObject({ Authorization: 'Bearer secret-token' })
+      return Response.json({ data: [{ id: 'app_1' }], total: 1, page: 2, limit: 25 })
+    })
+    const stdout: string[] = []
+
+    const exitCode = await runCli([
+      'applications',
+      'list',
+      '--page',
+      '2',
+      '--limit',
+      '25',
+      '--job-id',
+      'job_1',
+      '--candidate-id',
+      'candidate_1',
+      '--status',
+      'screening',
+      '--search',
+      'quantum upholstery',
+      '--config',
+      configPath,
+      '--json',
+    ], {
+      stdout: value => stdout.push(value),
+      stderr: () => {},
+      fetch: fetchMock as typeof fetch,
+    })
+
+    expect(exitCode).toBe(0)
+    expect(JSON.parse(stdout[0])).toEqual({ data: [{ id: 'app_1' }], total: 1, page: 2, limit: 25 })
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/unit/fetch-swr.test.ts
+++ b/tests/unit/fetch-swr.test.ts
@@ -66,10 +66,15 @@ describe('applications cache contract', () => {
   it('routes application cache refreshes through the applications list helper', () => {
     const useApplication = readProjectFile('app/composables/useApplication.ts')
     const useApplicationScoring = readProjectFile('app/composables/useApplicationScoring.ts')
+    const useApplications = readProjectFile('app/composables/useApplications.ts')
 
     expect(useApplication).toContain('refreshApplicationsListCaches')
     expect(useApplicationScoring).toContain('refreshApplicationsListCaches')
     expect(useApplication).not.toContain("refreshNuxtData('applications')")
+    expect(useApplications).toContain("clearNuxtData(key =>")
+    expect(useApplications).toContain('key !== activeKeyToPreserve')
+    expect(useApplications).toContain('refreshApplicationsListCaches(dataKey.value)')
+    expect(useApplications).not.toContain('Promise.all(refreshKeys.map')
   })
 })
 

--- a/tests/unit/fetch-swr.test.ts
+++ b/tests/unit/fetch-swr.test.ts
@@ -58,7 +58,9 @@ describe('applications cache contract', () => {
     expect(useApplications).toContain('getSwrCachedData')
     expect(useApplications).toContain('watchFetchSwrStamp')
     expect(useApplications).not.toContain("key: 'applications'")
-    expect(useApplications).toMatch(/key:\s*computed\(\(\)\s*=>\s*applicationsListKey/)
+    expect(useApplications).toContain('const dataKey = computed(() =>')
+    expect(useApplications).toContain('applicationsListKey(query.value)')
+    expect(useApplications).toContain('useAsyncData(dataKey')
   })
 
   it('routes application cache refreshes through the applications list helper', () => {

--- a/tests/unit/job-pipeline-chunk.test.ts
+++ b/tests/unit/job-pipeline-chunk.test.ts
@@ -37,7 +37,7 @@ describe('job pipeline lazy panels', () => {
     const source = readProjectFile('app/pages/dashboard/jobs/[id]/index.vue')
 
     expect(source).toContain('useJob(jobId)')
-    expect(source).toContain('useApplications({ jobId, limit: 100 })')
+    expect(source).toContain('useApplications({ jobId, limit: 100, search: debouncedApplicationSearch, allPages: true })')
     expect(source).toContain('pipeline-application-${currentApplicationId.value}')
     expect(source).toContain('cachedApplication')
   })

--- a/tests/unit/server-helpers-epic7-pr1.test.ts
+++ b/tests/unit/server-helpers-epic7-pr1.test.ts
@@ -36,6 +36,11 @@ describe('paginationQuerySchema', () => {
       limit: 20,
       status: 'screening',
     })
+    expect(applicationQuerySchema.parse({ search: '  portfolio  ' })).toMatchObject({
+      page: 1,
+      limit: 20,
+      search: 'portfolio',
+    })
     expect(jobQuerySchema.parse({ status: 'open', page: '3' })).toEqual({
       page: 3,
       limit: 20,


### PR DESCRIPTION
## Summary

- move broad application-content search above the job pipeline and place candidate name/email search inside the filter panel
- search tenant-scoped application content across candidate data, resumes (including legacy parsed JSON), answers, properties, interviews, comments, sources, tracking metadata, and AI evidence
- remove the 100-candidate cap by loading every result page in bounded-concurrency batches
- maintain a denormalized PostgreSQL search document with transaction-deduplicated trigger refreshes and a trigram GIN index
- expose the same content search through `factory-careers applications list --search`

## Why

The job pipeline search only matched candidate names and the pipeline silently stopped at 100 applications. Expanding the original query directly across every source table would also have created an unindexed correlated scan and repeated the work for the count query.

## User and developer impact

Recruiters can now search the complete application record from a page-level control while candidate-only filtering remains grouped with other candidate filters. The paginated API contract is preserved, CLI parity is maintained, and search remains tenant-scoped. Queries shorter than three characters stay client-side to protect trigram-index performance.

## Verification

- `npm run preflight:pr` — 225 files / 1,334 unit tests, typecheck, CLI smoke, production environment contract, production build, and resume-parser bundle passed
- `npm run check:conventions` — passed
- focused search/CLI/UI tests — 29/29 passed after the final rebase
- disposable PostgreSQL migration, tenant/property scoping, legacy resume, and transaction-deduped trigger smoke — passed
- `EXPLAIN` confirmed the trigram GIN bitmap index scan
- browser QA — full-content resume search, three-character guard, clear-search state, and candidate filter placement passed

<!-- openclaw-review-loop:
channel=codex
agent=codex
sessionKey=
providerThreadId=
origin=external-ui
-->