### PR TITLE
fix: harden organization and public security boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com). Categories: **Add
 ### Fixed
 
 * **analytics:** restrict the PostHog browser proxy to required SDK routes with bounded request and response streaming, safe headers, and separate ingestion and asset rate limits
+* **calendar:** bind delegated integrations to organizations, require organization administrators for shared-calendar changes, protect reconnect races, and retry pending Google webhook setup
+* **compliance:** require organization settings permission and suppress protected-dimension results for cohorts smaller than five
+* **operations:** keep database connection credentials out of Drizzle configuration diagnostics
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com). Categories: **Add
 * **blog:** add Cluster 8 career page articles — pillar (career-page-that-converts) and two supporting articles (career-page-seo, google-for-jobs-structured-data)
 * **blog:** add incoming links to career page content from how-applicant-tracking-systems-work, open-source-applicant-tracking-system, and self-hosted-vs-cloud-ats
 
+### Fixed
+
+* **analytics:** restrict the PostHog browser proxy to required SDK routes with bounded request and response streaming, safe headers, and separate ingestion and asset rate limits
+
 ---
 
 ## [1.4.0](https://github.com/reqcore-inc/reqcore/compare/v1.3.0...v1.4.0) (2026-04-30)

--- a/app/composables/useCalendarIntegration.ts
+++ b/app/composables/useCalendarIntegration.ts
@@ -25,6 +25,10 @@ export interface CalendarStatus {
 }
 
 export function useCalendarIntegration() {
+  const {
+    allowed: canManageCalendar,
+    isLoading: isCalendarPermissionLoading,
+  } = usePermission({ organization: ['update'] })
   const { data, status, error, refresh } = useFetch<CalendarStatus>('/api/calendar/status', {
     key: 'calendar-status',
     headers: useRequestHeaders(['cookie']),
@@ -51,6 +55,8 @@ export function useCalendarIntegration() {
   const isAvailable = computed(() => calendarStatus.value.available)
 
   function connect() {
+    if (!canManageCalendar.value) return
+
     // In application / admin-managed mode, connection is handled purely via server configuration
     // (MICROSOFT_CALENDAR_AUTH_MODE=application). No per-user OAuth flow is needed or allowed.
     if (calendarStatus.value.managedByAdmin || calendarStatus.value.authMode === 'application') return
@@ -61,6 +67,8 @@ export function useCalendarIntegration() {
   }
 
   async function disconnect() {
+    if (!canManageCalendar.value) return
+
     await $fetch('/api/calendar/disconnect', { method: 'POST' })
     await refresh()
   }
@@ -69,6 +77,8 @@ export function useCalendarIntegration() {
     calendarStatus,
     isConnected,
     isAvailable,
+    canManageCalendar,
+    isCalendarPermissionLoading,
     status,
     error,
     refresh,

--- a/app/pages/dashboard/settings/integrations.vue
+++ b/app/pages/dashboard/settings/integrations.vue
@@ -12,7 +12,17 @@ useSeoMeta({
 })
 
 const route = useRoute()
-const { calendarStatus, isConnected, isAvailable, connect, disconnect, refresh, status } = useCalendarIntegration()
+const {
+  calendarStatus,
+  isConnected,
+  isAvailable,
+  canManageCalendar,
+  isCalendarPermissionLoading,
+  connect,
+  disconnect,
+  refresh,
+  status,
+} = useCalendarIntegration()
 const toast = useToast()
 
 const isDisconnecting = ref(false)
@@ -60,6 +70,8 @@ onMounted(() => {
 })
 
 async function handleDisconnect() {
+  if (!canManageCalendar.value) return
+
   isDisconnecting.value = true
   try {
     await disconnect()
@@ -75,6 +87,8 @@ async function handleDisconnect() {
 }
 
 async function updateSyncInterviewers(enabled: boolean) {
+  if (!canManageCalendar.value) return
+
   try {
     await $fetch('/api/org-settings', {
       method: 'PATCH',
@@ -227,7 +241,7 @@ async function updateSyncInterviewers(enabled: boolean) {
               </div>
             </div>
             <!-- Sync Interviewers Toggle (only for Microsoft app mode) -->
-            <div v-if="isMicrosoftCalendar && isAdminManagedCalendar" class="flex items-center justify-between pt-2 border-t border-surface-200 dark:border-surface-700">
+            <div v-if="isMicrosoftCalendar && isAdminManagedCalendar && canManageCalendar" class="flex items-center justify-between pt-2 border-t border-surface-200 dark:border-surface-700">
               <div class="text-sm text-surface-600 dark:text-surface-400">
                 Also create events on interviewers' personal calendars
               </div>
@@ -275,7 +289,7 @@ async function updateSyncInterviewers(enabled: boolean) {
               {{ isAdminManagedCalendar ? 'App credentials managed by server configuration' : 'Tokens encrypted at rest' }}
             </div>
 
-            <div v-if="!isAdminManagedCalendar" class="flex items-center gap-2">
+            <div v-if="!isAdminManagedCalendar && !isCalendarPermissionLoading && canManageCalendar" class="flex items-center gap-2">
               <button
                 v-if="!showDisconnectConfirm"
                 class="ui-button ui-button-danger-outline px-3 py-1.5"
@@ -303,6 +317,12 @@ async function updateSyncInterviewers(enabled: boolean) {
                 </button>
               </template>
             </div>
+            <p
+              v-else-if="!isAdminManagedCalendar && !isCalendarPermissionLoading"
+              class="text-xs text-surface-500 dark:text-surface-400"
+            >
+              Only organization administrators can change the shared calendar connection.
+            </p>
           </div>
         </div>
 
@@ -369,13 +389,19 @@ async function updateSyncInterviewers(enabled: boolean) {
             </div>
 
             <button
-              v-if="!isMicrosoftAppMode"
+              v-if="!isMicrosoftAppMode && !isCalendarPermissionLoading && canManageCalendar"
               class="ui-button ui-button-primary py-2.5"
               @click="connect"
             >
               <Calendar class="size-4" />
               Connect shared calendar
             </button>
+            <div
+              v-else-if="!isMicrosoftAppMode && !isCalendarPermissionLoading"
+              class="ui-alert ui-alert-info"
+            >
+              Only organization administrators can change the shared calendar connection.
+            </div>
           </div>
         </div>
       </div>

--- a/docs/plans/2026-07-16-factory-careers-hardening-design.md
+++ b/docs/plans/2026-07-16-factory-careers-hardening-design.md
@@ -1,0 +1,31 @@
+# Factory Careers Hardening Design
+
+## Objective
+
+Resolve every accepted finding from the July 16 audit without combining unrelated risk into one unreviewable release. Delivery is split into five dependency-ordered pull requests. Each PR starts from the then-current `main`, uses test-first changes, receives spec and code-quality review, passes `npm run preflight:pr`, and is merged before the next PR is finalized.
+
+## Delivery shape
+
+1. **Security boundaries** — keep authorization outside caches; org-scope calendar renewal; suppress small compliance cohorts; bound the public analytics proxy; remove connection-string logging.
+2. **Application integrity** — associate documents with applications; make the core submission transaction conflict-aware; enforce listing expiry consistently.
+3. **Scoring and processing** — reconcile model output against the stored rubric; treat applicant content as untrusted; persist resumable parsing/scoring work; align browser and CLI batch behavior.
+4. **Pipeline correctness and scale** — prevent cross-candidate stale state and replace the 100-record client slice with a server-paginated pipeline contract.
+5. **Reliability and maintainability** — repair migration locking, parser cleanup and corpus coverage, score-run display, property-filter query shape, job request types, lint enforcement, and setup documentation.
+
+## Architecture decisions
+
+Authenticated event handlers always execute `requirePermission` before consulting a cache. Cached functions receive an already-authorized `organizationId` and normalized query input; they never receive `H3Event` or session state. This preserves organization-level reuse while making membership revocation effective on every request.
+
+Documents gain a nullable `applicationId` for historical compatibility. New public submissions always populate it. Scoring prefers the application association and uses an explicit newest-resume legacy fallback only for pre-migration records. The core candidate/application/compliance/response writes use one database transaction; S3 remains a compensating saga.
+
+Processing uses durable database records rather than request-local loops. Workers atomically claim bounded batches, record attempts and failure details, and can resume pending work after interruption. Automatic scoring, bulk scoring, and reparsing all use this same contract. Browser and CLI surfaces report persisted progress rather than inferring success from returned IDs.
+
+The pipeline endpoint owns stage/search/filter/sort pagination and returns independent stage counts. The page preserves selection by application ID, never by stale array position, and renders no previous candidate’s interactive detail while a new selection loads.
+
+## Failure and privacy behavior
+
+Known uniqueness conflicts become stable 409 responses. Failed processing items remain inspectable and retryable without duplicating completed work. Protected-trait summaries require elevated organization permission and suppress small totals/cells. Applicant text is delimited as untrusted data, and model-provided criterion keys or maxima never determine stored scores.
+
+## Verification
+
+Every behavior change follows red-green-refactor. Focused unit/integration tests run per task; each PR finishes with unit tests, conventions, CLI parity where applicable, typecheck, build, production-env validation, and browser QA for visible workflows. Migrations are reviewed against the latest journal before merge. The final merged `main` receives a fresh full preflight and smoke pass.

--- a/docs/superpowers/plans/2026-07-16-application-integrity.md
+++ b/docs/superpowers/plans/2026-07-16-application-integrity.md
@@ -29,7 +29,7 @@
 
 **Files:**
 - Modify: `server/database/schema/app.ts`
-- Create: `server/database/migrations/0049_application_documents.sql`
+- Create: `server/database/migrations/0050_application_documents.sql`
 - Modify: `server/database/migrations/meta/_journal.json`
 - Modify: `server/api/public/jobs/[slug]/apply.post.ts`
 - Modify: `server/api/applications/[id].get.ts`

--- a/docs/superpowers/plans/2026-07-16-application-integrity.md
+++ b/docs/superpowers/plans/2026-07-16-application-integrity.md
@@ -1,0 +1,77 @@
+# Application Integrity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make public submissions atomic, application-specific, and unavailable after the configured closing date.
+
+**Architecture:** A shared public-job predicate owns schedule semantics. Documents optionally reference applications for legacy compatibility. Core database writes use one transaction and conflict-aware inserts; S3 uploads remain compensating operations.
+
+**Tech Stack:** Nuxt 4, Nitro, Drizzle/PostgreSQL, S3, Vitest, Playwright.
+
+---
+
+### Task 1: Centralize public listing eligibility
+
+**Files:**
+- Create: `server/utils/publicJobVisibility.ts`
+- Modify: `server/api/public/jobs/index.get.ts`
+- Modify: `server/api/public/jobs/[slug].get.ts`
+- Modify: `server/api/public/jobs/[slug]/apply.post.ts`
+- Test: `tests/unit/public-job-visibility.test.ts`
+
+- [ ] Write failing boundary tests for absent, future, current, and expired `validThrough` values.
+- [ ] Implement conditions equivalent to `status = open AND activeFrom <= now AND (validThrough IS NULL OR validThrough >= now)` using one helper.
+- [ ] Apply the helper to list, detail, and submission queries.
+- [ ] Run the focused tests; expect pass.
+- [ ] Commit with `fix: enforce public job expiration`.
+
+### Task 2: Associate documents with applications
+
+**Files:**
+- Modify: `server/database/schema/app.ts`
+- Create: `server/database/migrations/0049_application_documents.sql`
+- Modify: `server/database/migrations/meta/_journal.json`
+- Modify: `server/api/public/jobs/[slug]/apply.post.ts`
+- Modify: `server/api/applications/[id].get.ts`
+- Test: `tests/unit/application-document-association.test.ts`
+
+- [ ] Write a failing schema/route test requiring nullable `document.applicationId`, its index, and public-upload assignment.
+- [ ] Add the nullable foreign key with `ON DELETE SET NULL` and an index; record the migration after the latest main journal entry.
+- [ ] Populate `applicationId` for built-in and custom-question uploads.
+- [ ] Return application-associated documents first, with an explicit legacy fallback.
+- [ ] Run focused tests and `npm run db:generate` only as a zero-diff verification; expect no untracked migration.
+- [ ] Commit with `feat: associate submitted documents with applications`.
+
+### Task 3: Make core submission writes conflict-aware and atomic
+
+**Files:**
+- Create: `server/utils/createPublicApplication.ts`
+- Modify: `server/api/public/jobs/[slug]/apply.post.ts`
+- Test: `tests/unit/public-application-transaction.test.ts`
+
+- [ ] Write failing tests using an injected transaction adapter for compliance failure, response failure, and duplicate application races.
+- [ ] Implement a transaction returning `{ candidateId, applicationId }`; use conflict-aware candidate upsert, application `onConflictDoNothing`, and transactional compliance and non-file responses.
+- [ ] Convert an empty application insert result to the existing stable 409 response.
+- [ ] Leave attribution best-effort and keep S3 cleanup as a saga that deletes the application on upload failure.
+- [ ] Run focused tests; expect no partial records in every injected-failure case.
+- [ ] Commit with `fix: make public application writes atomic`.
+
+### Task 4: Select the application’s resume for scoring
+
+**Files:**
+- Create: `server/utils/applicationResume.ts`
+- Modify: `server/api/applications/[id]/analyze.post.ts`
+- Modify: `server/utils/ai/autoScore.ts`
+- Test: `tests/unit/application-resume-selection.test.ts`
+
+- [ ] Write failing tests proving application-associated resume wins and the legacy fallback is newest-first and deterministic.
+- [ ] Implement `loadApplicationResume(orgId, applicationId, candidateId)` with those rules.
+- [ ] Replace both unordered candidate document scans.
+- [ ] Run focused tests; expect pass.
+- [ ] Commit with `fix: score the resume submitted for each application`.
+
+### Task 5: Validate the application PR
+
+- [ ] Run unit tests, typecheck, build, conventions, CLI parity, and `npm run preflight:pr`; expect exit 0.
+- [ ] Run the public-application and resume-upload browser specs; expect pass.
+- [ ] Request spec and code-quality review; resolve and reverify every blocking issue.

--- a/docs/superpowers/plans/2026-07-16-application-integrity.md
+++ b/docs/superpowers/plans/2026-07-16-application-integrity.md
@@ -29,7 +29,7 @@
 
 **Files:**
 - Modify: `server/database/schema/app.ts`
-- Create: `server/database/migrations/0050_application_documents.sql`
+- Create: `server/database/migrations/0051_application_documents.sql`
 - Modify: `server/database/migrations/meta/_journal.json`
 - Modify: `server/api/public/jobs/[slug]/apply.post.ts`
 - Modify: `server/api/applications/[id].get.ts`

--- a/docs/superpowers/plans/2026-07-16-pipeline-correctness.md
+++ b/docs/superpowers/plans/2026-07-16-pipeline-correctness.md
@@ -1,0 +1,59 @@
+# Pipeline Correctness And Scale Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent cross-candidate stale data and make every application reachable with correct pipeline counts and filters.
+
+**Architecture:** Candidate detail caches are identity-bound. A job-pipeline API owns filtering, sorting, pagination, and stage counts; the Nuxt page incrementally loads results and preserves selection by application ID.
+
+**Tech Stack:** Nuxt 4, Vue 3, Nitro, Drizzle/PostgreSQL, Vitest, Playwright.
+
+---
+
+### Task 1: Make candidate detail state identity-safe
+
+**Files:**
+- Modify: `app/pages/dashboard/jobs/[id]/index.vue`
+- Modify: `app/components/ScoreBreakdown.vue`
+- Test: `tests/unit/job-pipeline-selection-state.test.ts`
+- Test: `e2e/critical-flows/job-pipeline-selection.spec.ts`
+
+- [ ] Write a failing component/browser regression that delays candidate B’s detail response and asserts candidate A’s documents, properties, and score controls disappear immediately.
+- [ ] Cache `{ applicationId, data }` and resolve only an exact ID match; otherwise render noninteractive skeletons.
+- [ ] Key score data by application ID and clear expanded/error state on change.
+- [ ] Run focused unit and browser tests; expect pass.
+- [ ] Commit with `fix: isolate pipeline candidate detail state`.
+
+### Task 2: Add a server-paginated pipeline contract
+
+**Files:**
+- Create: `server/utils/schemas/pipeline.ts`
+- Create: `server/api/jobs/[id]/pipeline.get.ts`
+- Create: `app/composables/useJobPipeline.ts`
+- Test: `tests/unit/job-pipeline-api.test.ts`
+
+- [ ] Write failing tests with 101 applications proving independent stage counts, page boundaries, search, score, interview, property filters, and stable sorting.
+- [ ] Implement a maximum page size of 50 and return `{ data, total, page, limit, stageCounts }`.
+- [ ] Scope every query by authorized organization and job.
+- [ ] Run focused tests; expect pass.
+- [ ] Commit with `feat: add paginated job pipeline API`.
+
+### Task 3: Migrate the pipeline page to incremental results
+
+**Files:**
+- Modify: `app/pages/dashboard/jobs/[id]/index.vue`
+- Modify: `app/components/JobPipelineCandidateCard.vue`
+- Test: `tests/unit/job-pipeline-chunk.test.ts`
+- Test: `e2e/critical-flows/job-pipeline-pagination.spec.ts`
+
+- [ ] Write failing tests requiring server-owned counts and a reachable 101st candidate.
+- [ ] Replace `useApplications({ limit: 100 })` and client-wide filtering with `useJobPipeline`.
+- [ ] Add an accessible load-more control, loading state, and result count; preserve keyboard selection and current ID when pages append.
+- [ ] Run focused unit and browser tests at desktop and mobile viewports; expect pass with no horizontal bleed.
+- [ ] Commit with `fix: load every pipeline candidate`.
+
+### Task 4: Validate the pipeline PR
+
+- [ ] Run unit tests, typecheck, build, conventions, full preflight, and dashboard smoke tests.
+- [ ] Manually verify the reported production route shape in a local authenticated browser with 101+ seeded applications.
+- [ ] Request spec and code-quality review; resolve and reverify every blocking issue.

--- a/docs/superpowers/plans/2026-07-16-reliability-maintainability.md
+++ b/docs/superpowers/plans/2026-07-16-reliability-maintainability.md
@@ -1,0 +1,106 @@
+# Reliability And Maintainability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the remaining parser, migration, score display, query, type-contract, lint, and documentation findings.
+
+**Architecture:** Small reliability fixes stay isolated; query changes are benchmarked before indexing; shared request contracts replace parallel type declarations; CI enforces a deliberately small lint baseline.
+
+**Tech Stack:** Nuxt 4, PostgreSQL, Drizzle, pdf-parse, ESLint, Vitest.
+
+---
+
+### Task 1: Keep migration locking on one PostgreSQL session
+
+**Files:**
+- Modify: `server/plugins/migrations.ts`
+- Test: `tests/unit/migration-locking.test.ts`
+
+- [ ] Write a failing dependency-injected test requiring acquire, migrate, unlock, and client close on the same reserved client.
+- [ ] Create a dedicated `postgres(env.DATABASE_URL, { max: 1 })` client in the plugin, build a Drizzle instance from it, and unlock/close in `finally`.
+- [ ] Make lock contention wait/retry or verify schema currency before startup proceeds.
+- [ ] Run focused tests; expect pass.
+- [ ] Commit with `fix: keep migration lock ownership on one session`.
+
+### Task 2: Harden parser lifecycle and add a format corpus
+
+**Files:**
+- Modify: `server/utils/resume-parser.ts`
+- Create: `tests/fixtures/resumes/README.md`
+- Create: `tests/unit/resume-parser-corpus.test.ts`
+- Modify: `tests/unit/resume-parser.test.ts`
+
+- [ ] Write a failing test proving `destroy()` runs when PDF extraction rejects.
+- [ ] Move parser cleanup into `finally` without changing the null-on-failure contract.
+- [ ] Add sanitized/generated fixtures for multi-page, compressed, subset-font, multi-column, valid DOCX, and valid DOC inputs; explicitly assert encrypted/image-only classification.
+- [ ] Run parser tests and the production bundle verifier; expect pass.
+- [ ] Commit with `test: cover representative resume formats`.
+
+### Task 3: Separate latest success from latest scoring attempt
+
+**Files:**
+- Modify: `server/api/applications/[id]/scores.get.ts`
+- Modify: `app/components/ScoreBreakdown.vue`
+- Test: `tests/unit/score-run-display.test.ts`
+
+- [ ] Write a failing test with a completed run followed by a failed run.
+- [ ] Return `latestSuccessfulRun` and `latestAttempt`; render scores/summary from success and failure state from the attempt.
+- [ ] Run focused tests; expect pass.
+- [ ] Commit with `fix: preserve successful score display after retries`.
+
+### Task 4: Move property filter intersection into PostgreSQL
+
+**Files:**
+- Modify: `server/utils/properties.ts`
+- Modify: `server/api/applications/index.get.ts`
+- Modify: `server/api/candidates/index.get.ts`
+- Test: `tests/unit/property-filter-query.test.ts`
+
+- [ ] Write failing semantic tests for equality, contains, multi-select, empty values, and multi-filter intersection.
+- [ ] Replace materialized ID sets with correlated `EXISTS` predicates applied before pagination.
+- [ ] Capture `EXPLAIN ANALYZE` against representative local data; add an index only when the plan demonstrates benefit.
+- [ ] Run focused tests; expect pass.
+- [ ] Commit with `perf: filter custom properties in PostgreSQL`.
+
+### Task 5: Share job request contracts
+
+**Files:**
+- Modify: `server/utils/schemas/job.ts`
+- Create: `shared/job-contract.ts`
+- Modify: `app/composables/useJobs.ts`
+- Modify: `app/composables/useJob.ts`
+- Modify: `app/pages/dashboard/jobs/new.vue`
+- Modify: `app/pages/dashboard/jobs/[id]/application-form.vue`
+- Test: `tests/unit/job-contract.test.ts`
+
+- [ ] Write a failing type/contract test covering create defaults and patch null/optional semantics.
+- [ ] Export shared inferred request types and explicit form-to-request adapters.
+- [ ] Remove duplicated payload declarations and `as any`.
+- [ ] Run focused tests and typecheck; expect pass.
+- [ ] Commit with `refactor: share typed job request contracts`.
+
+### Task 6: Enforce lint and reconcile setup documentation
+
+**Files:**
+- Create: `eslint.config.mjs`
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `scripts/run-pr-validation-preflight.mjs`
+- Modify: `.github/workflows/pr-validation.yml`
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `CLAUDE.md`
+- Modify: `CONTRIBUTING.md`
+- Test: `tests/unit/repository-quality-gates.test.ts`
+
+- [ ] Write a failing source-contract test requiring a real lint command in package scripts, preflight, and CI, plus one canonical host-development URL.
+- [ ] Add a Nuxt/Vue-aware ESLint flat configuration with a small zero-warning baseline and make lint mandatory.
+- [ ] Split host and Docker setup instructions; consistently use port 3001 for `npm run dev` and port 3000 only for Docker.
+- [ ] Run lint, convention checks, and typecheck; expect exit 0.
+- [ ] Commit with `chore: enforce repository quality gates`.
+
+### Task 7: Validate the final PR
+
+- [ ] Run unit tests, lint, typecheck, build, conventions, CLI parity, production-env validation, and full preflight.
+- [ ] Request spec and code-quality review; resolve and reverify every blocking issue.
+- [ ] After merge, run a fresh full preflight against updated `main`.

--- a/docs/superpowers/plans/2026-07-16-scoring-processing.md
+++ b/docs/superpowers/plans/2026-07-16-scoring-processing.md
@@ -1,0 +1,96 @@
+# Scoring And Processing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make scoring rubric-safe, resumable, observable, and identical across automatic, browser, CLI, and reparsing paths.
+
+**Architecture:** Model output is reconciled against canonical criteria before persistence. A PostgreSQL-backed processing queue atomically claims bounded tasks and records retry state; a Nitro worker and explicit drain endpoint use the same processor.
+
+**Tech Stack:** Nuxt 4, Drizzle/PostgreSQL, structured AI output, CLI, Vitest.
+
+---
+
+### Task 1: Reconcile scoring output with the canonical rubric
+
+**Files:**
+- Modify: `server/utils/ai/scoring.ts`
+- Test: `tests/unit/ai-scoring-validation.test.ts`
+
+- [ ] Write failing tests for missing, duplicate, unknown, mismatched-maximum, zero-maximum, and over-maximum evaluations.
+- [ ] Add `reconcileEvaluations(criteria, evaluations)` that requires exactly one evaluation per stored criterion, ignores model maxima, and clamps against `criterion.maxScore`.
+- [ ] Delimit resume, cover letter, and notes in separate untrusted-data tags and add an explicit system rule to ignore embedded instructions.
+- [ ] Make `computeCompositeScore` accept only reconciled evaluations.
+- [ ] Run focused tests; expect pass.
+- [ ] Commit with `fix: validate AI scores against stored rubrics`.
+
+### Task 2: Add durable processing records and atomic claiming
+
+**Files:**
+- Modify: `server/database/schema/app.ts`
+- Create: `server/database/migrations/0050_processing_queue.sql`
+- Modify: `server/database/migrations/meta/_journal.json`
+- Create: `server/utils/processingQueue.ts`
+- Test: `tests/unit/processing-queue.test.ts`
+
+- [ ] Write failing state-transition tests for enqueue idempotency, bounded claims, completion, retry backoff, and terminal failure.
+- [ ] Add processing batch/task tables with organization, type, resource ID, status, attempt count, availability, lease, error, and timestamps.
+- [ ] Implement claim SQL with `FOR UPDATE SKIP LOCKED`, finite leases, and a maximum attempt count.
+- [ ] Run focused tests; expect pass.
+- [ ] Commit with `feat: add durable recruiting processing queue`.
+
+### Task 3: Extract reusable single-application analysis
+
+**Files:**
+- Create: `server/utils/analyzeApplication.ts`
+- Modify: `server/api/applications/[id]/analyze.post.ts`
+- Modify: `server/utils/ai/autoScore.ts`
+- Test: `tests/unit/analyze-application.test.ts`
+
+- [ ] Write a failing unit test for success, parse failure, missing criteria, provider failure, and preserved latest successful score metadata.
+- [ ] Move analysis and persistence into `analyzeApplication({ organizationId, applicationId, aiConfigId, scoredById })`.
+- [ ] Store the successful summary/raw response consistently for manual and automatic analysis.
+- [ ] Keep the HTTP route responsible only for auth, rate limiting, validation, and response mapping.
+- [ ] Run focused tests; expect pass.
+- [ ] Commit with `refactor: share application analysis execution`.
+
+### Task 4: Process scoring and parsing tasks
+
+**Files:**
+- Create: `server/utils/processRecruitingTasks.ts`
+- Create: `server/plugins/recruiting-worker.ts`
+- Create: `server/api/processing/[id].get.ts`
+- Create: `server/api/processing/[id]/drain.post.ts`
+- Modify: `server/api/jobs/[id]/analyze-all.post.ts`
+- Modify: `server/api/documents/parse-all.post.ts`
+- Modify: `server/api/documents/[id]/parse.post.ts`
+- Modify: `server/api/public/jobs/[slug]/apply.post.ts`
+- Test: `tests/unit/recruiting-processing.test.ts`
+
+- [ ] Write failing tests that prove bulk endpoints enqueue rather than loop, reparsing enqueues affected scoring, and a restarted worker can reclaim an expired lease.
+- [ ] Implement bounded queue draining for `application_analysis` and `document_parse` task types.
+- [ ] Start a small unref’d polling worker outside prerender/test contexts; all correctness remains in persisted queue state.
+- [ ] Return batch IDs and structured progress.
+- [ ] Run focused tests; expect pass.
+- [ ] Commit with `feat: make parsing and scoring resumable`.
+
+### Task 5: Align browser and CLI batch behavior
+
+**Files:**
+- Modify: `app/components/JobSubNavActions.vue`
+- Modify: `packages/careers-cli/src/commands/jobs.ts`
+- Modify: `packages/careers-cli/src/commands/documents.ts`
+- Modify: `docs/CLI.md`
+- Test: `tests/unit/cli-job-workflow-commands.test.ts`
+- Test: `tests/unit/cli-documents-commands.test.ts`
+
+- [ ] Write failing CLI tests requiring batch creation, progress polling/draining, and structured attempted/succeeded/failed counts.
+- [ ] Replace per-application browser requests with persisted batch progress.
+- [ ] Implement deterministic CLI draining with `--json`, interruption-safe batch ID output, and nonzero status on terminal failures.
+- [ ] Run focused tests and CLI parity preflight; expect pass.
+- [ ] Commit with `fix: align browser and CLI processing batches`.
+
+### Task 6: Validate the processing PR
+
+- [ ] Run unit tests, typecheck, build, conventions, CLI parity, production-env validation, and full preflight.
+- [ ] Run AI candidate-review and resume-upload smoke flows.
+- [ ] Request spec and code-quality review; resolve and reverify every blocking issue.

--- a/docs/superpowers/plans/2026-07-16-scoring-processing.md
+++ b/docs/superpowers/plans/2026-07-16-scoring-processing.md
@@ -27,7 +27,7 @@
 
 **Files:**
 - Modify: `server/database/schema/app.ts`
-- Create: `server/database/migrations/0050_processing_queue.sql`
+- Create: `server/database/migrations/0051_processing_queue.sql`
 - Modify: `server/database/migrations/meta/_journal.json`
 - Create: `server/utils/processingQueue.ts`
 - Test: `tests/unit/processing-queue.test.ts`

--- a/docs/superpowers/plans/2026-07-16-scoring-processing.md
+++ b/docs/superpowers/plans/2026-07-16-scoring-processing.md
@@ -27,7 +27,7 @@
 
 **Files:**
 - Modify: `server/database/schema/app.ts`
-- Create: `server/database/migrations/0051_processing_queue.sql`
+- Create: `server/database/migrations/0052_processing_queue.sql`
 - Modify: `server/database/migrations/meta/_journal.json`
 - Create: `server/utils/processingQueue.ts`
 - Test: `tests/unit/processing-queue.test.ts`

--- a/docs/superpowers/plans/2026-07-16-security-boundaries.md
+++ b/docs/superpowers/plans/2026-07-16-security-boundaries.md
@@ -1,0 +1,98 @@
+# Security Boundaries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure every sensitive request is authorized at request time and remove four adjacent cross-tenant, privacy, denial-of-service, and secret-logging risks.
+
+**Architecture:** Route handlers authorize first and call organization-scoped cached functions second. Compliance aggregation, calendar maintenance, and analytics proxy validation use small testable server utilities so the security policy is explicit and behaviorally covered.
+
+**Tech Stack:** Nuxt 4, Nitro/h3, TypeScript, Drizzle ORM, Vitest.
+
+---
+
+### Task 1: Put authorization outside dashboard data caches
+
+**Files:**
+- Modify: `server/utils/httpCache.ts`
+- Modify: `server/api/{jobs,candidates,applications,interviews}/index.get.ts`
+- Modify: `server/api/dashboard/stats.get.ts`
+- Test: `tests/unit/list-api-cache.test.ts`
+
+- [ ] Write a failing test that rejects `defineCachedEventHandler` on authenticated routes and requires `requirePermission` before an organization-scoped cached function call.
+- [ ] Run `npm run test:unit -- tests/unit/list-api-cache.test.ts`; expect the current cached handlers to fail.
+- [ ] Export a typed helper with this contract:
+
+```ts
+export function defineOrgScopedCachedFunction<TInput, TResult>(
+  name: string,
+  loader: (organizationId: string, input: TInput) => Promise<TResult>,
+) {
+  return defineCachedFunction(loader, {
+    name,
+    maxAge: ORG_SCOPED_CACHE_MAX_AGE_SECONDS,
+    swr: true,
+    getKey: async (organizationId, input) =>
+      `${escapeCacheKeyPart(organizationId)}:v${await getOrgDashboardCacheVersion(organizationId)}:${hash(input)}`,
+  })
+}
+```
+
+- [ ] Convert each route to `defineEventHandler`, run `requirePermission`, validate its query, then call its module-level cached data function with the authorized org ID.
+- [ ] Run the focused test and `npm run typecheck`; expect both to pass.
+- [ ] Commit with `fix: authorize dashboard reads before cache lookup`.
+
+### Task 2: Restrict and suppress compliance reporting
+
+**Files:**
+- Create: `server/utils/complianceReporting.ts`
+- Modify: `server/api/compliance/applications/summary.get.ts`
+- Test: `tests/unit/compliance-reporting.test.ts`
+
+- [ ] Write failing tests for totals below five and cells below five.
+- [ ] Implement `suppressComplianceBreakdown(rows, total)` returning no breakdowns below the cohort threshold and replacing small cells with `{ value: 'suppressed', count: null }`.
+- [ ] Require `{ organization: ['update'] }` instead of ordinary application-read permission.
+- [ ] Run the focused tests; expect pass.
+- [ ] Commit with `fix: protect small-cohort compliance reporting`.
+
+### Task 3: Separate cron-only global calendar renewal
+
+**Files:**
+- Modify: `server/api/calendar/renew-webhooks.post.ts`
+- Test: `tests/unit/calendar-renewal-scope.test.ts`
+
+- [ ] Write a failing test requiring a configured, timing-safe cron secret and no interactive permission fallback.
+- [ ] Make missing or invalid `x-cron-secret` return 403 before any integration query.
+- [ ] Keep global renewal behavior only after secret verification.
+- [ ] Run the focused test; expect pass.
+- [ ] Commit with `fix: make global calendar renewal cron only`.
+
+### Task 4: Bound the public analytics proxy
+
+**Files:**
+- Create: `server/utils/analyticsProxyPolicy.ts`
+- Modify: `server/routes/ingest/[...path].ts`
+- Test: `tests/unit/analytics-proxy-policy.test.ts`
+
+- [ ] Write failing tests for unsupported methods, unknown paths, missing/oversized content lengths, and oversized streamed bodies.
+- [ ] Implement explicit capture/static path allowlists, `GET|HEAD|POST` methods, a 1 MiB request maximum, a 2 MiB response maximum, and route-specific rate limiting.
+- [ ] Stream or size-check upstream response reads before allocating the final buffer.
+- [ ] Run focused tests; expect pass.
+- [ ] Commit with `fix: bound public analytics proxy traffic`.
+
+### Task 5: Remove raw connection strings from errors
+
+**Files:**
+- Modify: `drizzle.config.ts`
+- Test: `tests/unit/drizzle-config-secrets.test.ts`
+
+- [ ] Write a failing source-contract test asserting the error does not interpolate `raw`.
+- [ ] Replace the message with a diagnostic that names only missing variable categories.
+- [ ] Run the focused test; expect pass.
+- [ ] Commit with `fix: prevent database URL disclosure in errors`.
+
+### Task 6: Validate the security PR
+
+- [ ] Run `npm run test:unit` and expect 0 failures.
+- [ ] Run `npm run check:conventions`, `npm run typecheck`, and `npm run build`; expect exit 0.
+- [ ] Run `npm run preflight:pr`; expect exit 0.
+- [ ] Request spec review, then code-quality review; resolve every Critical or Important issue and re-run affected checks.

--- a/docs/superpowers/plans/2026-07-16-security-boundaries.md
+++ b/docs/superpowers/plans/2026-07-16-security-boundaries.md
@@ -54,17 +54,17 @@ export function defineOrgScopedCachedFunction<TInput, TResult>(
 - [ ] Run the focused tests; expect pass.
 - [ ] Commit with `fix: protect small-cohort compliance reporting`.
 
-### Task 3: Separate cron-only global calendar renewal
+### Task 3: Separate global cron renewal from organization-scoped renewal
 
 **Files:**
 - Modify: `server/api/calendar/renew-webhooks.post.ts`
 - Test: `tests/unit/calendar-renewal-scope.test.ts`
 
-- [ ] Write a failing test requiring a configured, timing-safe cron secret and no interactive permission fallback.
-- [ ] Make missing or invalid `x-cron-secret` return 403 before any integration query.
-- [ ] Keep global renewal behavior only after secret verification.
+- [ ] Write failing tests proving a configured, timing-safe cron secret can renew globally while an interactive administrator can renew only integrations whose `organizationId` matches the active organization.
+- [ ] Keep global renewal behavior only after valid cron-secret verification. Reject an invalid supplied secret before any integration query.
+- [ ] Preserve the supported CLI path by requiring `{ organization: ['update'] }` when no cron secret is supplied and adding `eq(calendarIntegration.organizationId, orgId)` to that branch.
 - [ ] Run the focused test; expect pass.
-- [ ] Commit with `fix: make global calendar renewal cron only`.
+- [ ] Commit with `fix: scope interactive calendar renewal by organization`.
 
 ### Task 4: Bound the public analytics proxy
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -27,9 +27,9 @@ function resolveDatabaseUrl(): string {
   }
 
   throw new Error(
-    `DATABASE_URL is missing a hostname and no PGHOST fallback is available.\n`
-    + `Raw DATABASE_URL: "${raw}"\n`
-    + `In Railway PR environments, ensure the Postgres service variables are linked to this service.`,
+    'Database configuration is incomplete: expected a DATABASE_URL hostname '
+    + 'or a PGHOST/RAILWAY_TCP_PROXY_DOMAIN fallback.\n'
+    + 'In Railway PR environments, ensure the Postgres service variables are linked to this service.',
   )
 }
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -103,7 +103,9 @@ export default defineNuxtConfig({
     host: process.env.POSTHOG_HOST || "https://eu.i.posthog.com",
     clientConfig: {
       // ── Reverse proxy: route PostHog through the app domain to bypass ad blockers ──
-      // Requests to /ingest/** are proxied by Nitro to eu.i.posthog.com
+      // Nitro allowlists POST /ingest/e[/] and /ingest/flags[/] on the EU
+      // ingestion host, plus GET/HEAD /ingest/static/** and the two
+      // /ingest/array/{token}/config[.js] asset endpoints. All other paths fail closed.
       api_host: "/ingest",
       ui_host: "https://eu.posthog.com",
       // ── Privacy: disable invasive features ──
@@ -287,8 +289,9 @@ export default defineNuxtConfig({
   // ─────────────────────────────────────────────
   routeRules: {
     // ── PostHog reverse proxy ──
-    // Handled by server/routes/ingest/[...path].ts (which routes /ingest/static/**
-    // to eu-assets.i.posthog.com and everything else to eu.i.posthog.com).
+    // Handled by server/routes/ingest/[...path].ts with an explicit SDK allowlist:
+    // POST e/flags use eu.i.posthog.com; GET/HEAD static and array config assets
+    // use eu-assets.i.posthog.com. Unknown paths and methods are rejected.
     // Defining routeRules here would be shadowed by the server route, so we
     // intentionally do not declare them.
     ...localizedRootRedirectRules,

--- a/packages/careers-cli/src/routeCoverage.ts
+++ b/packages/careers-cli/src/routeCoverage.ts
@@ -75,7 +75,7 @@ export const cliRouteCoverage: CliRouteCoverageEntry[] = [
   { route: 'server/api/comments/[id].patch.ts', status: 'supported', command: 'comments update' },
   { route: 'server/api/comments/index.get.ts', status: 'supported', command: 'comments list' },
   { route: 'server/api/comments/index.post.ts', status: 'supported', command: 'comments create' },
-  { route: 'server/api/compliance/applications/summary.get.ts', status: 'excluded', reason: 'Dashboard-only aggregate compliance report; no CLI workflow until exports/reporting are productized.' },
+  { route: 'server/api/compliance/applications/summary.get.ts', status: 'excluded', reason: 'Dashboard-only privacy-protected aggregate compliance report; no CLI workflow until exports/reporting are productized.' },
   { route: 'server/api/dashboard/stats.get.ts', status: 'supported', command: 'dashboard summary' },
   { route: 'server/api/documents/[id].delete.ts', status: 'supported', command: 'documents delete' },
   { route: 'server/api/documents/[id]/download.get.ts', status: 'supported', command: 'documents download' },

--- a/server/api/applications/index.get.ts
+++ b/server/api/applications/index.get.ts
@@ -1,93 +1,104 @@
 import { eq, and, desc, inArray } from 'drizzle-orm'
+import type { z } from 'zod'
 import { application, candidate, job } from '../../database/schema'
-import { paginatedListResponse, paginationOffset } from '../../utils/schemas/common'
-import { applicationQuerySchema } from '../../utils/schemas/application'
 import {
-  loadPropertyEntriesForEntities,
-} from '../../utils/properties'
-import { matchingEntityIdsForPropertyFilters, parsePropertyFiltersParam } from '../../utils/propertyFilters'
+  paginatedListResponse,
+  paginationOffset,
+} from '../../utils/schemas/common'
+import { applicationQuerySchema } from '../../utils/schemas/application'
+import { loadPropertyEntriesForEntities } from '../../utils/properties'
+import {
+  matchingEntityIdsForPropertyFilters,
+  parsePropertyFiltersParam,
+} from '../../utils/propertyFilters'
 
 /**
  * GET /api/applications
  * List applications for the current organization.
  * Filterable by jobId, candidateId, status, and custom property filters. Paginated.
  */
-export default defineCachedEventHandler(async (event) => {
-  const session = await requirePermission(event, { application: ['read'] })
-  const orgId = session.session.activeOrganizationId
+const getCachedApplications = defineOrgScopedCachedFunction(
+  'applications-list',
+  async (orgId, query: z.infer<typeof applicationQuerySchema>) => {
+    const offset = paginationOffset(query.page, query.limit)
+    const conditions = [eq(application.organizationId, orgId)]
 
-  const query = await getValidatedQuery(event, applicationQuerySchema.parse)
+    if (query.jobId) {
+      conditions.push(eq(application.jobId, query.jobId))
+    }
+    if (query.candidateId) {
+      conditions.push(eq(application.candidateId, query.candidateId))
+    }
+    if (query.status) {
+      conditions.push(eq(application.status, query.status))
+    }
 
-  const offset = paginationOffset(query.page, query.limit)
-  const conditions = [eq(application.organizationId, orgId)]
+    const propertyFilters = parsePropertyFiltersParam(query.propertyFilters)
+    if (propertyFilters.length > 0) {
+      const matching = await matchingEntityIdsForPropertyFilters({
+        organizationId: orgId,
+        entityType: 'application',
+        filters: propertyFilters,
+      })
+      if (!matching || matching.size === 0) {
+        return paginatedListResponse([], 0, query.page, query.limit)
+      }
+      conditions.push(inArray(application.id, [...matching]))
+    }
 
-  if (query.jobId) {
-    conditions.push(eq(application.jobId, query.jobId))
-  }
-  if (query.candidateId) {
-    conditions.push(eq(application.candidateId, query.candidateId))
-  }
-  if (query.status) {
-    conditions.push(eq(application.status, query.status))
-  }
+    const where = and(...conditions)
 
-  const propertyFilters = parsePropertyFiltersParam(query.propertyFilters)
-  if (propertyFilters.length > 0) {
-    const matching = await matchingEntityIdsForPropertyFilters({
+    const [data, total] = await Promise.all([
+      db
+        .select({
+          id: application.id,
+          status: application.status,
+          score: application.score,
+          notes: application.notes,
+          createdAt: application.createdAt,
+          updatedAt: application.updatedAt,
+          candidateId: application.candidateId,
+          candidateFirstName: candidate.firstName,
+          candidateLastName: candidate.lastName,
+          candidateEmail: candidate.email,
+          jobId: application.jobId,
+          jobTitle: job.title,
+          jobStatus: job.status,
+        })
+        .from(application)
+        .innerJoin(candidate, eq(candidate.id, application.candidateId))
+        .innerJoin(job, eq(job.id, application.jobId))
+        .where(where)
+        .orderBy(desc(application.createdAt))
+        .limit(query.limit)
+        .offset(offset),
+      db.$count(application, where),
+    ])
+
+    // Bulk-attach properties for the current page (org-global + per-job)
+    const ids = data.map(a => a.id)
+    const jobIds = [...new Set(data.map(a => a.jobId))]
+    const entityJobIds = new Map(data.map(a => [a.id, a.jobId] as const))
+    const propertyMap = await loadPropertyEntriesForEntities({
       organizationId: orgId,
       entityType: 'application',
-      filters: propertyFilters,
+      entityIds: ids,
+      jobIds,
+      entityJobIds,
     })
-    if (!matching || matching.size === 0) {
-      return paginatedListResponse([], 0, query.page, query.limit)
-    }
-    conditions.push(inArray(application.id, [...matching]))
-  }
+    const enriched = data.map(a => ({
+      ...a,
+      properties: propertyMap.get(a.id) ?? [],
+    }))
 
-  const where = and(...conditions)
+    return paginatedListResponse(enriched, total, query.page, query.limit)
+  },
+)
 
-  const [data, total] = await Promise.all([
-    db
-      .select({
-        id: application.id,
-        status: application.status,
-        score: application.score,
-        notes: application.notes,
-        createdAt: application.createdAt,
-        updatedAt: application.updatedAt,
-        candidateId: application.candidateId,
-        candidateFirstName: candidate.firstName,
-        candidateLastName: candidate.lastName,
-        candidateEmail: candidate.email,
-        jobId: application.jobId,
-        jobTitle: job.title,
-        jobStatus: job.status,
-      })
-      .from(application)
-      .innerJoin(candidate, eq(candidate.id, application.candidateId))
-      .innerJoin(job, eq(job.id, application.jobId))
-      .where(where)
-      .orderBy(desc(application.createdAt))
-      .limit(query.limit)
-      .offset(offset),
-    db.$count(application, where),
-  ])
+export default defineEventHandler(async event => {
+  const session = await requirePermission(event, { application: ['read'] })
+  const orgId = session.session.activeOrganizationId
+  const query = await getValidatedQuery(event, applicationQuerySchema.parse)
 
-  // Bulk-attach properties for the current page (org-global + per-job)
-  const ids = data.map((a) => a.id)
-  const jobIds = [...new Set(data.map((a) => a.jobId))]
-  const entityJobIds = new Map(data.map((a) => [a.id, a.jobId] as const))
-  const propertyMap = await loadPropertyEntriesForEntities({
-    organizationId: orgId,
-    entityType: 'application',
-    entityIds: ids,
-    jobIds,
-    entityJobIds,
-  })
-  const enriched = data.map((a) => ({
-    ...a,
-    properties: propertyMap.get(a.id) ?? [],
-  }))
-
-  return paginatedListResponse(enriched, total, query.page, query.limit)
-}, orgScopedCacheOptions)
+  return getCachedApplications(orgId, query)
+})

--- a/server/api/calendar/disconnect.post.ts
+++ b/server/api/calendar/disconnect.post.ts
@@ -8,7 +8,7 @@ import { isCalendarConfigured, removeConnectedCalendarIntegration } from '../../
 import { isMicrosoftCalendarApplicationMode } from '../../utils/microsoft-calendar'
 
 export default defineEventHandler(async (event) => {
-  const session = await requireAuth(event)
+  const session = await requirePermission(event, { organization: ['update'] })
   const orgId = session.session.activeOrganizationId
 
   if (!isCalendarConfigured()) {

--- a/server/api/calendar/google/callback.get.ts
+++ b/server/api/calendar/google/callback.get.ts
@@ -11,20 +11,30 @@ import { handleCalendarOAuthCallback } from '../../../utils/calendarOAuth'
 const GOOGLE_CALLBACK_PATH = '/api/calendar/google/callback'
 
 export default defineEventHandler(async (event) => {
-  const session = await requireAuth(event)
+  const session = await requirePermission(event, { organization: ['update'] })
+  const activeOrgId = session.session.activeOrganizationId
+
+  if (!activeOrgId) {
+    throw createError({ statusCode: 403, statusMessage: 'No active organization' })
+  }
 
   return handleCalendarOAuthCallback(event, {
     stateCookieName: 'gcal_oauth_state',
     callbackPath: GOOGLE_CALLBACK_PATH,
+    extraCookieNames: ['gcal_oauth_org'],
     consentDeniedRedirect: '/dashboard/settings/integrations?error=consent_denied',
     successRedirect: '/dashboard/settings/integrations?success=connected',
     oauthFailedRedirect: '/dashboard/settings/integrations?error=oauth_failed',
     logFailureEvent: 'calendar.oauth_callback_failed',
-    onSuccess: async ({ code }) => {
-      const tokens = await exchangeCodeForTokens(code)
-      await saveCalendarIntegration(session.user.id, tokens)
+    onSuccess: async ({ code, extraCookies }) => {
+      if (extraCookies.gcal_oauth_org !== activeOrgId) {
+        throw new Error('Google Calendar organization changed during authorization')
+      }
 
-      setupCalendarWebhook(session.user.id).catch((err) => {
+      const tokens = await exchangeCodeForTokens(code)
+      const integration = await saveCalendarIntegration(session.user.id, activeOrgId, tokens)
+
+      setupCalendarWebhook(integration).catch((err) => {
         logWarn('calendar.webhook_setup_failed', {
           posthog_distinct_id: session.user.id,
           error_message: err instanceof Error ? err.message : String(err),

--- a/server/api/calendar/google/connect.get.ts
+++ b/server/api/calendar/google/connect.get.ts
@@ -10,7 +10,12 @@ import { initiateCalendarOAuth } from '../../../utils/calendarOAuth'
 const GOOGLE_CALLBACK_PATH = '/api/calendar/google/callback'
 
 export default defineEventHandler(async (event) => {
-  await requireAuth(event)
+  const session = await requirePermission(event, { organization: ['update'] })
+  const orgId = session.session.activeOrganizationId
+
+  if (!orgId) {
+    throw createError({ statusCode: 403, statusMessage: 'No active organization' })
+  }
 
   if (!isGoogleCalendarConfigured()) {
     throw createError({
@@ -22,6 +27,7 @@ export default defineEventHandler(async (event) => {
   return initiateCalendarOAuth(event, {
     stateCookieName: 'gcal_oauth_state',
     callbackPath: GOOGLE_CALLBACK_PATH,
+    extraCookies: [{ name: 'gcal_oauth_org', value: orgId }],
     getAuthUrl: getGoogleAuthUrl,
   })
 })

--- a/server/api/calendar/microsoft/callback.get.ts
+++ b/server/api/calendar/microsoft/callback.get.ts
@@ -14,7 +14,7 @@ import { handleCalendarOAuthCallback } from '../../../utils/calendarOAuth'
 const MICROSOFT_CALLBACK_PATH = '/api/calendar/microsoft/callback'
 
 export default defineEventHandler(async (event) => {
-  const session = await requireAuth(event)
+  const session = await requirePermission(event, { organization: ['update'] })
   const activeOrgId = session.session.activeOrganizationId
 
   return handleCalendarOAuthCallback(event, {

--- a/server/api/calendar/microsoft/callback.get.ts
+++ b/server/api/calendar/microsoft/callback.get.ts
@@ -17,6 +17,10 @@ export default defineEventHandler(async (event) => {
   const session = await requirePermission(event, { organization: ['update'] })
   const activeOrgId = session.session.activeOrganizationId
 
+  if (!activeOrgId) {
+    throw createError({ statusCode: 403, statusMessage: 'No active organization' })
+  }
+
   return handleCalendarOAuthCallback(event, {
     stateCookieName: 'mscal_oauth_state',
     callbackPath: MICROSOFT_CALLBACK_PATH,
@@ -33,13 +37,12 @@ export default defineEventHandler(async (event) => {
       return null
     },
     onSuccess: async ({ code, extraCookies }) => {
-      const orgId = extraCookies.mscal_oauth_org || activeOrgId
-      if (!orgId) {
-        throw new Error('Missing active organization for Microsoft Calendar connection')
+      if (extraCookies.mscal_oauth_org !== activeOrgId) {
+        throw new Error('Microsoft Calendar organization changed during authorization')
       }
 
       const tokens = await exchangeMicrosoftCodeForTokens(code)
-      await saveMicrosoftCalendarIntegration(session.user.id, orgId, tokens)
+      await saveMicrosoftCalendarIntegration(session.user.id, activeOrgId, tokens)
     },
   })
 })

--- a/server/api/calendar/microsoft/connect.get.ts
+++ b/server/api/calendar/microsoft/connect.get.ts
@@ -5,7 +5,6 @@
  * access. Generates a CSRF state token stored in a secure, httpOnly cookie.
  */
 import {
-  enableMicrosoftCalendarAppIntegration,
   getMicrosoftAuthUrl,
   isMicrosoftCalendarApplicationMode,
   isMicrosoftCalendarConfigured,
@@ -33,7 +32,8 @@ export default defineEventHandler(async (event) => {
   }
 
   if (isMicrosoftCalendarApplicationMode()) {
-    await enableMicrosoftCalendarAppIntegration(orgId)
+    // Application credentials are authoritative server configuration. This
+    // safe GET must never mutate organization integration state.
     return sendRedirect(event, '/dashboard/settings/integrations?success=connected&provider=microsoft')
   }
 

--- a/server/api/calendar/microsoft/connect.get.ts
+++ b/server/api/calendar/microsoft/connect.get.ts
@@ -15,7 +15,7 @@ import { initiateCalendarOAuth } from '../../../utils/calendarOAuth'
 const MICROSOFT_CALLBACK_PATH = '/api/calendar/microsoft/callback'
 
 export default defineEventHandler(async (event) => {
-  const session = await requireAuth(event)
+  const session = await requirePermission(event, { organization: ['update'] })
   const orgId = session.session.activeOrganizationId
 
   if (!isMicrosoftCalendarConfigured()) {

--- a/server/api/calendar/renew-webhooks.post.ts
+++ b/server/api/calendar/renew-webhooks.post.ts
@@ -34,14 +34,16 @@ export default defineEventHandler(async (event) => {
     where: orgId
       ? and(
           eq(calendarIntegration.organizationId, orgId),
+          eq(calendarIntegration.provider, 'google'),
           isNotNull(calendarIntegration.webhookChannelId),
           lt(calendarIntegration.webhookExpiration, expirationThreshold),
         )
       : and(
+          eq(calendarIntegration.provider, 'google'),
           isNotNull(calendarIntegration.webhookChannelId),
           lt(calendarIntegration.webhookExpiration, expirationThreshold),
         ),
-    columns: { userId: true },
+    columns: { id: true, userId: true, organizationId: true },
   })
 
   let renewed = 0
@@ -53,7 +55,11 @@ export default defineEventHandler(async (event) => {
       continue
     }
     try {
-      const success = await setupCalendarWebhook(integration.userId)
+      const success = await setupCalendarWebhook({
+        integrationId: integration.id,
+        userId: integration.userId,
+        organizationId: integration.organizationId,
+      })
       if (success) renewed++
       else failed++
     }

--- a/server/api/calendar/renew-webhooks.post.ts
+++ b/server/api/calendar/renew-webhooks.post.ts
@@ -7,7 +7,7 @@
  *
  * This is an internal endpoint — only callable by authenticated admins/owners.
  */
-import { lt, and, isNotNull } from 'drizzle-orm'
+import { lt, and, eq, isNotNull } from 'drizzle-orm'
 import { calendarIntegration } from '../../database/schema'
 import { setupCalendarWebhook } from '../../utils/google-calendar'
 import { timingSafeStringEqual } from '../../utils/secureCompare'
@@ -15,24 +15,32 @@ import { timingSafeStringEqual } from '../../utils/secureCompare'
 export default defineEventHandler(async (event) => {
   // Check for CRON_SECRET header (server-to-server / scheduled job)
   const cronSecret = getHeader(event, 'x-cron-secret')
-  if (cronSecret && env.CRON_SECRET) {
-    if (!timingSafeStringEqual(cronSecret, env.CRON_SECRET)) {
+  let orgId: string | undefined
+  if (cronSecret !== undefined) {
+    if (!env.CRON_SECRET || !timingSafeStringEqual(cronSecret, env.CRON_SECRET)) {
       throw createError({ statusCode: 403, statusMessage: 'Invalid cron secret' })
     }
   }
   else {
     // Interactive user — require authentication + admin-level permission
-    await requirePermission(event, { interview: ['update'] })
+    const session = await requirePermission(event, { organization: ['update'] })
+    orgId = session.session.activeOrganizationId
   }
 
   // Find all integrations with webhooks expiring within the next 24 hours
   const expirationThreshold = new Date(Date.now() + 24 * 60 * 60 * 1000)
 
   const expiring = await db.query.calendarIntegration.findMany({
-    where: and(
-      isNotNull(calendarIntegration.webhookChannelId),
-      lt(calendarIntegration.webhookExpiration, expirationThreshold),
-    ),
+    where: orgId
+      ? and(
+          eq(calendarIntegration.organizationId, orgId),
+          isNotNull(calendarIntegration.webhookChannelId),
+          lt(calendarIntegration.webhookExpiration, expirationThreshold),
+        )
+      : and(
+          isNotNull(calendarIntegration.webhookChannelId),
+          lt(calendarIntegration.webhookExpiration, expirationThreshold),
+        ),
     columns: { userId: true },
   })
 

--- a/server/api/calendar/renew-webhooks.post.ts
+++ b/server/api/calendar/renew-webhooks.post.ts
@@ -7,7 +7,7 @@
  *
  * This is an internal endpoint — only callable by authenticated admins/owners.
  */
-import { lt, and, eq, isNotNull } from 'drizzle-orm'
+import { lt, and, eq, isNull, or } from 'drizzle-orm'
 import { calendarIntegration } from '../../database/schema'
 import { setupCalendarWebhook } from '../../utils/google-calendar'
 import { timingSafeStringEqual } from '../../utils/secureCompare'
@@ -35,13 +35,19 @@ export default defineEventHandler(async (event) => {
       ? and(
           eq(calendarIntegration.organizationId, orgId),
           eq(calendarIntegration.provider, 'google'),
-          isNotNull(calendarIntegration.webhookChannelId),
-          lt(calendarIntegration.webhookExpiration, expirationThreshold),
+          or(
+            isNull(calendarIntegration.webhookChannelId),
+            isNull(calendarIntegration.webhookExpiration),
+            lt(calendarIntegration.webhookExpiration, expirationThreshold),
+          ),
         )
       : and(
           eq(calendarIntegration.provider, 'google'),
-          isNotNull(calendarIntegration.webhookChannelId),
-          lt(calendarIntegration.webhookExpiration, expirationThreshold),
+          or(
+            isNull(calendarIntegration.webhookChannelId),
+            isNull(calendarIntegration.webhookExpiration),
+            lt(calendarIntegration.webhookExpiration, expirationThreshold),
+          ),
         ),
     columns: { id: true, userId: true, organizationId: true },
   })

--- a/server/api/calendar/webhook.post.ts
+++ b/server/api/calendar/webhook.post.ts
@@ -9,7 +9,7 @@
  * Security is ensured by validating the X-Goog-Channel-ID header against
  * stored webhook channel IDs in the database.
  */
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { calendarIntegration } from '../../database/schema'
 import { performIncrementalSync } from '../../utils/google-calendar'
 
@@ -38,8 +38,11 @@ export default defineEventHandler(async (event) => {
 
   // Find the integration associated with this webhook channel
   const integration = await db.query.calendarIntegration.findFirst({
-    where: eq(calendarIntegration.webhookChannelId, channelId),
-    columns: { userId: true, webhookResourceId: true },
+    where: and(
+      eq(calendarIntegration.webhookChannelId, channelId),
+      eq(calendarIntegration.provider, 'google'),
+    ),
+    columns: { id: true, userId: true, organizationId: true, webhookResourceId: true },
   })
 
   if (!integration) {
@@ -61,7 +64,11 @@ export default defineEventHandler(async (event) => {
     return { ok: true }
   }
 
-  performIncrementalSync(userId).catch(err => {
+  performIncrementalSync({
+    integrationId: integration.id,
+    userId,
+    organizationId: integration.organizationId,
+  }).catch(err => {
     logError('calendar.webhook_sync_failed', {
       posthog_distinct_id: userId,
       error_message: err instanceof Error ? err.message : String(err),

--- a/server/api/candidates/index.get.ts
+++ b/server/api/candidates/index.get.ts
@@ -1,95 +1,109 @@
 import { eq, and, or, ilike, desc, sql, gte, lte, inArray } from 'drizzle-orm'
+import type { z } from 'zod'
 import { candidate, application } from '../../database/schema'
-import { paginatedListResponse, paginationOffset } from '../../utils/schemas/common'
-import { candidateQuerySchema } from '../../utils/schemas/candidate'
 import {
-  loadPropertyEntriesForEntities,
-} from '../../utils/properties'
-import { matchingEntityIdsForPropertyFilters, parsePropertyFiltersParam } from '../../utils/propertyFilters'
+  paginatedListResponse,
+  paginationOffset,
+} from '../../utils/schemas/common'
+import { candidateQuerySchema } from '../../utils/schemas/candidate'
+import { loadPropertyEntriesForEntities } from '../../utils/properties'
+import {
+  matchingEntityIdsForPropertyFilters,
+  parsePropertyFiltersParam,
+} from '../../utils/propertyFilters'
 
-export default defineCachedEventHandler(async (event) => {
-  const session = await requirePermission(event, { candidate: ['read'] })
-  const orgId = session.session.activeOrganizationId
+const getCachedCandidates = defineOrgScopedCachedFunction(
+  'candidates-list',
+  async (orgId, query: z.infer<typeof candidateQuerySchema>) => {
+    const offset = paginationOffset(query.page, query.limit)
+    const conditions = [eq(candidate.organizationId, orgId)]
 
-  const query = await getValidatedQuery(event, candidateQuerySchema.parse)
+    if (query.search) {
+      // Escape LIKE meta-characters to prevent pattern injection
+      const escaped = query.search.replace(/[%_\\]/g, '\\$&')
+      const pattern = `%${escaped}%`
+      conditions.push(
+        or(
+          ilike(candidate.firstName, pattern),
+          ilike(candidate.lastName, pattern),
+          ilike(candidate.email, pattern),
+        )!,
+      )
+    }
 
-  const offset = paginationOffset(query.page, query.limit)
-  const conditions = [eq(candidate.organizationId, orgId)]
+    if (query.gender) {
+      conditions.push(eq(candidate.gender, query.gender))
+    }
 
-  if (query.search) {
-    // Escape LIKE meta-characters to prevent pattern injection
-    const escaped = query.search.replace(/[%_\\]/g, '\\$&')
-    const pattern = `%${escaped}%`
-    conditions.push(
-      or(
-        ilike(candidate.firstName, pattern),
-        ilike(candidate.lastName, pattern),
-        ilike(candidate.email, pattern),
-      )!,
-    )
-  }
+    // dateOfBirth is stored as ISO 8601 text (YYYY-MM-DD), so lexicographic comparison works
+    if (query.dobFrom) {
+      conditions.push(gte(candidate.dateOfBirth, query.dobFrom))
+    }
+    if (query.dobTo) {
+      conditions.push(lte(candidate.dateOfBirth, query.dobTo))
+    }
 
-  if (query.gender) {
-    conditions.push(eq(candidate.gender, query.gender))
-  }
+    const propertyFilters = parsePropertyFiltersParam(query.propertyFilters)
+    if (propertyFilters.length > 0) {
+      const matching = await matchingEntityIdsForPropertyFilters({
+        organizationId: orgId,
+        entityType: 'candidate',
+        filters: propertyFilters,
+      })
+      if (!matching || matching.size === 0) {
+        return paginatedListResponse([], 0, query.page, query.limit)
+      }
+      conditions.push(inArray(candidate.id, [...matching]))
+    }
 
-  // dateOfBirth is stored as ISO 8601 text (YYYY-MM-DD), so lexicographic comparison works
-  if (query.dobFrom) {
-    conditions.push(gte(candidate.dateOfBirth, query.dobFrom))
-  }
-  if (query.dobTo) {
-    conditions.push(lte(candidate.dateOfBirth, query.dobTo))
-  }
+    const where = and(...conditions)
 
-  const propertyFilters = parsePropertyFiltersParam(query.propertyFilters)
-  if (propertyFilters.length > 0) {
-    const matching = await matchingEntityIdsForPropertyFilters({
+    const [data, total] = await Promise.all([
+      db
+        .select({
+          id: candidate.id,
+          firstName: candidate.firstName,
+          lastName: candidate.lastName,
+          displayName: candidate.displayName,
+          email: candidate.email,
+          phone: candidate.phone,
+          gender: candidate.gender,
+          dateOfBirth: candidate.dateOfBirth,
+          quickNotes: candidate.quickNotes,
+          createdAt: candidate.createdAt,
+          updatedAt: candidate.updatedAt,
+          applicationCount: sql<number>`count(${application.id})::int`,
+        })
+        .from(candidate)
+        .leftJoin(application, eq(application.candidateId, candidate.id))
+        .where(where)
+        .groupBy(candidate.id)
+        .orderBy(desc(candidate.createdAt))
+        .limit(query.limit)
+        .offset(offset),
+      db.$count(candidate, where),
+    ])
+
+    // Bulk-attach properties for the current page
+    const ids = data.map(c => c.id)
+    const propertyMap = await loadPropertyEntriesForEntities({
       organizationId: orgId,
       entityType: 'candidate',
-      filters: propertyFilters,
+      entityIds: ids,
     })
-    if (!matching || matching.size === 0) {
-      return paginatedListResponse([], 0, query.page, query.limit)
-    }
-    conditions.push(inArray(candidate.id, [...matching]))
-  }
+    const enriched = data.map(c => ({
+      ...c,
+      properties: propertyMap.get(c.id) ?? [],
+    }))
 
-  const where = and(...conditions)
+    return paginatedListResponse(enriched, total, query.page, query.limit)
+  },
+)
 
-  const [data, total] = await Promise.all([
-    db
-      .select({
-        id: candidate.id,
-        firstName: candidate.firstName,
-        lastName: candidate.lastName,
-        displayName: candidate.displayName,
-        email: candidate.email,
-        phone: candidate.phone,
-        gender: candidate.gender,
-        dateOfBirth: candidate.dateOfBirth,
-        quickNotes: candidate.quickNotes,
-        createdAt: candidate.createdAt,
-        updatedAt: candidate.updatedAt,
-        applicationCount: sql<number>`count(${application.id})::int`,
-      })
-      .from(candidate)
-      .leftJoin(application, eq(application.candidateId, candidate.id))
-      .where(where)
-      .groupBy(candidate.id)
-      .orderBy(desc(candidate.createdAt))
-      .limit(query.limit)
-      .offset(offset),
-    db.$count(candidate, where),
-  ])
+export default defineEventHandler(async event => {
+  const session = await requirePermission(event, { candidate: ['read'] })
+  const orgId = session.session.activeOrganizationId
+  const query = await getValidatedQuery(event, candidateQuerySchema.parse)
 
-  // Bulk-attach properties for the current page
-  const ids = data.map((c) => c.id)
-  const propertyMap = await loadPropertyEntriesForEntities({
-    organizationId: orgId,
-    entityType: 'candidate',
-    entityIds: ids,
-  })
-  const enriched = data.map((c) => ({ ...c, properties: propertyMap.get(c.id) ?? [] }))
-
-  return paginatedListResponse(enriched, total, query.page, query.limit)
-}, orgScopedCacheOptions)
+  return getCachedCandidates(orgId, query)
+})

--- a/server/api/compliance/applications/summary.get.ts
+++ b/server/api/compliance/applications/summary.get.ts
@@ -62,7 +62,7 @@ export default defineEventHandler(async (event) => {
   return {
     jurisdiction: 'US',
     formVersion: 'US-SELF-ID-2026-05',
-    totalResponses,
+    totalResponses: protectedReporting.totalResponses,
     suppressed: protectedReporting.suppressed,
     minimumCohortSize: protectedReporting.minimumCohortSize,
     breakdowns: protectedReporting.breakdowns,

--- a/server/api/compliance/applications/summary.get.ts
+++ b/server/api/compliance/applications/summary.get.ts
@@ -1,14 +1,15 @@
 import { count, eq, sql } from 'drizzle-orm'
 import { applicationComplianceResponse } from '../../../database/schema'
+import { protectComplianceReporting } from '../../../utils/complianceReporting'
 
 /**
  * GET /api/compliance/applications/summary
- * Dashboard-only aggregate compliance reporting for the active organization.
+ * Owner/admin-only aggregate compliance reporting for the active organization.
  * Returns grouped counts only; individual self-identification answers are not
  * exposed to ordinary candidate/application evaluation surfaces.
  */
 export default defineEventHandler(async (event) => {
-  const session = await requirePermission(event, { application: ['read'] })
+  const session = await requirePermission(event, { organization: ['update'] })
   const orgId = session.session.activeOrganizationId
 
   const [totalResponses, sex, raceEthnicity, veteranStatus, disabilityStatus] = await Promise.all([
@@ -51,19 +52,19 @@ export default defineEventHandler(async (event) => {
       .orderBy(sql`count(*) desc`),
   ])
 
+  const protectedReporting = protectComplianceReporting(totalResponses, {
+    sex,
+    raceEthnicity,
+    veteranStatus,
+    disabilityStatus,
+  })
+
   return {
     jurisdiction: 'US',
     formVersion: 'US-SELF-ID-2026-05',
     totalResponses,
-    breakdowns: {
-      sex: omitNullBuckets(sex),
-      raceEthnicity: omitNullBuckets(raceEthnicity),
-      veteranStatus: omitNullBuckets(veteranStatus),
-      disabilityStatus: omitNullBuckets(disabilityStatus),
-    },
+    suppressed: protectedReporting.suppressed,
+    minimumCohortSize: protectedReporting.minimumCohortSize,
+    breakdowns: protectedReporting.breakdowns,
   }
 })
-
-function omitNullBuckets(rows: Array<{ value: string | null; count: number }>) {
-  return rows.filter((row) => row.value !== null)
-}

--- a/server/api/dashboard/stats.get.ts
+++ b/server/api/dashboard/stats.get.ts
@@ -14,127 +14,165 @@ import { application, candidate, job } from '../../database/schema'
 // Server-side SWR cache for dashboard stats (30s).
 // This is safe because the data is org-scoped and read-mostly.
 // Repeated calls from the same org within the window get a fast cached response.
-export default defineCachedEventHandler(async (event) => {
-  const session = await requirePermission(event, { job: ['read'], candidate: ['read'], application: ['read'] })
+const getCachedDashboardStats = defineOrgScopedCachedFunction(
+  'dashboard-stats',
+  async (orgId, _input: Record<string, never>) => {
+    // ─────────────────────────────────────────────
+    // Run all queries in parallel for performance
+    // ─────────────────────────────────────────────
+    const [
+      openJobsCount,
+      totalCandidatesCount,
+      totalApplicationsCount,
+      newApplicationsCount,
+      pipelineRows,
+      jobStatusRows,
+      recentApplications,
+      topJobs,
+    ] = await Promise.all([
+      // 1. Open jobs count
+      db.$count(
+        job,
+        and(eq(job.organizationId, orgId), eq(job.status, 'open')),
+      ),
+
+      // 2. Total candidates
+      db.$count(candidate, eq(candidate.organizationId, orgId)),
+
+      // 3. Total applications
+      db.$count(application, eq(application.organizationId, orgId)),
+
+      // 4. New (unreviewed) applications
+      db.$count(
+        application,
+        and(
+          eq(application.organizationId, orgId),
+          eq(application.status, 'new'),
+        ),
+      ),
+
+      // 5. Pipeline breakdown — application count per status
+      db
+        .select({
+          status: application.status,
+          count: count().as('count'),
+        })
+        .from(application)
+        .where(eq(application.organizationId, orgId))
+        .groupBy(application.status),
+
+      // 6. Jobs by status
+      db
+        .select({
+          status: job.status,
+          count: count().as('count'),
+        })
+        .from(job)
+        .where(eq(job.organizationId, orgId))
+        .groupBy(job.status),
+
+      // 7. Recent applications (last 10) with candidate + job details
+      db
+        .select({
+          id: application.id,
+          status: application.status,
+          createdAt: application.createdAt,
+          candidateId: application.candidateId,
+          candidateFirstName: candidate.firstName,
+          candidateLastName: candidate.lastName,
+          candidateEmail: candidate.email,
+          jobId: application.jobId,
+          jobTitle: job.title,
+        })
+        .from(application)
+        .innerJoin(candidate, eq(candidate.id, application.candidateId))
+        .innerJoin(job, eq(job.id, application.jobId))
+        .where(eq(application.organizationId, orgId))
+        .orderBy(desc(application.createdAt))
+        .limit(10),
+
+      // 8. Top 5 active (open) jobs by total application count + per-status breakdown
+      db
+        .select({
+          id: job.id,
+          title: job.title,
+          slug: job.slug,
+          status: job.status,
+          createdAt: job.createdAt,
+          applicationCount: count(application.id).as('application_count'),
+          newCount:
+            sql<number>`count(case when ${application.status} = 'new' then 1 end)`.as(
+              'new_count',
+            ),
+          screeningCount:
+            sql<number>`count(case when ${application.status} = 'screening' then 1 end)`.as(
+              'screening_count',
+            ),
+          interviewCount:
+            sql<number>`count(case when ${application.status} = 'interview' then 1 end)`.as(
+              'interview_count',
+            ),
+          offerCount:
+            sql<number>`count(case when ${application.status} = 'offer' then 1 end)`.as(
+              'offer_count',
+            ),
+          hiredCount:
+            sql<number>`count(case when ${application.status} = 'hired' then 1 end)`.as(
+              'hired_count',
+            ),
+          rejectedCount:
+            sql<number>`count(case when ${application.status} = 'rejected' then 1 end)`.as(
+              'rejected_count',
+            ),
+        })
+        .from(job)
+        .leftJoin(application, eq(application.jobId, job.id))
+        .where(and(eq(job.organizationId, orgId), eq(job.status, 'open')))
+        .groupBy(job.id)
+        .orderBy(sql`count(${application.id}) desc`)
+        .limit(5),
+    ])
+
+    // ─────────────────────────────────────────────
+    // Transform grouped rows into keyed objects
+    // ─────────────────────────────────────────────
+    const pipeline: Record<string, number> = emptyPipelineCounts()
+    for (const row of pipelineRows) {
+      pipeline[row.status] = row.count
+    }
+
+    const jobsByStatus: Record<string, number> = {
+      draft: 0,
+      open: 0,
+      closed: 0,
+      archived: 0,
+    }
+    for (const row of jobStatusRows) {
+      jobsByStatus[row.status] = row.count
+    }
+
+    return {
+      counts: {
+        openJobs: openJobsCount,
+        totalCandidates: totalCandidatesCount,
+        totalApplications: totalApplicationsCount,
+        newApplications: newApplicationsCount,
+      },
+      pipeline,
+      jobsByStatus,
+      recentApplications,
+      topJobs,
+    }
+  },
+)
+
+export default defineEventHandler(async event => {
+  const session = await requirePermission(event, {
+    job: ['read'],
+    candidate: ['read'],
+    application: ['read'],
+  })
   const orgId = session.session.activeOrganizationId
 
-  // ─────────────────────────────────────────────
-  // Run all queries in parallel for performance
-  // ─────────────────────────────────────────────
-  const [
-    openJobsCount,
-    totalCandidatesCount,
-    totalApplicationsCount,
-    newApplicationsCount,
-    pipelineRows,
-    jobStatusRows,
-    recentApplications,
-    topJobs,
-  ] = await Promise.all([
-    // 1. Open jobs count
-    db.$count(job, and(eq(job.organizationId, orgId), eq(job.status, 'open'))),
-
-    // 2. Total candidates
-    db.$count(candidate, eq(candidate.organizationId, orgId)),
-
-    // 3. Total applications
-    db.$count(application, eq(application.organizationId, orgId)),
-
-    // 4. New (unreviewed) applications
-    db.$count(application, and(eq(application.organizationId, orgId), eq(application.status, 'new'))),
-
-    // 5. Pipeline breakdown — application count per status
-    db
-      .select({
-        status: application.status,
-        count: count().as('count'),
-      })
-      .from(application)
-      .where(eq(application.organizationId, orgId))
-      .groupBy(application.status),
-
-    // 6. Jobs by status
-    db
-      .select({
-        status: job.status,
-        count: count().as('count'),
-      })
-      .from(job)
-      .where(eq(job.organizationId, orgId))
-      .groupBy(job.status),
-
-    // 7. Recent applications (last 10) with candidate + job details
-    db
-      .select({
-        id: application.id,
-        status: application.status,
-        createdAt: application.createdAt,
-        candidateId: application.candidateId,
-        candidateFirstName: candidate.firstName,
-        candidateLastName: candidate.lastName,
-        candidateEmail: candidate.email,
-        jobId: application.jobId,
-        jobTitle: job.title,
-      })
-      .from(application)
-      .innerJoin(candidate, eq(candidate.id, application.candidateId))
-      .innerJoin(job, eq(job.id, application.jobId))
-      .where(eq(application.organizationId, orgId))
-      .orderBy(desc(application.createdAt))
-      .limit(10),
-
-    // 8. Top 5 active (open) jobs by total application count + per-status breakdown
-    db
-      .select({
-        id: job.id,
-        title: job.title,
-        slug: job.slug,
-        status: job.status,
-        createdAt: job.createdAt,
-        applicationCount: count(application.id).as('application_count'),
-        newCount: sql<number>`count(case when ${application.status} = 'new' then 1 end)`.as('new_count'),
-        screeningCount: sql<number>`count(case when ${application.status} = 'screening' then 1 end)`.as('screening_count'),
-        interviewCount: sql<number>`count(case when ${application.status} = 'interview' then 1 end)`.as('interview_count'),
-        offerCount: sql<number>`count(case when ${application.status} = 'offer' then 1 end)`.as('offer_count'),
-        hiredCount: sql<number>`count(case when ${application.status} = 'hired' then 1 end)`.as('hired_count'),
-        rejectedCount: sql<number>`count(case when ${application.status} = 'rejected' then 1 end)`.as('rejected_count'),
-      })
-      .from(job)
-      .leftJoin(application, eq(application.jobId, job.id))
-      .where(and(eq(job.organizationId, orgId), eq(job.status, 'open')))
-      .groupBy(job.id)
-      .orderBy(sql`count(${application.id}) desc`)
-      .limit(5),
-  ])
-
-  // ─────────────────────────────────────────────
-  // Transform grouped rows into keyed objects
-  // ─────────────────────────────────────────────
-  const pipeline: Record<string, number> = emptyPipelineCounts()
-  for (const row of pipelineRows) {
-    pipeline[row.status] = row.count
-  }
-
-  const jobsByStatus: Record<string, number> = {
-    draft: 0,
-    open: 0,
-    closed: 0,
-    archived: 0,
-  }
-  for (const row of jobStatusRows) {
-    jobsByStatus[row.status] = row.count
-  }
-
-  return {
-    counts: {
-      openJobs: openJobsCount,
-      totalCandidates: totalCandidatesCount,
-      totalApplications: totalApplicationsCount,
-      newApplications: newApplicationsCount,
-    },
-    pipeline,
-    jobsByStatus,
-    recentApplications,
-    topJobs,
-  }
-}, orgScopedCacheOptions)
+  return getCachedDashboardStats(orgId, {})
+})

--- a/server/api/interviews/index.get.ts
+++ b/server/api/interviews/index.get.ts
@@ -1,77 +1,84 @@
 import { and, count, desc, eq, gte, lte } from 'drizzle-orm'
+import type { z } from 'zod'
 import { interview, application, candidate, job } from '../../database/schema'
 import { interviewQuerySchema } from '../../utils/schemas/interview'
 
-export default defineCachedEventHandler(async (event) => {
+const getCachedInterviews = defineOrgScopedCachedFunction(
+  'interviews-list',
+  async (orgId, query: z.infer<typeof interviewQuerySchema>) => {
+    const conditions = [eq(interview.organizationId, orgId)]
+
+    if (query.applicationId) {
+      conditions.push(eq(interview.applicationId, query.applicationId))
+    }
+    if (query.jobId) {
+      conditions.push(eq(application.jobId, query.jobId))
+    }
+    if (query.status) {
+      conditions.push(eq(interview.status, query.status))
+    }
+    if (query.from) {
+      conditions.push(gte(interview.scheduledAt, new Date(query.from)))
+    }
+    if (query.to) {
+      conditions.push(lte(interview.scheduledAt, new Date(query.to)))
+    }
+
+    const whereClause = and(...conditions)
+
+    const [data, total] = await Promise.all([
+      db
+        .select({
+          id: interview.id,
+          title: interview.title,
+          type: interview.type,
+          status: interview.status,
+          scheduledAt: interview.scheduledAt,
+          duration: interview.duration,
+          location: interview.location,
+          notes: interview.notes,
+          interviewers: interview.interviewers,
+          invitationSentAt: interview.invitationSentAt,
+          candidateResponse: interview.candidateResponse,
+          candidateRespondedAt: interview.candidateRespondedAt,
+          calendarEventProvider: interview.calendarEventProvider,
+          googleCalendarEventId: interview.googleCalendarEventId,
+          googleCalendarEventLink: interview.googleCalendarEventLink,
+          createdAt: interview.createdAt,
+          updatedAt: interview.updatedAt,
+          applicationId: interview.applicationId,
+          candidateFirstName: candidate.firstName,
+          candidateLastName: candidate.lastName,
+          candidateEmail: candidate.email,
+          jobId: application.jobId,
+          jobTitle: job.title,
+        })
+        .from(interview)
+        .innerJoin(application, eq(application.id, interview.applicationId))
+        .innerJoin(candidate, eq(candidate.id, application.candidateId))
+        .innerJoin(job, eq(job.id, application.jobId))
+        .where(whereClause)
+        .orderBy(desc(interview.scheduledAt))
+        .limit(query.limit)
+        .offset((query.page - 1) * query.limit),
+      db
+        .select({ count: count() })
+        .from(interview)
+        .innerJoin(application, eq(application.id, interview.applicationId))
+        .innerJoin(candidate, eq(candidate.id, application.candidateId))
+        .innerJoin(job, eq(job.id, application.jobId))
+        .where(whereClause)
+        .then(rows => rows[0]?.count ?? 0),
+    ])
+
+    return { data, total, page: query.page, limit: query.limit }
+  },
+)
+
+export default defineEventHandler(async event => {
   const session = await requirePermission(event, { interview: ['read'] })
   const orgId = session.session.activeOrganizationId
-
   const query = await getValidatedQuery(event, interviewQuerySchema.parse)
 
-  const conditions = [eq(interview.organizationId, orgId)]
-
-  if (query.applicationId) {
-    conditions.push(eq(interview.applicationId, query.applicationId))
-  }
-  if (query.jobId) {
-    conditions.push(eq(application.jobId, query.jobId))
-  }
-  if (query.status) {
-    conditions.push(eq(interview.status, query.status))
-  }
-  if (query.from) {
-    conditions.push(gte(interview.scheduledAt, new Date(query.from)))
-  }
-  if (query.to) {
-    conditions.push(lte(interview.scheduledAt, new Date(query.to)))
-  }
-
-  const whereClause = and(...conditions)
-
-  const [data, total] = await Promise.all([
-    db
-      .select({
-        id: interview.id,
-        title: interview.title,
-        type: interview.type,
-        status: interview.status,
-        scheduledAt: interview.scheduledAt,
-        duration: interview.duration,
-        location: interview.location,
-        notes: interview.notes,
-        interviewers: interview.interviewers,
-        invitationSentAt: interview.invitationSentAt,
-        candidateResponse: interview.candidateResponse,
-        candidateRespondedAt: interview.candidateRespondedAt,
-        calendarEventProvider: interview.calendarEventProvider,
-        googleCalendarEventId: interview.googleCalendarEventId,
-        googleCalendarEventLink: interview.googleCalendarEventLink,
-        createdAt: interview.createdAt,
-        updatedAt: interview.updatedAt,
-        applicationId: interview.applicationId,
-        candidateFirstName: candidate.firstName,
-        candidateLastName: candidate.lastName,
-        candidateEmail: candidate.email,
-        jobId: application.jobId,
-        jobTitle: job.title,
-      })
-      .from(interview)
-      .innerJoin(application, eq(application.id, interview.applicationId))
-      .innerJoin(candidate, eq(candidate.id, application.candidateId))
-      .innerJoin(job, eq(job.id, application.jobId))
-      .where(whereClause)
-      .orderBy(desc(interview.scheduledAt))
-      .limit(query.limit)
-      .offset((query.page - 1) * query.limit),
-    db
-      .select({ count: count() })
-      .from(interview)
-      .innerJoin(application, eq(application.id, interview.applicationId))
-      .innerJoin(candidate, eq(candidate.id, application.candidateId))
-      .innerJoin(job, eq(job.id, application.jobId))
-      .where(whereClause)
-      .then(rows => rows[0]?.count ?? 0),
-  ])
-
-  return { data, total, page: query.page, limit: query.limit }
-}, orgScopedCacheOptions)
+  return getCachedInterviews(orgId, query)
+})

--- a/server/api/jobs/index.get.ts
+++ b/server/api/jobs/index.get.ts
@@ -1,73 +1,88 @@
 import { eq, and, desc, count, inArray } from 'drizzle-orm'
+import type { z } from 'zod'
 import { job, application } from '../../database/schema'
-import { emptyPipelineCounts, type PipelineCounts } from '~~/shared/application-status'
-import { paginatedListResponse, paginationOffset } from '../../utils/schemas/common'
+import {
+  emptyPipelineCounts,
+  type PipelineCounts,
+} from '~~/shared/application-status'
+import {
+  paginatedListResponse,
+  paginationOffset,
+} from '../../utils/schemas/common'
 import { jobQuerySchema } from '../../utils/schemas/job'
 
-export default defineCachedEventHandler(async (event) => {
+const getCachedJobs = defineOrgScopedCachedFunction(
+  'jobs-list',
+  async (orgId, query: z.infer<typeof jobQuerySchema>) => {
+    const offset = paginationOffset(query.page, query.limit)
+    const conditions = [eq(job.organizationId, orgId)]
+    if (query.status) conditions.push(eq(job.status, query.status))
+
+    const [data, total] = await Promise.all([
+      db.query.job.findMany({
+        where: and(...conditions),
+        limit: query.limit,
+        offset,
+        orderBy: [desc(job.createdAt)],
+        columns: {
+          id: true,
+          title: true,
+          slug: true,
+          description: true,
+          divisions: true,
+          descriptionBlocks: true,
+          location: true,
+          type: true,
+          status: true,
+          experienceLevel: true,
+          remoteStatus: true,
+          activeFrom: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      }),
+      db.$count(job, and(...conditions)),
+    ])
+
+    // Fetch pipeline counts (application status breakdown) for returned jobs
+    const jobIds = data.map(j => j.id)
+    let pipelineMap: Record<string, PipelineCounts> = {}
+
+    if (jobIds.length > 0) {
+      const pipelineRows = await db
+        .select({
+          jobId: application.jobId,
+          status: application.status,
+          count: count().as('count'),
+        })
+        .from(application)
+        .where(
+          and(
+            eq(application.organizationId, orgId),
+            inArray(application.jobId, jobIds),
+          ),
+        )
+        .groupBy(application.jobId, application.status)
+
+      for (const row of pipelineRows) {
+        const entry = (pipelineMap[row.jobId] ??= emptyPipelineCounts())
+        entry[row.status as keyof PipelineCounts] = row.count
+      }
+    }
+
+    const enrichedData = data.map(j => ({
+      ...j,
+      pipeline: pipelineMap[j.id] ?? emptyPipelineCounts(),
+    }))
+
+    return paginatedListResponse(enrichedData, total, query.page, query.limit)
+  },
+)
+
+export default defineEventHandler(async event => {
   const session = await requirePermission(event, { job: ['read'] })
   const orgId = session.session.activeOrganizationId
-
   const query = await getValidatedQuery(event, jobQuerySchema.parse)
 
-  const offset = paginationOffset(query.page, query.limit)
-  const conditions = [eq(job.organizationId, orgId)]
-  if (query.status) conditions.push(eq(job.status, query.status))
-
-  const [data, total] = await Promise.all([
-    db.query.job.findMany({
-      where: and(...conditions),
-      limit: query.limit,
-      offset,
-      orderBy: [desc(job.createdAt)],
-      columns: {
-        id: true,
-        title: true,
-        slug: true,
-        description: true,
-        divisions: true,
-        descriptionBlocks: true,
-        location: true,
-        type: true,
-        status: true,
-        experienceLevel: true,
-        remoteStatus: true,
-        activeFrom: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    }),
-    db.$count(job, and(...conditions)),
-  ])
-
-  // Fetch pipeline counts (application status breakdown) for returned jobs
-  const jobIds = data.map((j) => j.id)
-  let pipelineMap: Record<string, PipelineCounts> = {}
-
-  if (jobIds.length > 0) {
-    const pipelineRows = await db
-      .select({
-        jobId: application.jobId,
-        status: application.status,
-        count: count().as('count'),
-      })
-      .from(application)
-      .where(and(
-        eq(application.organizationId, orgId),
-        inArray(application.jobId, jobIds),
-      ))
-      .groupBy(application.jobId, application.status)
-
-    for (const row of pipelineRows) {
-      const entry = (pipelineMap[row.jobId] ??= emptyPipelineCounts())
-      entry[row.status as keyof PipelineCounts] = row.count
-    }
-  }
-
-  const enrichedData = data.map((j) => ({
-    ...j,
-    pipeline: pipelineMap[j.id] ?? emptyPipelineCounts(),
-  }))
-
-  return paginatedListResponse(enrichedData, total, query.page, query.limit)
-}, orgScopedCacheOptions)
+  return getCachedJobs(orgId, query)
+})

--- a/server/database/migrations/0049_google_calendar_organization_backfill.sql
+++ b/server/database/migrations/0049_google_calendar_organization_backfill.sql
@@ -1,0 +1,38 @@
+WITH "single_membership" AS (
+  SELECT
+    "user_id",
+    MIN("organization_id") AS "organization_id"
+  FROM "member"
+  GROUP BY "user_id"
+  HAVING COUNT(*) = 1
+),
+"candidates" AS (
+  SELECT
+    "integration"."id",
+    "membership"."organization_id",
+    COUNT(*) OVER (PARTITION BY "membership"."organization_id") AS "organization_candidate_count"
+  FROM "calendar_integration" AS "integration"
+  INNER JOIN "single_membership" AS "membership"
+    ON "membership"."user_id" = "integration"."user_id"
+  WHERE "integration"."provider" = 'google'
+    AND "integration"."organization_id" IS NULL
+),
+"safe_candidates" AS (
+  SELECT "candidate"."id", "candidate"."organization_id"
+  FROM "candidates" AS "candidate"
+  WHERE "candidate"."organization_candidate_count" = 1
+    AND NOT EXISTS (
+      SELECT 1
+      FROM "calendar_integration" AS "existing"
+      WHERE "existing"."organization_id" = "candidate"."organization_id"
+        AND "existing"."provider" = 'google'
+    )
+)
+UPDATE "calendar_integration" AS "integration"
+SET
+  "organization_id" = "candidate"."organization_id",
+  "updated_at" = NOW()
+FROM "safe_candidates" AS "candidate"
+WHERE "integration"."id" = "candidate"."id"
+  AND "integration"."provider" = 'google'
+  AND "integration"."organization_id" IS NULL;

--- a/server/database/migrations/0050_calendar_connection_generation.sql
+++ b/server/database/migrations/0050_calendar_connection_generation.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "calendar_integration" ADD COLUMN "connection_generation" text;
+
+UPDATE "calendar_integration"
+SET "connection_generation" = "id"
+WHERE "connection_generation" IS NULL;
+
+ALTER TABLE "calendar_integration"
+ALTER COLUMN "connection_generation" SET NOT NULL;

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1779692400000,
       "tag": "0048_salary_display_on_listing",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1784192400000,
+      "tag": "0049_google_calendar_organization_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1784192400000,
       "tag": "0049_google_calendar_organization_backfill",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1784196000000,
+      "tag": "0050_calendar_connection_generation",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database/schema/app.ts
+++ b/server/database/schema/app.ts
@@ -456,6 +456,8 @@ export const calendarIntegration = pgTable('calendar_integration', {
   userId: text('user_id').references(() => user.id, { onDelete: 'cascade' }),
   organizationId: text('organization_id').references(() => organization.id, { onDelete: 'cascade' }),
   provider: calendarProviderEnum('provider').notNull().default('google'),
+  /** Stable connection generation; changes only when OAuth reconnects, not when tokens refresh */
+  connectionGeneration: text('connection_generation').notNull().$defaultFn(() => crypto.randomUUID()),
   /** AES-256-GCM encrypted provider OAuth2 access token (null for app-only integrations) */
   accessTokenEncrypted: text('access_token_encrypted'),
   /** AES-256-GCM encrypted provider OAuth2 refresh token (null for app-only integrations) */

--- a/server/routes/ingest/[...path].ts
+++ b/server/routes/ingest/[...path].ts
@@ -1,119 +1,58 @@
+import { createRateLimiter } from '../../utils/rateLimit'
+import {
+  AnalyticsProxyError,
+  executeAnalyticsProxyRequest,
+  readBoundedAnalyticsRequestBody,
+} from '../../utils/analyticsProxyPolicy'
+
 /**
- * Reverse-proxy: /ingest/** → eu.i.posthog.com/** (and /ingest/static/** →
- * eu-assets.i.posthog.com/**).
+ * Bounded, allowlisted reverse proxy for the PostHog browser SDK.
  *
- * Proxies PostHog API calls (event capture, decide, feature flags) and the
- * autocapture/web-vitals static assets through our domain to bypass
- * ad-blockers.
- *
- * IMPORTANT — why we do NOT use h3's `proxyRequest` here:
- *
- * app.reqcore.com is behind Cloudflare (in front of Railway). Inbound
- * requests therefore arrive carrying CF-* headers (cf-connecting-ip,
- * cf-ray, cf-ipcountry, cf-visitor) plus an X-Forwarded-For chain that
- * starts with a Cloudflare edge IP. `proxyRequest` forwards ALL inbound
- * headers verbatim, so PostHog's Cloudflare sees a request that looks
- * like it came from another Cloudflare-protected site and rejects it
- * with HTTP 403 + Error 1000 ("DNS points to prohibited IP") and an
- * HTML body. The browser then refuses to execute that HTML as JS due
- * to our X-Content-Type-Options: nosniff header — surfacing as
- * NS_ERROR_CORRUPTED_CONTENT / "MIME type mismatch" in the console.
- *
- * Doing a manual `fetch` with an explicit, minimal allow-list of
- * outbound headers sidesteps the problem entirely: Cloudflare sees a
- * normal direct request and serves the asset.
+ * Keeping this proxy on our origin helps analytics survive common ad blockers,
+ * but it must not become a general-purpose proxy to PostHog. The policy helper
+ * therefore owns the exact SDK paths, methods, byte limits, fixed EU hosts,
+ * safe headers, and manual redirect behavior.
  */
 
-// Methods that do not carry a request body (per RFC 9110).  fetch() throws
-// if you pass a body with these methods.
-const BODYLESS_METHODS = new Set(['GET', 'HEAD'])
+const ingestionRateLimit = createRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 120,
+  message: 'Too many analytics ingestion requests. Please retry shortly.',
+})
 
-// Headers we are willing to forward upstream.  Anything not on this list
-// (Cookie, Authorization, all CF-*, X-Forwarded-*, X-Real-IP, Host, etc.)
-// is dropped so PostHog's CDN does not see anything that looks like a
-// proxy/Cloudflare loop.
-const FORWARDABLE_REQUEST_HEADERS = new Set([
-  'accept',
-  'accept-encoding',
-  'accept-language',
-  'content-type',
-  'content-length',
-  'origin',
-  'referer',
-  'user-agent',
-])
-
-// Response headers we strip before relaying back to the browser.  Hop-by-hop
-// headers per RFC 7230 §6.1, plus a couple that would conflict with our own
-// security headers if they leaked through.
-const STRIPPED_RESPONSE_HEADERS = new Set([
-  'connection',
-  'keep-alive',
-  'proxy-authenticate',
-  'proxy-authorization',
-  'te',
-  'trailer',
-  'transfer-encoding',
-  'upgrade',
-  // Let Nitro handle compression negotiation; passing through an upstream
-  // content-encoding alongside a decoded body would corrupt the response.
-  'content-encoding',
-  'content-length',
-])
+const assetRateLimit = createRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 600,
+  message: 'Too many analytics asset requests. Please retry shortly.',
+})
 
 export default defineEventHandler(async (event) => {
-  const path = getRouterParam(event, 'path') || ''
-  const query = getQuery(event)
-  const qs = new URLSearchParams(query as Record<string, string>).toString()
-
-  // Static assets (autocapture scripts, web-vitals, etc.) live on the
-  // assets host. Everything else (capture, decide, flags) goes to the
-  // main ingestion host.
-  const upstreamOrigin = path.startsWith('static/')
-    ? 'https://eu-assets.i.posthog.com'
-    : 'https://eu.i.posthog.com'
-  const target = `${upstreamOrigin}/${path}${qs ? `?${qs}` : ''}`
-
-  const inboundHeaders = getRequestHeaders(event)
-  const outboundHeaders: Record<string, string> = {}
-  for (const [name, value] of Object.entries(inboundHeaders)) {
-    if (!value) continue
-    if (FORWARDABLE_REQUEST_HEADERS.has(name.toLowerCase())) {
-      outboundHeaders[name] = Array.isArray(value) ? value.join(', ') : value
-    }
-  }
-
-  const method = event.method.toUpperCase()
-  const body = BODYLESS_METHODS.has(method)
-    ? undefined
-    : await readRawBody(event, false) // returns Buffer | undefined
-
-  let upstream: Response
   try {
-    upstream = await fetch(target, {
-      method,
-      headers: outboundHeaders,
-      body: body as BodyInit | undefined,
-      redirect: 'manual',
+    const result = await executeAnalyticsProxyRequest({
+      path: getRouterParam(event, 'path') || '',
+      method: event.method,
+      query: getRequestURL(event).searchParams,
+      headers: getRequestHeaders(event),
+      readBody: async (maxBytes) => await readBoundedAnalyticsRequestBody(event.node.req, maxBytes),
+    }, {
+      fetch: globalThis.fetch,
+      enforceRateLimit: async (bucket) => {
+        await (bucket === 'assets' ? assetRateLimit : ingestionRateLimit)(event)
+      },
     })
-  } catch (err) {
-    throw createError({
-      statusCode: 502,
-      statusMessage: 'Bad Gateway',
-      message: `PostHog proxy upstream error: ${(err as Error).message}`,
-    })
+
+    setResponseStatus(event, result.status, result.statusText)
+    result.headers.forEach((value, name) => setResponseHeader(event, name, value))
+    return Buffer.from(result.body)
   }
-
-  // Mirror upstream status & safe headers
-  setResponseStatus(event, upstream.status, upstream.statusText)
-  upstream.headers.forEach((value, name) => {
-    if (!STRIPPED_RESPONSE_HEADERS.has(name.toLowerCase())) {
-      setResponseHeader(event, name, value)
+  catch (error) {
+    if (error instanceof AnalyticsProxyError) {
+      throw createError({
+        statusCode: error.statusCode,
+        statusMessage: error.statusMessage,
+        message: error.message,
+      })
     }
-  })
-
-  // Stream the body back.  Buffer is fine here — PostHog static assets are
-  // small (<200 KB) and capture endpoints return tiny JSON payloads.
-  const buf = Buffer.from(await upstream.arrayBuffer())
-  return buf
+    throw error
+  }
 })

--- a/server/routes/ingest/[...path].ts
+++ b/server/routes/ingest/[...path].ts
@@ -1,8 +1,13 @@
 import {
   AnalyticsProxyError,
+  ANALYTICS_PROXY_TIMEOUT_MS,
   executeAnalyticsProxyRequest,
   readBoundedAnalyticsRequestBody,
 } from '../../utils/analyticsProxyPolicy'
+import {
+  createAnalyticsProxyConcurrencyGuard,
+  holdAnalyticsProxyLeaseUntilResponse,
+} from '../../utils/analyticsProxyConcurrency'
 import { createAnalyticsProxyRateLimitGuard } from '../../utils/analyticsProxyRateLimit'
 
 /**
@@ -15,27 +20,49 @@ import { createAnalyticsProxyRateLimitGuard } from '../../utils/analyticsProxyRa
  */
 
 const enforceAnalyticsProxyRateLimit = createAnalyticsProxyRateLimitGuard()
+const acquireAnalyticsProxyLease = createAnalyticsProxyConcurrencyGuard()
 
 export default defineEventHandler(async (event) => {
+  let releaseLease: (() => void) | undefined
+  let releaseAfterHandler = true
+  let bodyDraining = false
+  const drainBody = () => {
+    if (bodyDraining) return
+    bodyDraining = true
+    event.node.req.resume()
+  }
+  const timeoutSignal = AbortSignal.timeout(ANALYTICS_PROXY_TIMEOUT_MS)
   try {
+    releaseLease = acquireAnalyticsProxyLease()
     const result = await executeAnalyticsProxyRequest({
       path: getRouterParam(event, 'path') || '',
       method: event.method,
       query: getRequestURL(event).searchParams,
       headers: getRequestHeaders(event),
-      readBody: async (maxBytes) => await readBoundedAnalyticsRequestBody(event.node.req, maxBytes),
+      readBody: async (maxBytes, signal) => await readBoundedAnalyticsRequestBody(
+        event.node.req,
+        maxBytes,
+        signal,
+        () => { bodyDraining = true },
+      ),
+      drainBody,
     }, {
       fetch: globalThis.fetch,
       enforceRateLimit: async (bucket) => {
         await enforceAnalyticsProxyRateLimit(event, bucket)
       },
+      timeoutSignal,
     })
 
     setResponseStatus(event, result.status, result.statusText)
     result.headers.forEach((value, name) => setResponseHeader(event, name, value))
-    return Buffer.from(result.body)
+
+    holdAnalyticsProxyLeaseUntilResponse(event.node.res, timeoutSignal, releaseLease)
+    releaseAfterHandler = false
+    return Buffer.from(result.body.buffer, result.body.byteOffset, result.body.byteLength)
   }
   catch (error) {
+    drainBody()
     if (error instanceof AnalyticsProxyError) {
       throw createError({
         statusCode: error.statusCode,
@@ -44,5 +71,8 @@ export default defineEventHandler(async (event) => {
       })
     }
     throw error
+  }
+  finally {
+    if (releaseAfterHandler) releaseLease?.()
   }
 })

--- a/server/routes/ingest/[...path].ts
+++ b/server/routes/ingest/[...path].ts
@@ -1,9 +1,9 @@
-import { createRateLimiter } from '../../utils/rateLimit'
 import {
   AnalyticsProxyError,
   executeAnalyticsProxyRequest,
   readBoundedAnalyticsRequestBody,
 } from '../../utils/analyticsProxyPolicy'
+import { createAnalyticsProxyRateLimitGuard } from '../../utils/analyticsProxyRateLimit'
 
 /**
  * Bounded, allowlisted reverse proxy for the PostHog browser SDK.
@@ -14,17 +14,7 @@ import {
  * safe headers, and manual redirect behavior.
  */
 
-const ingestionRateLimit = createRateLimiter({
-  windowMs: 60_000,
-  maxRequests: 120,
-  message: 'Too many analytics ingestion requests. Please retry shortly.',
-})
-
-const assetRateLimit = createRateLimiter({
-  windowMs: 60_000,
-  maxRequests: 600,
-  message: 'Too many analytics asset requests. Please retry shortly.',
-})
+const enforceAnalyticsProxyRateLimit = createAnalyticsProxyRateLimitGuard()
 
 export default defineEventHandler(async (event) => {
   try {
@@ -37,7 +27,7 @@ export default defineEventHandler(async (event) => {
     }, {
       fetch: globalThis.fetch,
       enforceRateLimit: async (bucket) => {
-        await (bucket === 'assets' ? assetRateLimit : ingestionRateLimit)(event)
+        await enforceAnalyticsProxyRateLimit(event, bucket)
       },
     })
 

--- a/server/utils/analyticsProxyConcurrency.ts
+++ b/server/utils/analyticsProxyConcurrency.ts
@@ -1,0 +1,69 @@
+import { AnalyticsProxyError } from './analyticsProxyPolicy'
+
+const DEFAULT_MAX_IN_FLIGHT = 32
+
+/**
+ * Bound buffered upstream responses until Nitro has finished sending them.
+ * The returned release callback is idempotent because Node may emit both
+ * `finish` and `close` for the same response.
+ */
+export function createAnalyticsProxyConcurrencyGuard(maxInFlight = DEFAULT_MAX_IN_FLIGHT) {
+  const capacity = Number.isInteger(maxInFlight) && maxInFlight > 0
+    ? maxInFlight
+    : DEFAULT_MAX_IN_FLIGHT
+  let inFlight = 0
+
+  return function acquire(): () => void {
+    if (inFlight >= capacity) {
+      throw new AnalyticsProxyError(
+        503,
+        'Service Unavailable',
+        'Analytics proxy is temporarily at capacity',
+      )
+    }
+
+    inFlight += 1
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      inFlight -= 1
+    }
+  }
+}
+
+interface AnalyticsResponseLifecycle {
+  once: (event: 'finish' | 'close', listener: () => void) => unknown
+  removeListener?: (event: 'finish' | 'close', listener: () => void) => unknown
+  destroy?: () => unknown
+}
+
+/** Hold a lease until downstream completes, closes, or exceeds the request deadline. */
+export function holdAnalyticsProxyLeaseUntilResponse(
+  response: AnalyticsResponseLifecycle,
+  signal: AbortSignal,
+  release: () => void,
+): void {
+  let complete = false
+  const finish = () => {
+    if (complete) return
+    complete = true
+    signal.removeEventListener('abort', abort)
+    response.removeListener?.('finish', finish)
+    response.removeListener?.('close', finish)
+    release()
+  }
+  const abort = () => {
+    try {
+      response.destroy?.()
+    }
+    finally {
+      finish()
+    }
+  }
+
+  response.once('finish', finish)
+  response.once('close', finish)
+  signal.addEventListener('abort', abort, { once: true })
+  if (signal.aborted) abort()
+}

--- a/server/utils/analyticsProxyPolicy.ts
+++ b/server/utils/analyticsProxyPolicy.ts
@@ -3,6 +3,7 @@ const ASSETS_ORIGIN = 'https://eu-assets.i.posthog.com'
 
 export const MAX_ANALYTICS_REQUEST_BYTES = 1024 * 1024
 export const MAX_ANALYTICS_RESPONSE_BYTES = 2 * 1024 * 1024
+export const ANALYTICS_PROXY_TIMEOUT_MS = 10_000
 
 const SAFE_STATIC_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._~-]*$/
 const SAFE_PROJECT_TOKEN = /^[A-Za-z0-9_-]+$/
@@ -12,7 +13,6 @@ const FORWARDABLE_REQUEST_HEADERS = new Set([
   'accept-language',
   'content-type',
   'origin',
-  'referer',
   'user-agent',
 ])
 
@@ -43,12 +43,14 @@ export interface AnalyticsProxyRequest {
   method: string
   query: URLSearchParams
   headers: HeaderSource
-  readBody: (maxBytes: number) => Promise<Uint8Array | undefined>
+  readBody: (maxBytes: number, signal: AbortSignal) => Promise<Uint8Array | undefined>
+  drainBody: () => void
 }
 
 export interface AnalyticsProxyDependencies {
   fetch: (input: string, init: RequestInit) => Promise<Response>
   enforceRateLimit: (bucket: AnalyticsRateLimitBucket) => Promise<void>
+  timeoutSignal?: AbortSignal
 }
 
 export interface AnalyticsProxyResult {
@@ -186,8 +188,62 @@ function parseRequestContentLength(headers: HeaderSource): number {
   return length
 }
 
-async function readRequestBody(request: AnalyticsProxyRequest, declaredLength: number): Promise<Uint8Array> {
-  const body = await request.readBody(MAX_ANALYTICS_REQUEST_BYTES) ?? new Uint8Array()
+function rejectBodyOnBodylessMethod(request: AnalyticsProxyRequest): void {
+  const rawLength = getHeader(request.headers, 'content-length')
+  const transferEncoding = getHeader(request.headers, 'transfer-encoding')
+  const hasDeclaredBody = rawLength !== undefined && rawLength !== '0'
+  const hasTransferBody = transferEncoding !== undefined
+
+  if (!hasDeclaredBody && !hasTransferBody) return
+
+  request.drainBody()
+  if (rawLength && /^(0|[1-9]\d*)$/.test(rawLength)) {
+    const length = Number(rawLength)
+    if (!Number.isSafeInteger(length) || length > MAX_ANALYTICS_REQUEST_BYTES) {
+      throw new AnalyticsProxyError(413, 'Content Too Large')
+    }
+  }
+  throw new AnalyticsProxyError(400, 'Bad Request', 'Request body is not allowed for this method')
+}
+
+async function withAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+  timeoutMessage: string,
+  statusCode = 502,
+  statusMessage = 'Bad Gateway',
+): Promise<T> {
+  if (signal.aborted) {
+    throw new AnalyticsProxyError(statusCode, statusMessage, timeoutMessage)
+  }
+
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new AnalyticsProxyError(statusCode, statusMessage, timeoutMessage))
+    signal.addEventListener('abort', onAbort, { once: true })
+    promise.then(resolve, reject).finally(() => signal.removeEventListener('abort', onAbort))
+  })
+}
+
+async function readRequestBody(
+  request: AnalyticsProxyRequest,
+  declaredLength: number,
+  signal: AbortSignal,
+): Promise<Uint8Array> {
+  let body: Uint8Array | undefined
+  try {
+    body = await withAbort(
+      request.readBody(MAX_ANALYTICS_REQUEST_BYTES, signal),
+      signal,
+      'Analytics request body timed out',
+      408,
+      'Request Timeout',
+    )
+  }
+  catch (error) {
+    if (error instanceof AnalyticsProxyError && error.statusCode === 408) request.drainBody()
+    throw error
+  }
+  body ??= new Uint8Array()
   if (body.byteLength > MAX_ANALYTICS_REQUEST_BYTES) {
     throw new AnalyticsProxyError(413, 'Content Too Large')
   }
@@ -202,17 +258,20 @@ interface DrainableRequestStream extends AsyncIterable<Uint8Array | string> {
   resume: () => unknown
 }
 
-async function releaseIteratorAndDrain(
+function releaseIteratorAndDrain(
   iterator: AsyncIterator<Uint8Array | string>,
   stream: DrainableRequestStream,
-): Promise<void> {
+): void {
   try {
-    await iterator.return?.()
+    // Initiate iterator detachment without awaiting it: Node can keep this
+    // promise pending until a slow client finishes its declared body.
+    void iterator.return?.().catch(() => undefined)
   }
   catch {
     // Cleanup failures must not replace the policy response.
   }
   try {
+    // Resuming discards any later request bytes without retaining them.
     stream.resume()
   }
   catch {
@@ -228,44 +287,54 @@ async function releaseIteratorAndDrain(
 export async function readBoundedAnalyticsRequestBody(
   stream: DrainableRequestStream,
   maxBytes = MAX_ANALYTICS_REQUEST_BYTES,
+  signal?: AbortSignal,
+  onDrain?: () => void,
 ): Promise<Uint8Array> {
-  const chunks: Uint8Array[] = []
+  const body = new Uint8Array(maxBytes)
   let totalBytes = 0
   const iterator = stream.iterator({ destroyOnReturn: false })
 
   try {
     while (true) {
-      const { done, value: rawChunk } = await iterator.next()
+      const { done, value: rawChunk } = signal
+        ? await withAbort(
+            iterator.next(),
+            signal,
+            'Analytics request body timed out',
+            408,
+            'Request Timeout',
+          )
+        : await iterator.next()
       if (done) break
       const chunk = typeof rawChunk === 'string'
         ? new TextEncoder().encode(rawChunk)
         : rawChunk
       totalBytes += chunk.byteLength
       if (totalBytes > maxBytes) {
-        // Release every retained chunk immediately. Returning this iterator
-        // with destroyOnReturn:false detaches it without destroying the socket;
-        // resume then drains/discards the remaining request so Nitro can send 413.
-        chunks.length = 0
-        await releaseIteratorAndDrain(iterator, stream)
+        // Returning this iterator with destroyOnReturn:false detaches it
+        // without destroying the socket; resume then drains/discards the
+        // remaining request so Nitro can send 413.
+        onDrain?.()
+        releaseIteratorAndDrain(iterator, stream)
         throw new AnalyticsProxyError(413, 'Content Too Large')
       }
-      chunks.push(chunk)
+      body.set(chunk, totalBytes - chunk.byteLength)
     }
   }
   catch (error) {
-    if (error instanceof AnalyticsProxyError) throw error
-    chunks.length = 0
-    await releaseIteratorAndDrain(iterator, stream)
+    if (error instanceof AnalyticsProxyError) {
+      if (error.statusCode === 408) {
+        onDrain?.()
+        releaseIteratorAndDrain(iterator, stream)
+      }
+      throw error
+    }
+    onDrain?.()
+    releaseIteratorAndDrain(iterator, stream)
     throw new AnalyticsProxyError(400, 'Bad Request', 'Unable to read analytics request body')
   }
 
-  const body = new Uint8Array(totalBytes)
-  let offset = 0
-  for (const chunk of chunks) {
-    body.set(chunk, offset)
-    offset += chunk.byteLength
-  }
-  return body
+  return body.subarray(0, totalBytes)
 }
 
 async function cancelBody(body: ReadableStream<Uint8Array> | null): Promise<void> {
@@ -278,7 +347,7 @@ async function cancelBody(body: ReadableStream<Uint8Array> | null): Promise<void
   }
 }
 
-async function readBoundedResponseBody(response: Response): Promise<Uint8Array> {
+async function readBoundedResponseBody(response: Response, signal: AbortSignal): Promise<Uint8Array> {
   const rawContentLength = response.headers.get('content-length')
   if (rawContentLength && /^\d+$/.test(rawContentLength)) {
     const declaredLength = Number(rawContentLength)
@@ -291,34 +360,41 @@ async function readBoundedResponseBody(response: Response): Promise<Uint8Array> 
   if (!response.body) return new Uint8Array()
 
   const reader = response.body.getReader()
-  const chunks: Uint8Array[] = []
+  const body = new Uint8Array(MAX_ANALYTICS_RESPONSE_BYTES)
   let totalBytes = 0
 
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    if (!value) continue
+  try {
+    while (true) {
+      const { done, value } = await withAbort(
+        reader.read(),
+        signal,
+        'Analytics upstream response timed out',
+      )
+      if (done) break
+      if (!value) continue
 
-    totalBytes += value.byteLength
-    if (totalBytes > MAX_ANALYTICS_RESPONSE_BYTES) {
-      try {
-        await reader.cancel()
+      const nextTotalBytes = totalBytes + value.byteLength
+      if (nextTotalBytes > MAX_ANALYTICS_RESPONSE_BYTES) {
+        try {
+          await reader.cancel()
+        }
+        catch {
+          // The bounded failure is still returned if the peer already closed.
+        }
+        throw new AnalyticsProxyError(502, 'Bad Gateway', 'Analytics upstream response exceeded the size limit')
       }
-      catch {
-        // The bounded failure is still returned if the peer already closed.
-      }
-      throw new AnalyticsProxyError(502, 'Bad Gateway', 'Analytics upstream response exceeded the size limit')
+      body.set(value, totalBytes)
+      totalBytes = nextTotalBytes
     }
-    chunks.push(value)
+  }
+  catch (error) {
+    if (error instanceof AnalyticsProxyError && error.message.includes('timed out')) {
+      await reader.cancel().catch(() => undefined)
+    }
+    throw error
   }
 
-  const body = new Uint8Array(totalBytes)
-  let offset = 0
-  for (const chunk of chunks) {
-    body.set(chunk, offset)
-    offset += chunk.byteLength
-  }
-  return body
+  return body.subarray(0, totalBytes)
 }
 
 function asUpstreamFailure(error: unknown): AnalyticsProxyError {
@@ -330,16 +406,52 @@ export async function executeAnalyticsProxyRequest(
   request: AnalyticsProxyRequest,
   dependencies: AnalyticsProxyDependencies,
 ): Promise<AnalyticsProxyResult> {
-  const policy = classifyAnalyticsProxyRequest(request.path, request.method)
-  await dependencies.enforceRateLimit(policy.rateLimitBucket)
+  const timeoutSignal = dependencies.timeoutSignal
+    ?? AbortSignal.timeout(ANALYTICS_PROXY_TIMEOUT_MS)
+  let policy: AnalyticsProxyPolicy
+  try {
+    policy = classifyAnalyticsProxyRequest(request.path, request.method)
+  }
+  catch (error) {
+    request.drainBody()
+    throw error
+  }
+  try {
+    await dependencies.enforceRateLimit(policy.rateLimitBucket)
+  }
+  catch (error) {
+    request.drainBody()
+    throw error
+  }
 
-  const declaredLength = policy.method === 'POST'
-    ? parseRequestContentLength(request.headers)
-    : undefined
+  let declaredLength: number | undefined
+  if (policy.method === 'POST') {
+    try {
+      declaredLength = parseRequestContentLength(request.headers)
+    }
+    catch (error) {
+      if (error instanceof AnalyticsProxyError && error.statusCode === 413) {
+        try {
+          await request.readBody(MAX_ANALYTICS_REQUEST_BYTES, timeoutSignal)
+        }
+        catch (readError) {
+          if (readError instanceof AnalyticsProxyError && readError.statusCode === 408) throw readError
+          // The bounded reader already drained an oversized body. Preserve the
+          // declared-size 413 instead of exposing stream/parser details.
+        }
+        throw error
+      }
+      request.drainBody()
+      throw error
+    }
+  }
+  else {
+    rejectBodyOnBodylessMethod(request)
+  }
 
   const body = declaredLength === undefined
     ? undefined
-    : await readRequestBody(request, declaredLength)
+    : await readRequestBody(request, declaredLength, timeoutSignal)
 
   let upstream: Response
   try {
@@ -348,12 +460,17 @@ export async function executeAnalyticsProxyRequest(
     const fetchBody = body
       ? body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength) as ArrayBuffer
       : undefined
-    upstream = await dependencies.fetch(buildAnalyticsProxyTarget(policy, request.query), {
-      method: policy.method,
-      headers: filterAnalyticsProxyRequestHeaders(request.headers),
-      body: fetchBody,
-      redirect: 'manual',
-    })
+    upstream = await withAbort(
+      dependencies.fetch(buildAnalyticsProxyTarget(policy, request.query), {
+        method: policy.method,
+        headers: filterAnalyticsProxyRequestHeaders(request.headers),
+        body: fetchBody,
+        redirect: 'manual',
+        signal: timeoutSignal,
+      }),
+      timeoutSignal,
+      'Analytics upstream request timed out',
+    )
   }
   catch (error) {
     throw asUpstreamFailure(error)
@@ -370,7 +487,7 @@ export async function executeAnalyticsProxyRequest(
 
   let responseBody: Uint8Array
   try {
-    responseBody = await readBoundedResponseBody(upstream)
+    responseBody = await readBoundedResponseBody(upstream, timeoutSignal)
   }
   catch (error) {
     throw asUpstreamFailure(error)

--- a/server/utils/analyticsProxyPolicy.ts
+++ b/server/utils/analyticsProxyPolicy.ts
@@ -304,11 +304,11 @@ export async function executeAnalyticsProxyRequest(
   dependencies: AnalyticsProxyDependencies,
 ): Promise<AnalyticsProxyResult> {
   const policy = classifyAnalyticsProxyRequest(request.path, request.method)
+  await dependencies.enforceRateLimit(policy.rateLimitBucket)
+
   const declaredLength = policy.method === 'POST'
     ? parseRequestContentLength(request.headers)
     : undefined
-
-  await dependencies.enforceRateLimit(policy.rateLimitBucket)
 
   const body = declaredLength === undefined
     ? undefined

--- a/server/utils/analyticsProxyPolicy.ts
+++ b/server/utils/analyticsProxyPolicy.ts
@@ -197,30 +197,56 @@ async function readRequestBody(request: AnalyticsProxyRequest, declaredLength: n
   return body
 }
 
-interface DestroyableRequestStream extends AsyncIterable<Uint8Array | string> {
-  destroy?: () => void
+interface DrainableRequestStream extends AsyncIterable<Uint8Array | string> {
+  iterator: (options: { destroyOnReturn: boolean }) => AsyncIterator<Uint8Array | string>
+  resume: () => unknown
+}
+
+async function releaseIteratorAndDrain(
+  iterator: AsyncIterator<Uint8Array | string>,
+  stream: DrainableRequestStream,
+): Promise<void> {
+  try {
+    await iterator.return?.()
+  }
+  catch {
+    // Cleanup failures must not replace the policy response.
+  }
+  try {
+    stream.resume()
+  }
+  catch {
+    // A stream that already failed may reject resume; preserve the response.
+  }
 }
 
 /**
  * Read an inbound Node/Nitro request without first buffering an untrusted body.
- * The stream is destroyed immediately when its cumulative size crosses the
- * policy cap, so a false Content-Length cannot turn the proxy into a memory sink.
+ * Once cumulative size crosses the cap, retained chunks are released and the
+ * rest is drained without destroying the socket, so Nitro can still emit 413.
  */
 export async function readBoundedAnalyticsRequestBody(
-  stream: DestroyableRequestStream,
+  stream: DrainableRequestStream,
   maxBytes = MAX_ANALYTICS_REQUEST_BYTES,
 ): Promise<Uint8Array> {
   const chunks: Uint8Array[] = []
   let totalBytes = 0
+  const iterator = stream.iterator({ destroyOnReturn: false })
 
   try {
-    for await (const rawChunk of stream) {
+    while (true) {
+      const { done, value: rawChunk } = await iterator.next()
+      if (done) break
       const chunk = typeof rawChunk === 'string'
         ? new TextEncoder().encode(rawChunk)
         : rawChunk
       totalBytes += chunk.byteLength
       if (totalBytes > maxBytes) {
-        stream.destroy?.()
+        // Release every retained chunk immediately. Returning this iterator
+        // with destroyOnReturn:false detaches it without destroying the socket;
+        // resume then drains/discards the remaining request so Nitro can send 413.
+        chunks.length = 0
+        await releaseIteratorAndDrain(iterator, stream)
         throw new AnalyticsProxyError(413, 'Content Too Large')
       }
       chunks.push(chunk)
@@ -228,7 +254,8 @@ export async function readBoundedAnalyticsRequestBody(
   }
   catch (error) {
     if (error instanceof AnalyticsProxyError) throw error
-    stream.destroy?.()
+    chunks.length = 0
+    await releaseIteratorAndDrain(iterator, stream)
     throw new AnalyticsProxyError(400, 'Bad Request', 'Unable to read analytics request body')
   }
 

--- a/server/utils/analyticsProxyPolicy.ts
+++ b/server/utils/analyticsProxyPolicy.ts
@@ -1,0 +1,358 @@
+const INGESTION_ORIGIN = 'https://eu.i.posthog.com'
+const ASSETS_ORIGIN = 'https://eu-assets.i.posthog.com'
+
+export const MAX_ANALYTICS_REQUEST_BYTES = 1024 * 1024
+export const MAX_ANALYTICS_RESPONSE_BYTES = 2 * 1024 * 1024
+
+const SAFE_STATIC_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._~-]*$/
+const SAFE_PROJECT_TOKEN = /^[A-Za-z0-9_-]+$/
+
+const FORWARDABLE_REQUEST_HEADERS = new Set([
+  'accept',
+  'accept-language',
+  'content-type',
+  'origin',
+  'referer',
+  'user-agent',
+])
+
+const FORWARDABLE_RESPONSE_HEADERS = new Set([
+  'cache-control',
+  'content-language',
+  'content-type',
+  'etag',
+  'expires',
+  'last-modified',
+  'vary',
+])
+
+export type AnalyticsRateLimitBucket = 'ingestion' | 'assets'
+
+export interface AnalyticsProxyPolicy {
+  family: 'capture' | 'flags' | 'static' | 'array-config'
+  path: string
+  method: 'GET' | 'HEAD' | 'POST'
+  upstreamOrigin: typeof INGESTION_ORIGIN | typeof ASSETS_ORIGIN
+  rateLimitBucket: AnalyticsRateLimitBucket
+}
+
+type HeaderSource = Headers | Record<string, string | string[] | undefined>
+
+export interface AnalyticsProxyRequest {
+  path: string
+  method: string
+  query: URLSearchParams
+  headers: HeaderSource
+  readBody: (maxBytes: number) => Promise<Uint8Array | undefined>
+}
+
+export interface AnalyticsProxyDependencies {
+  fetch: (input: string, init: RequestInit) => Promise<Response>
+  enforceRateLimit: (bucket: AnalyticsRateLimitBucket) => Promise<void>
+}
+
+export interface AnalyticsProxyResult {
+  status: number
+  statusText: string
+  headers: Headers
+  body: Uint8Array
+}
+
+export class AnalyticsProxyError extends Error {
+  readonly statusCode: number
+  readonly statusMessage: string
+
+  constructor(statusCode: number, statusMessage: string, message = statusMessage) {
+    super(message)
+    this.name = 'AnalyticsProxyError'
+    this.statusCode = statusCode
+    this.statusMessage = statusMessage
+  }
+}
+
+function rejectMethod(method: string): never {
+  throw new AnalyticsProxyError(405, 'Method Not Allowed')
+}
+
+function requireMethod(method: string, allowed: readonly string[]): AnalyticsProxyPolicy['method'] {
+  const normalizedMethod = method.toUpperCase()
+  if (!allowed.includes(normalizedMethod)) rejectMethod(normalizedMethod)
+  return normalizedMethod as AnalyticsProxyPolicy['method']
+}
+
+function isSafeStaticPath(path: string): boolean {
+  const segments = path.slice('static/'.length).split('/')
+  return segments.length > 0
+    && segments.every(segment => SAFE_STATIC_SEGMENT.test(segment) && segment !== '.' && segment !== '..')
+}
+
+function isArrayConfigPath(path: string): boolean {
+  const match = /^array\/([^/]+)\/(config(?:\.js)?)$/.exec(path)
+  return Boolean(match && SAFE_PROJECT_TOKEN.test(match[1]!))
+}
+
+export function classifyAnalyticsProxyRequest(path: string, method: string): AnalyticsProxyPolicy {
+  if (path === 'e' || path === 'e/') {
+    return {
+      family: 'capture',
+      path,
+      method: requireMethod(method, ['POST']),
+      upstreamOrigin: INGESTION_ORIGIN,
+      rateLimitBucket: 'ingestion',
+    }
+  }
+
+  if (path === 'flags' || path === 'flags/') {
+    return {
+      family: 'flags',
+      path,
+      method: requireMethod(method, ['POST']),
+      upstreamOrigin: INGESTION_ORIGIN,
+      rateLimitBucket: 'ingestion',
+    }
+  }
+
+  if (path.startsWith('static/')) {
+    if (!isSafeStaticPath(path)) throw new AnalyticsProxyError(404, 'Not Found')
+    return {
+      family: 'static',
+      path,
+      method: requireMethod(method, ['GET', 'HEAD']),
+      upstreamOrigin: ASSETS_ORIGIN,
+      rateLimitBucket: 'assets',
+    }
+  }
+
+  if (path.startsWith('array/')) {
+    if (!isArrayConfigPath(path)) throw new AnalyticsProxyError(404, 'Not Found')
+    return {
+      family: 'array-config',
+      path,
+      method: requireMethod(method, ['GET', 'HEAD']),
+      upstreamOrigin: ASSETS_ORIGIN,
+      rateLimitBucket: 'assets',
+    }
+  }
+
+  throw new AnalyticsProxyError(404, 'Not Found')
+}
+
+export function buildAnalyticsProxyTarget(policy: AnalyticsProxyPolicy, query: URLSearchParams): string {
+  const target = new URL(`/${policy.path}`, policy.upstreamOrigin)
+  target.search = new URLSearchParams(query).toString()
+  return target.toString()
+}
+
+function headerEntries(source: HeaderSource): Array<[string, string]> {
+  if (source instanceof Headers) return [...source.entries()]
+
+  return Object.entries(source).flatMap(([name, value]) => {
+    if (value === undefined) return []
+    return [[name, Array.isArray(value) ? value.join(', ') : value]]
+  })
+}
+
+function getHeader(source: HeaderSource, requestedName: string): string | undefined {
+  const normalizedRequestedName = requestedName.toLowerCase()
+  return headerEntries(source).find(([name]) => name.toLowerCase() === normalizedRequestedName)?.[1]
+}
+
+export function filterAnalyticsProxyRequestHeaders(source: HeaderSource): Headers {
+  const result = new Headers()
+  for (const [name, value] of headerEntries(source)) {
+    const normalizedName = name.toLowerCase()
+    if (FORWARDABLE_REQUEST_HEADERS.has(normalizedName)) result.set(normalizedName, value)
+  }
+  return result
+}
+
+function filterAnalyticsProxyResponseHeaders(source: Headers): Headers {
+  const result = new Headers()
+  source.forEach((value, name) => {
+    if (FORWARDABLE_RESPONSE_HEADERS.has(name.toLowerCase())) result.set(name, value)
+  })
+  return result
+}
+
+function parseRequestContentLength(headers: HeaderSource): number {
+  const rawLength = getHeader(headers, 'content-length')
+  if (rawLength === undefined || !/^(0|[1-9]\d*)$/.test(rawLength)) {
+    throw new AnalyticsProxyError(411, 'Length Required')
+  }
+
+  const length = Number(rawLength)
+  if (!Number.isSafeInteger(length)) throw new AnalyticsProxyError(413, 'Content Too Large')
+  if (length > MAX_ANALYTICS_REQUEST_BYTES) throw new AnalyticsProxyError(413, 'Content Too Large')
+  return length
+}
+
+async function readRequestBody(request: AnalyticsProxyRequest, declaredLength: number): Promise<Uint8Array> {
+  const body = await request.readBody(MAX_ANALYTICS_REQUEST_BYTES) ?? new Uint8Array()
+  if (body.byteLength > MAX_ANALYTICS_REQUEST_BYTES) {
+    throw new AnalyticsProxyError(413, 'Content Too Large')
+  }
+  if (body.byteLength !== declaredLength) {
+    throw new AnalyticsProxyError(400, 'Bad Request', 'Invalid Content-Length')
+  }
+  return body
+}
+
+interface DestroyableRequestStream extends AsyncIterable<Uint8Array | string> {
+  destroy?: () => void
+}
+
+/**
+ * Read an inbound Node/Nitro request without first buffering an untrusted body.
+ * The stream is destroyed immediately when its cumulative size crosses the
+ * policy cap, so a false Content-Length cannot turn the proxy into a memory sink.
+ */
+export async function readBoundedAnalyticsRequestBody(
+  stream: DestroyableRequestStream,
+  maxBytes = MAX_ANALYTICS_REQUEST_BYTES,
+): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+
+  try {
+    for await (const rawChunk of stream) {
+      const chunk = typeof rawChunk === 'string'
+        ? new TextEncoder().encode(rawChunk)
+        : rawChunk
+      totalBytes += chunk.byteLength
+      if (totalBytes > maxBytes) {
+        stream.destroy?.()
+        throw new AnalyticsProxyError(413, 'Content Too Large')
+      }
+      chunks.push(chunk)
+    }
+  }
+  catch (error) {
+    if (error instanceof AnalyticsProxyError) throw error
+    stream.destroy?.()
+    throw new AnalyticsProxyError(400, 'Bad Request', 'Unable to read analytics request body')
+  }
+
+  const body = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return body
+}
+
+async function cancelBody(body: ReadableStream<Uint8Array> | null): Promise<void> {
+  if (!body) return
+  try {
+    await body.cancel()
+  }
+  catch {
+    // The response is being rejected regardless; cancellation is best-effort.
+  }
+}
+
+async function readBoundedResponseBody(response: Response): Promise<Uint8Array> {
+  const rawContentLength = response.headers.get('content-length')
+  if (rawContentLength && /^\d+$/.test(rawContentLength)) {
+    const declaredLength = Number(rawContentLength)
+    if (!Number.isSafeInteger(declaredLength) || declaredLength > MAX_ANALYTICS_RESPONSE_BYTES) {
+      await cancelBody(response.body)
+      throw new AnalyticsProxyError(502, 'Bad Gateway', 'Analytics upstream response exceeded the size limit')
+    }
+  }
+
+  if (!response.body) return new Uint8Array()
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (!value) continue
+
+    totalBytes += value.byteLength
+    if (totalBytes > MAX_ANALYTICS_RESPONSE_BYTES) {
+      try {
+        await reader.cancel()
+      }
+      catch {
+        // The bounded failure is still returned if the peer already closed.
+      }
+      throw new AnalyticsProxyError(502, 'Bad Gateway', 'Analytics upstream response exceeded the size limit')
+    }
+    chunks.push(value)
+  }
+
+  const body = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return body
+}
+
+function asUpstreamFailure(error: unknown): AnalyticsProxyError {
+  if (error instanceof AnalyticsProxyError) return error
+  return new AnalyticsProxyError(502, 'Bad Gateway', 'Analytics upstream request failed')
+}
+
+export async function executeAnalyticsProxyRequest(
+  request: AnalyticsProxyRequest,
+  dependencies: AnalyticsProxyDependencies,
+): Promise<AnalyticsProxyResult> {
+  const policy = classifyAnalyticsProxyRequest(request.path, request.method)
+  const declaredLength = policy.method === 'POST'
+    ? parseRequestContentLength(request.headers)
+    : undefined
+
+  await dependencies.enforceRateLimit(policy.rateLimitBucket)
+
+  const body = declaredLength === undefined
+    ? undefined
+    : await readRequestBody(request, declaredLength)
+
+  let upstream: Response
+  try {
+    // readBoundedAnalyticsRequestBody always returns an owned Uint8Array backed
+    // by ArrayBuffer; slice to the exact byte range for the Fetch BodyInit type.
+    const fetchBody = body
+      ? body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength) as ArrayBuffer
+      : undefined
+    upstream = await dependencies.fetch(buildAnalyticsProxyTarget(policy, request.query), {
+      method: policy.method,
+      headers: filterAnalyticsProxyRequestHeaders(request.headers),
+      body: fetchBody,
+      redirect: 'manual',
+    })
+  }
+  catch (error) {
+    throw asUpstreamFailure(error)
+  }
+
+  if (upstream.status >= 300 && upstream.status < 400) {
+    await cancelBody(upstream.body)
+    throw new AnalyticsProxyError(
+      502,
+      'Bad Gateway',
+      'Analytics upstream returned an unexpected redirect',
+    )
+  }
+
+  let responseBody: Uint8Array
+  try {
+    responseBody = await readBoundedResponseBody(upstream)
+  }
+  catch (error) {
+    throw asUpstreamFailure(error)
+  }
+
+  return {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: filterAnalyticsProxyResponseHeaders(upstream.headers),
+    body: responseBody,
+  }
+}

--- a/server/utils/analyticsProxyRateLimit.ts
+++ b/server/utils/analyticsProxyRateLimit.ts
@@ -1,0 +1,110 @@
+import { isIP } from 'node:net'
+import type { H3Event } from 'h3'
+import type { AnalyticsRateLimitBucket } from './analyticsProxyPolicy'
+import { createRateLimiter } from './rateLimit'
+
+const MAX_IP_HEADER_LENGTH = 512
+const MAX_IP_LITERAL_LENGTH = 64
+
+export const ANALYTICS_PROXY_RATE_LIMITS = {
+  windowMs: 60_000,
+  ingestionPerClient: 120,
+  ingestionGlobal: 1_200,
+  assetsPerClient: 600,
+  assetsGlobal: 6_000,
+} as const
+
+interface AnalyticsClientKeyInput {
+  socketIp?: string
+  cfConnectingIp?: string
+  forwardedFor?: string
+}
+
+interface AnalyticsProxyRateLimitOptions {
+  windowMs?: number
+  ingestionPerClient?: number
+  ingestionGlobal?: number
+  assetsPerClient?: number
+  assetsGlobal?: number
+  maxTrackedClientKeys?: number
+}
+
+function validIpLiteral(rawValue: string | undefined): string | undefined {
+  if (!rawValue || rawValue.length > MAX_IP_LITERAL_LENGTH) return undefined
+  const candidate = rawValue.trim()
+  return isIP(candidate) ? candidate : undefined
+}
+
+function firstForwardedIp(rawValue: string | undefined): string | undefined {
+  if (!rawValue || rawValue.length > MAX_IP_HEADER_LENGTH) return undefined
+  return validIpLiteral(rawValue.split(',', 1)[0])
+}
+
+/**
+ * Compose the non-spoofable socket peer with a bounded client hint. The hint
+ * improves fairness behind Cloudflare/Render, while the independent global
+ * family limiter remains the abuse boundary if a direct client spoofs it.
+ */
+export function buildAnalyticsClientRateLimitKey(input: AnalyticsClientKeyInput): string {
+  const socketIp = validIpLiteral(input.socketIp) ?? 'unknown'
+  const hintedClientIp = validIpLiteral(input.cfConnectingIp)
+    ?? firstForwardedIp(input.forwardedFor)
+    ?? 'unknown'
+  return `socket:${socketIp}|client:${hintedClientIp}`
+}
+
+function keyForAnalyticsClient(event: H3Event): string {
+  return buildAnalyticsClientRateLimitKey({
+    socketIp: getRequestIP(event),
+    cfConnectingIp: getHeader(event, 'cf-connecting-ip'),
+    forwardedFor: getHeader(event, 'x-forwarded-for'),
+  })
+}
+
+export function createAnalyticsProxyRateLimitGuard(options: AnalyticsProxyRateLimitOptions = {}) {
+  const windowMs = options.windowMs ?? ANALYTICS_PROXY_RATE_LIMITS.windowMs
+  const maxTrackedKeys = options.maxTrackedClientKeys ?? 10_000
+
+  const ingestionGlobal = createRateLimiter({
+    windowMs,
+    maxRequests: options.ingestionGlobal ?? ANALYTICS_PROXY_RATE_LIMITS.ingestionGlobal,
+    message: 'Analytics ingestion is temporarily busy. Please retry shortly.',
+    keyResolver: () => 'analytics-ingestion-global',
+    maxTrackedKeys: 1,
+  })
+  const ingestionPerClient = createRateLimiter({
+    windowMs,
+    maxRequests: options.ingestionPerClient ?? ANALYTICS_PROXY_RATE_LIMITS.ingestionPerClient,
+    message: 'Too many analytics ingestion requests. Please retry shortly.',
+    keyResolver: keyForAnalyticsClient,
+    maxTrackedKeys,
+  })
+  const assetsGlobal = createRateLimiter({
+    windowMs,
+    maxRequests: options.assetsGlobal ?? ANALYTICS_PROXY_RATE_LIMITS.assetsGlobal,
+    message: 'Analytics assets are temporarily busy. Please retry shortly.',
+    keyResolver: () => 'analytics-assets-global',
+    maxTrackedKeys: 1,
+  })
+  const assetsPerClient = createRateLimiter({
+    windowMs,
+    maxRequests: options.assetsPerClient ?? ANALYTICS_PROXY_RATE_LIMITS.assetsPerClient,
+    message: 'Too many analytics asset requests. Please retry shortly.',
+    keyResolver: keyForAnalyticsClient,
+    maxTrackedKeys,
+  })
+
+  return async function enforceAnalyticsProxyRateLimit(
+    event: H3Event,
+    bucket: AnalyticsRateLimitBucket,
+  ): Promise<void> {
+    if (bucket === 'assets') {
+      await assetsGlobal(event)
+      await assetsPerClient(event)
+      return
+    }
+
+    await ingestionGlobal(event)
+    await ingestionPerClient(event)
+  }
+}

--- a/server/utils/analyticsProxyRateLimit.ts
+++ b/server/utils/analyticsProxyRateLimit.ts
@@ -101,12 +101,16 @@ export function createAnalyticsProxyRateLimitGuard(options: AnalyticsProxyRateLi
     bucket: AnalyticsRateLimitBucket,
   ): Promise<void> {
     if (bucket === 'assets') {
-      await assetsPerClient(event)
-      await assetsGlobal(event)
+      const clientReservation = assetsPerClient.reserve(event)
+      const globalReservation = assetsGlobal.reserve(event)
+      clientReservation.commit()
+      globalReservation.commit()
       return
     }
 
-    await ingestionPerClient(event)
-    await ingestionGlobal(event)
+    const clientReservation = ingestionPerClient.reserve(event)
+    const globalReservation = ingestionGlobal.reserve(event)
+    clientReservation.commit()
+    globalReservation.commit()
   }
 }

--- a/server/utils/analyticsProxyRateLimit.ts
+++ b/server/utils/analyticsProxyRateLimit.ts
@@ -71,6 +71,7 @@ export function createAnalyticsProxyRateLimitGuard(options: AnalyticsProxyRateLi
     message: 'Analytics ingestion is temporarily busy. Please retry shortly.',
     keyResolver: () => 'analytics-ingestion-global',
     maxTrackedKeys: 1,
+    headerMode: 'on-limit',
   })
   const ingestionPerClient = createRateLimiter({
     windowMs,
@@ -85,6 +86,7 @@ export function createAnalyticsProxyRateLimitGuard(options: AnalyticsProxyRateLi
     message: 'Analytics assets are temporarily busy. Please retry shortly.',
     keyResolver: () => 'analytics-assets-global',
     maxTrackedKeys: 1,
+    headerMode: 'on-limit',
   })
   const assetsPerClient = createRateLimiter({
     windowMs,
@@ -99,12 +101,12 @@ export function createAnalyticsProxyRateLimitGuard(options: AnalyticsProxyRateLi
     bucket: AnalyticsRateLimitBucket,
   ): Promise<void> {
     if (bucket === 'assets') {
-      await assetsGlobal(event)
       await assetsPerClient(event)
+      await assetsGlobal(event)
       return
     }
 
-    await ingestionGlobal(event)
     await ingestionPerClient(event)
+    await ingestionGlobal(event)
   }
 }

--- a/server/utils/calendar.ts
+++ b/server/utils/calendar.ts
@@ -8,6 +8,7 @@ import {
   setupCalendarWebhook as setupGoogleCalendarWebhook,
   isGoogleCalendarConfigured,
   type GoogleCalendarIntegrationIdentity,
+  type GoogleCalendarIntegrationSnapshot,
 } from './google-calendar'
 import {
   createMicrosoftCalendarEvents,
@@ -19,6 +20,7 @@ import {
   isMicrosoftCalendarConfigured,
   isMicrosoftCalendarApplicationMode,
   type MicrosoftCalendarSyncResult,
+  type MicrosoftCalendarIntegrationIdentity,
 } from './microsoft-calendar'
 
 export type CalendarProvider = 'google' | 'microsoft'
@@ -257,16 +259,26 @@ export async function removeConnectedCalendarIntegration(userId: string, organiz
   if (!integration) return
 
   if (integration.provider === 'microsoft') {
-    await removeMicrosoftCalendarIntegration(integration.userId ?? userId, integration.organizationId ?? undefined)
+    const identity: MicrosoftCalendarIntegrationIdentity = {
+      integrationId: integration.id,
+      userId: integration.userId,
+      organizationId: integration.organizationId,
+      connectionGeneration: integration.connectionGeneration,
+    }
+    const removed = await removeMicrosoftCalendarIntegration(identity)
+    if (!removed) throw createError({ statusCode: 409, statusMessage: 'Calendar connection changed; retry disconnect' })
     return
   }
 
   const googleUserId = integration.userId ?? userId
-  await removeGoogleCalendarIntegration({
+  const snapshot: GoogleCalendarIntegrationSnapshot = {
     integrationId: integration.id,
     userId: googleUserId,
     organizationId: integration.organizationId,
-  })
+    connectionGeneration: integration.connectionGeneration,
+  }
+  const removed = await removeGoogleCalendarIntegration(snapshot)
+  if (!removed) throw createError({ statusCode: 409, statusMessage: 'Calendar connection changed; retry disconnect' })
 }
 
 export async function setupConnectedCalendarWebhook(userId: string, organizationId?: string | null, provider?: CalendarProvider | null): Promise<boolean> {

--- a/server/utils/calendar.ts
+++ b/server/utils/calendar.ts
@@ -65,19 +65,16 @@ export function isCalendarProviderConfigured(provider: CalendarProvider): boolea
 }
 
 export async function getConnectedCalendarIntegration(userId: string, organizationId?: string | null) {
-  const microsoft = organizationId
-    ? await db.query.calendarIntegration.findFirst({
-        where: and(eq(calendarIntegration.organizationId, organizationId), eq(calendarIntegration.provider, 'microsoft')),
-      })
-    : null
-  if (microsoft) return microsoft
+  if (organizationId) {
+    const microsoft = await db.query.calendarIntegration.findFirst({
+      where: and(eq(calendarIntegration.organizationId, organizationId), eq(calendarIntegration.provider, 'microsoft')),
+    })
+    if (microsoft) return microsoft
 
-  const google = organizationId
-    ? await db.query.calendarIntegration.findFirst({
-        where: and(eq(calendarIntegration.organizationId, organizationId), eq(calendarIntegration.provider, 'google')),
-      })
-    : null
-  if (google) return google
+    return await db.query.calendarIntegration.findFirst({
+      where: and(eq(calendarIntegration.organizationId, organizationId), eq(calendarIntegration.provider, 'google')),
+    }) ?? null
+  }
 
   const userMicrosoft = await db.query.calendarIntegration.findFirst({
     where: and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'microsoft')),
@@ -92,12 +89,11 @@ export async function getConnectedCalendarIntegration(userId: string, organizati
 async function resolveCalendarIntegration(userId: string, organizationId?: string | null, provider?: CalendarProvider | null) {
   if (!provider) return await getConnectedCalendarIntegration(userId, organizationId)
 
-  const orgIntegration = organizationId
-    ? await db.query.calendarIntegration.findFirst({
-        where: and(eq(calendarIntegration.organizationId, organizationId), eq(calendarIntegration.provider, provider)),
-      })
-    : null
-  if (orgIntegration) return orgIntegration
+  if (organizationId) {
+    return await db.query.calendarIntegration.findFirst({
+      where: and(eq(calendarIntegration.organizationId, organizationId), eq(calendarIntegration.provider, provider)),
+    }) ?? null
+  }
 
   return await db.query.calendarIntegration.findFirst({
     where: and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, provider)),
@@ -239,12 +235,23 @@ export async function removeConnectedCalendarIntegration(userId: string, organiz
     return
   }
 
-  await removeGoogleCalendarIntegration(integration.userId ?? userId)
+  const googleUserId = integration.userId ?? userId
+  await removeGoogleCalendarIntegration({
+    integrationId: integration.id,
+    userId: googleUserId,
+    organizationId: integration.organizationId,
+  })
 }
 
 export async function setupConnectedCalendarWebhook(userId: string, organizationId?: string | null, provider?: CalendarProvider | null): Promise<boolean> {
   const integration = await resolveCalendarIntegration(userId, organizationId, provider)
-  if (integration?.provider === 'google') return await setupGoogleCalendarWebhook(integration.userId ?? userId)
+  if (integration?.provider === 'google') {
+    return await setupGoogleCalendarWebhook({
+      integrationId: integration.id,
+      userId: integration.userId ?? userId,
+      organizationId: integration.organizationId,
+    })
+  }
 
   // Microsoft Graph event creation/update/delete works without a webhook.
   // RSVP/back-sync via Graph change subscriptions can be added later without

--- a/server/utils/calendar.ts
+++ b/server/utils/calendar.ts
@@ -7,6 +7,7 @@ import {
   removeCalendarIntegration as removeGoogleCalendarIntegration,
   setupCalendarWebhook as setupGoogleCalendarWebhook,
   isGoogleCalendarConfigured,
+  type GoogleCalendarIntegrationIdentity,
 } from './google-calendar'
 import {
   createMicrosoftCalendarEvents,
@@ -46,6 +47,17 @@ export interface CalendarEventRecord {
   destinationEmail: string | null
   eventId: string | null
   isPrimary: boolean
+}
+
+function googleIntegrationIdentity(
+  integration: { id: string, userId: string | null, organizationId: string | null },
+  fallbackUserId: string,
+): GoogleCalendarIntegrationIdentity {
+  return {
+    integrationId: integration.id,
+    userId: integration.userId ?? fallbackUserId,
+    organizationId: integration.organizationId,
+  }
 }
 
 export function getPreferredCalendarProvider(): CalendarProvider | null {
@@ -130,7 +142,10 @@ export async function createConnectedCalendarEvents(
     return results.map(result => ({ ...result, provider: 'microsoft' }))
   }
   if (integration?.provider === 'google') {
-    const result = await createGoogleCalendarEvent(integration.userId ?? userId, data)
+    const result = await createGoogleCalendarEvent(
+      googleIntegrationIdentity(integration, userId),
+      data,
+    )
     return result
       ? [{
           provider: 'google',
@@ -155,7 +170,13 @@ export async function updateConnectedCalendarEvent(
 ): Promise<string | null> {
   const integration = await resolveCalendarIntegration(userId, organizationId, provider)
   if (integration?.provider === 'microsoft') return await updateMicrosoftCalendarEvent(integration.userId ?? userId, integration.organizationId, eventId, data)
-  if (integration?.provider === 'google') return await updateGoogleCalendarEvent(integration.userId ?? userId, eventId, data)
+  if (integration?.provider === 'google') {
+    return await updateGoogleCalendarEvent(
+      googleIntegrationIdentity(integration, userId),
+      eventId,
+      data,
+    )
+  }
   return null
 }
 
@@ -167,7 +188,12 @@ export async function cancelConnectedCalendarEvent(
 ): Promise<boolean> {
   const integration = await resolveCalendarIntegration(userId, organizationId, provider)
   if (integration?.provider === 'microsoft') return await cancelMicrosoftCalendarEvent(integration.userId ?? userId, integration.organizationId, eventId)
-  if (integration?.provider === 'google') return await cancelGoogleCalendarEvent(integration.userId ?? userId, eventId)
+  if (integration?.provider === 'google') {
+    return await cancelGoogleCalendarEvent(
+      googleIntegrationIdentity(integration, userId),
+      eventId,
+    )
+  }
   return false
 }
 

--- a/server/utils/complianceReporting.ts
+++ b/server/utils/complianceReporting.ts
@@ -20,24 +20,24 @@ export type ComplianceReportingBreakdownsInput = Record<
   readonly ComplianceReportingInputBucket[]
 >
 
-export type ComplianceReportingBucket =
-  | {
-      value: string
-      count: number
-      suppressed: false
-    }
-  | {
-      value: 'suppressed'
-      count: null
-      suppressed: true
-    }
+export interface ComplianceReportingBucket {
+  value: string | null
+  count: number
+  suppressed: false
+}
+
+export interface ComplianceReportingDimension {
+  buckets: ComplianceReportingBucket[]
+  suppressed: boolean
+}
 
 export type ComplianceReportingBreakdowns = Record<
   ComplianceReportingBreakdownName,
-  ComplianceReportingBucket[]
+  ComplianceReportingDimension
 >
 
 export interface ProtectedComplianceReporting {
+  totalResponses: number | null
   suppressed: boolean
   minimumCohortSize: typeof MIN_COMPLIANCE_REPORTING_COHORT
   breakdowns: ComplianceReportingBreakdowns
@@ -49,90 +49,75 @@ export function protectComplianceReporting(
 ): ProtectedComplianceReporting {
   if (totalResponses < MIN_COMPLIANCE_REPORTING_COHORT) {
     return {
+      totalResponses: null,
       suppressed: true,
       minimumCohortSize: MIN_COMPLIANCE_REPORTING_COHORT,
-      breakdowns: emptyBreakdowns(),
+      breakdowns: suppressedBreakdowns(),
     }
   }
 
-  const sex = protectBreakdown(breakdowns.sex)
-  const raceEthnicity = protectBreakdown(breakdowns.raceEthnicity)
-  const veteranStatus = protectBreakdown(breakdowns.veteranStatus)
-  const disabilityStatus = protectBreakdown(breakdowns.disabilityStatus)
+  const sex = protectBreakdown(totalResponses, breakdowns.sex)
+  const raceEthnicity = protectBreakdown(totalResponses, breakdowns.raceEthnicity)
+  const veteranStatus = protectBreakdown(totalResponses, breakdowns.veteranStatus)
+  const disabilityStatus = protectBreakdown(totalResponses, breakdowns.disabilityStatus)
 
   return {
+    totalResponses,
     suppressed: sex.suppressed
       || raceEthnicity.suppressed
       || veteranStatus.suppressed
       || disabilityStatus.suppressed,
     minimumCohortSize: MIN_COMPLIANCE_REPORTING_COHORT,
     breakdowns: {
-      sex: sex.buckets,
-      raceEthnicity: raceEthnicity.buckets,
-      veteranStatus: veteranStatus.buckets,
-      disabilityStatus: disabilityStatus.buckets,
+      sex,
+      raceEthnicity,
+      veteranStatus,
+      disabilityStatus,
     },
   }
 }
 
-function emptyBreakdowns(): ComplianceReportingBreakdowns {
+function suppressedBreakdowns(): ComplianceReportingBreakdowns {
   return {
-    sex: [],
-    raceEthnicity: [],
-    veteranStatus: [],
-    disabilityStatus: [],
+    sex: suppressedDimension(),
+    raceEthnicity: suppressedDimension(),
+    veteranStatus: suppressedDimension(),
+    disabilityStatus: suppressedDimension(),
   }
 }
 
-function protectBreakdown(rows: readonly ComplianceReportingInputBucket[]): {
-  buckets: ComplianceReportingBucket[]
-  suppressed: boolean
-} {
-  const sortedRows = rows
-    .flatMap((row) => row.value === null ? [] : [{ value: row.value, count: row.count }])
-    .sort((left, right) => right.count - left.count || compareValues(left.value, right.value))
+function protectBreakdown(
+  totalResponses: number,
+  rows: readonly ComplianceReportingInputBucket[],
+): ComplianceReportingDimension {
+  const rowTotal = rows.reduce((sum, row) => sum + row.count, 0)
+  const hasSmallBucket = rows.some(row => row.count < MIN_COMPLIANCE_REPORTING_COHORT)
 
-  const suppressedIndexes = new Set(
-    sortedRows
-      .map((row, index) => ({ row, index }))
-      .filter(({ row }) => row.count < MIN_COMPLIANCE_REPORTING_COHORT)
-      .map(({ index }) => index),
-  )
+  if (rowTotal !== totalResponses || hasSmallBucket) {
+    return suppressedDimension()
+  }
 
-  if (suppressedIndexes.size === 1 && sortedRows.length > 1) {
-    const complementaryIndex = sortedRows
-      .map((row, index) => ({ row, index }))
-      .filter(({ index }) => !suppressedIndexes.has(index))
+  return {
+    suppressed: false,
+    buckets: rows
+      .map(row => ({ ...row, suppressed: false as const }))
       .sort((left, right) =>
-        left.row.count - right.row.count
-        || compareValues(left.row.value, right.row.value),
-      )[0]?.index
-
-    if (complementaryIndex !== undefined) {
-      suppressedIndexes.add(complementaryIndex)
-    }
-  }
-
-  return {
-    suppressed: suppressedIndexes.size > 0,
-    buckets: sortedRows.map((row, index) => {
-      if (suppressedIndexes.has(index)) {
-        return {
-          value: 'suppressed',
-          count: null,
-          suppressed: true,
-        }
-      }
-
-      return {
-        ...row,
-        suppressed: false,
-      }
-    }),
+        right.count - left.count || compareValues(left.value, right.value),
+      ),
   }
 }
 
-function compareValues(left: string, right: string): number {
+function suppressedDimension(): ComplianceReportingDimension {
+  return {
+    suppressed: true,
+    buckets: [],
+  }
+}
+
+function compareValues(left: string | null, right: string | null): number {
+  if (left === right) return 0
+  if (left === null) return 1
+  if (right === null) return -1
   if (left < right) return -1
   if (left > right) return 1
   return 0

--- a/server/utils/complianceReporting.ts
+++ b/server/utils/complianceReporting.ts
@@ -1,0 +1,139 @@
+/**
+ * Factory Careers privacy policy for aggregate compliance reporting.
+ * This conservative product threshold is not a legal safe harbor.
+ */
+export const MIN_COMPLIANCE_REPORTING_COHORT = 5
+
+export type ComplianceReportingBreakdownName =
+  | 'sex'
+  | 'raceEthnicity'
+  | 'veteranStatus'
+  | 'disabilityStatus'
+
+export interface ComplianceReportingInputBucket {
+  value: string | null
+  count: number
+}
+
+export type ComplianceReportingBreakdownsInput = Record<
+  ComplianceReportingBreakdownName,
+  readonly ComplianceReportingInputBucket[]
+>
+
+export type ComplianceReportingBucket =
+  | {
+      value: string
+      count: number
+      suppressed: false
+    }
+  | {
+      value: 'suppressed'
+      count: null
+      suppressed: true
+    }
+
+export type ComplianceReportingBreakdowns = Record<
+  ComplianceReportingBreakdownName,
+  ComplianceReportingBucket[]
+>
+
+export interface ProtectedComplianceReporting {
+  suppressed: boolean
+  minimumCohortSize: typeof MIN_COMPLIANCE_REPORTING_COHORT
+  breakdowns: ComplianceReportingBreakdowns
+}
+
+export function protectComplianceReporting(
+  totalResponses: number,
+  breakdowns: ComplianceReportingBreakdownsInput,
+): ProtectedComplianceReporting {
+  if (totalResponses < MIN_COMPLIANCE_REPORTING_COHORT) {
+    return {
+      suppressed: true,
+      minimumCohortSize: MIN_COMPLIANCE_REPORTING_COHORT,
+      breakdowns: emptyBreakdowns(),
+    }
+  }
+
+  const sex = protectBreakdown(breakdowns.sex)
+  const raceEthnicity = protectBreakdown(breakdowns.raceEthnicity)
+  const veteranStatus = protectBreakdown(breakdowns.veteranStatus)
+  const disabilityStatus = protectBreakdown(breakdowns.disabilityStatus)
+
+  return {
+    suppressed: sex.suppressed
+      || raceEthnicity.suppressed
+      || veteranStatus.suppressed
+      || disabilityStatus.suppressed,
+    minimumCohortSize: MIN_COMPLIANCE_REPORTING_COHORT,
+    breakdowns: {
+      sex: sex.buckets,
+      raceEthnicity: raceEthnicity.buckets,
+      veteranStatus: veteranStatus.buckets,
+      disabilityStatus: disabilityStatus.buckets,
+    },
+  }
+}
+
+function emptyBreakdowns(): ComplianceReportingBreakdowns {
+  return {
+    sex: [],
+    raceEthnicity: [],
+    veteranStatus: [],
+    disabilityStatus: [],
+  }
+}
+
+function protectBreakdown(rows: readonly ComplianceReportingInputBucket[]): {
+  buckets: ComplianceReportingBucket[]
+  suppressed: boolean
+} {
+  const sortedRows = rows
+    .flatMap((row) => row.value === null ? [] : [{ value: row.value, count: row.count }])
+    .sort((left, right) => right.count - left.count || compareValues(left.value, right.value))
+
+  const suppressedIndexes = new Set(
+    sortedRows
+      .map((row, index) => ({ row, index }))
+      .filter(({ row }) => row.count < MIN_COMPLIANCE_REPORTING_COHORT)
+      .map(({ index }) => index),
+  )
+
+  if (suppressedIndexes.size === 1 && sortedRows.length > 1) {
+    const complementaryIndex = sortedRows
+      .map((row, index) => ({ row, index }))
+      .filter(({ index }) => !suppressedIndexes.has(index))
+      .sort((left, right) =>
+        left.row.count - right.row.count
+        || compareValues(left.row.value, right.row.value),
+      )[0]?.index
+
+    if (complementaryIndex !== undefined) {
+      suppressedIndexes.add(complementaryIndex)
+    }
+  }
+
+  return {
+    suppressed: suppressedIndexes.size > 0,
+    buckets: sortedRows.map((row, index) => {
+      if (suppressedIndexes.has(index)) {
+        return {
+          value: 'suppressed',
+          count: null,
+          suppressed: true,
+        }
+      }
+
+      return {
+        ...row,
+        suppressed: false,
+      }
+    }),
+  }
+}
+
+function compareValues(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}

--- a/server/utils/google-calendar.ts
+++ b/server/utils/google-calendar.ts
@@ -363,9 +363,10 @@ interface InterviewEventData {
  * Returns the created event ID and HTML link, or null if creation failed.
  */
 export async function createCalendarEvent(
-  userId: string,
+  owner: string | GoogleCalendarIntegrationIdentity,
   data: InterviewEventData,
 ): Promise<{ id: string; htmlLink: string } | null> {
+  const userId = typeof owner === 'string' ? owner : owner.userId
   if (env.FACTORY_CALENDAR_TEST_MODE === 'mock') {
     const eventId = `mock-google-event-${data.startTime.getTime()}`
     return {
@@ -374,11 +375,13 @@ export async function createCalendarEvent(
     }
   }
 
-  const calendar = await getCalendarClient(userId)
+  const calendar = await getCalendarClient(owner)
   if (!calendar) return null
 
   const integration = await db.query.calendarIntegration.findFirst({
-    where: and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')),
+    where: typeof owner === 'string'
+      ? and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google'))
+      : googleIntegrationWhere(owner),
     columns: { calendarId: true },
   })
 
@@ -455,19 +458,22 @@ export async function createCalendarEvent(
  * Returns the htmlLink if the update succeeded, or null on failure.
  */
 export async function updateCalendarEvent(
-  userId: string,
+  owner: string | GoogleCalendarIntegrationIdentity,
   eventId: string,
   data: Partial<InterviewEventData>,
 ): Promise<string | null> {
+  const userId = typeof owner === 'string' ? owner : owner.userId
   if (env.FACTORY_CALENDAR_TEST_MODE === 'mock') {
     return `https://calendar.test.local/events/${encodeURIComponent(eventId)}`
   }
 
-  const calendar = await getCalendarClient(userId)
+  const calendar = await getCalendarClient(owner)
   if (!calendar) return null
 
   const integration = await db.query.calendarIntegration.findFirst({
-    where: and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')),
+    where: typeof owner === 'string'
+      ? and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google'))
+      : googleIntegrationWhere(owner),
     columns: { calendarId: true },
   })
 
@@ -537,16 +543,19 @@ export async function updateCalendarEvent(
  * Sends cancellation notifications to all attendees.
  */
 export async function cancelCalendarEvent(
-  userId: string,
+  owner: string | GoogleCalendarIntegrationIdentity,
   eventId: string,
 ): Promise<boolean> {
+  const userId = typeof owner === 'string' ? owner : owner.userId
   if (env.FACTORY_CALENDAR_TEST_MODE === 'mock') return true
 
-  const calendar = await getCalendarClient(userId)
+  const calendar = await getCalendarClient(owner)
   if (!calendar) return false
 
   const integration = await db.query.calendarIntegration.findFirst({
-    where: and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')),
+    where: typeof owner === 'string'
+      ? and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google'))
+      : googleIntegrationWhere(owner),
     columns: { calendarId: true },
   })
 
@@ -740,7 +749,9 @@ export async function performIncrementalSync(identity: GoogleCalendarIntegration
 
       for (const event of events) {
         if (!event.id) continue
-        await syncEventAttendeeStatus(event, identity.organizationId)
+        if (identity.organizationId !== null) {
+          await syncEventAttendeeStatus(event, identity.organizationId)
+        }
       }
 
       pageToken = data.nextPageToken ?? undefined
@@ -782,18 +793,16 @@ function mapAttendeeStatus(
  */
 async function syncEventAttendeeStatus(
   event: calendar_v3.Schema$Event,
-  organizationId: string | null,
+  organizationId: string,
 ): Promise<void> {
   if (!event.id) return
 
   // Find the interview linked to this Google Calendar event
   const interviewRecord = await db.query.interview.findFirst({
-    where: organizationId === null
-      ? eq(interview.googleCalendarEventId, event.id)
-      : and(
-          eq(interview.googleCalendarEventId, event.id),
-          eq(interview.organizationId, organizationId),
-        ),
+    where: and(
+      eq(interview.googleCalendarEventId, event.id),
+      eq(interview.organizationId, organizationId),
+    ),
     with: {
       application: {
         with: {
@@ -825,7 +834,10 @@ async function syncEventAttendeeStatus(
       candidateRespondedAt: new Date(),
       updatedAt: new Date(),
     })
-    .where(eq(interview.id, interviewRecord.id))
+    .where(and(
+      eq(interview.id, interviewRecord.id),
+      eq(interview.organizationId, organizationId),
+    ))
 
   console.info(
     `[Calendar] Synced candidate response for interview ${interviewRecord.id}: ` +

--- a/server/utils/google-calendar.ts
+++ b/server/utils/google-calendar.ts
@@ -5,7 +5,7 @@
  * for two-way interview scheduling sync.
  */
 import { google, type calendar_v3 } from 'googleapis'
-import { eq, and, isNull } from 'drizzle-orm'
+import { eq, and, exists, isNull } from 'drizzle-orm'
 import { encrypt, decrypt } from './encryption'
 import { calendarIntegration, interview } from '../database/schema'
 
@@ -28,6 +28,16 @@ function googleIntegrationConditions(identity: GoogleCalendarIntegrationIdentity
 
 function googleIntegrationWhere(identity: GoogleCalendarIntegrationIdentity) {
   return and(...googleIntegrationConditions(identity))
+}
+
+function googleCredentialGenerationWhere(
+  identity: GoogleCalendarIntegrationIdentity,
+  refreshTokenEncrypted: string,
+) {
+  return and(
+    ...googleIntegrationConditions(identity),
+    eq(calendarIntegration.refreshTokenEncrypted, refreshTokenEncrypted),
+  )
 }
 
 function calendarIntegrationConflict() {
@@ -160,7 +170,7 @@ export async function exchangeCodeForTokens(code: string): Promise<{
  */
 export async function getCalendarClient(
   owner: string | GoogleCalendarIntegrationIdentity,
-  expectedAccessTokenEncrypted?: string,
+  expectedRefreshTokenEncrypted?: string,
 ): Promise<calendar_v3.Calendar | null> {
   const userId = typeof owner === 'string' ? owner : owner.userId
   const integration = await db.query.calendarIntegration.findFirst({
@@ -168,14 +178,14 @@ export async function getCalendarClient(
       ? and(
           eq(calendarIntegration.userId, userId),
           eq(calendarIntegration.provider, 'google'),
-          ...(expectedAccessTokenEncrypted
-            ? [eq(calendarIntegration.accessTokenEncrypted, expectedAccessTokenEncrypted)]
+          ...(expectedRefreshTokenEncrypted
+            ? [eq(calendarIntegration.refreshTokenEncrypted, expectedRefreshTokenEncrypted)]
             : []),
         )
       : and(
           ...googleIntegrationConditions(owner),
-          ...(expectedAccessTokenEncrypted
-            ? [eq(calendarIntegration.accessTokenEncrypted, expectedAccessTokenEncrypted)]
+          ...(expectedRefreshTokenEncrypted
+            ? [eq(calendarIntegration.refreshTokenEncrypted, expectedRefreshTokenEncrypted)]
             : []),
         ),
   })
@@ -407,11 +417,11 @@ export async function createCalendarEvent(
     where: typeof owner === 'string'
       ? and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google'))
       : googleIntegrationWhere(owner),
-    columns: { accessTokenEncrypted: true, calendarId: true },
+    columns: { calendarId: true, refreshTokenEncrypted: true },
   })
 
-  if (!integration?.accessTokenEncrypted) return null
-  const calendar = await getCalendarClient(owner, integration.accessTokenEncrypted)
+  if (!integration?.refreshTokenEncrypted) return null
+  const calendar = await getCalendarClient(owner, integration.refreshTokenEncrypted)
   if (!calendar) return null
 
   const calendarId = integration?.calendarId || 'primary'
@@ -500,11 +510,11 @@ export async function updateCalendarEvent(
     where: typeof owner === 'string'
       ? and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google'))
       : googleIntegrationWhere(owner),
-    columns: { accessTokenEncrypted: true, calendarId: true },
+    columns: { calendarId: true, refreshTokenEncrypted: true },
   })
 
-  if (!integration?.accessTokenEncrypted) return null
-  const calendar = await getCalendarClient(owner, integration.accessTokenEncrypted)
+  if (!integration?.refreshTokenEncrypted) return null
+  const calendar = await getCalendarClient(owner, integration.refreshTokenEncrypted)
   if (!calendar) return null
 
   const calendarId = integration?.calendarId || 'primary'
@@ -583,11 +593,11 @@ export async function cancelCalendarEvent(
     where: typeof owner === 'string'
       ? and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google'))
       : googleIntegrationWhere(owner),
-    columns: { accessTokenEncrypted: true, calendarId: true },
+    columns: { calendarId: true, refreshTokenEncrypted: true },
   })
 
-  if (!integration?.accessTokenEncrypted) return false
-  const calendar = await getCalendarClient(owner, integration.accessTokenEncrypted)
+  if (!integration?.refreshTokenEncrypted) return false
+  const calendar = await getCalendarClient(owner, integration.refreshTokenEncrypted)
   if (!calendar) return false
 
   const calendarId = integration?.calendarId || 'primary'
@@ -625,16 +635,16 @@ export async function setupCalendarWebhook(identity: GoogleCalendarIntegrationId
   const integration = await db.query.calendarIntegration.findFirst({
     where: googleIntegrationWhere(identity),
     columns: {
-      accessTokenEncrypted: true,
       calendarId: true,
+      refreshTokenEncrypted: true,
       webhookChannelId: true,
       webhookResourceId: true,
     },
   })
 
-  if (!integration?.accessTokenEncrypted) return false
+  if (!integration?.refreshTokenEncrypted) return false
 
-  const calendar = await getCalendarClient(identity, integration.accessTokenEncrypted)
+  const calendar = await getCalendarClient(identity, integration.refreshTokenEncrypted)
   if (!calendar) return false
 
   // Stop existing channel if any
@@ -685,7 +695,7 @@ export async function setupCalendarWebhook(identity: GoogleCalendarIntegrationId
       })
       .where(and(
         ...googleIntegrationConditions(identity),
-        eq(calendarIntegration.accessTokenEncrypted, integration.accessTokenEncrypted),
+        eq(calendarIntegration.refreshTokenEncrypted, integration.refreshTokenEncrypted),
         integration.webhookChannelId === null
           ? isNull(calendarIntegration.webhookChannelId)
           : eq(calendarIntegration.webhookChannelId, integration.webhookChannelId),
@@ -723,14 +733,15 @@ export async function performIncrementalSync(identity: GoogleCalendarIntegration
   if (env.FACTORY_CALENDAR_TEST_MODE === 'mock') return
 
   const { userId } = identity
-  const calendar = await getCalendarClient(identity)
-  if (!calendar) return
-
   const integration = await db.query.calendarIntegration.findFirst({
     where: googleIntegrationWhere(identity),
   })
 
-  if (!integration) return
+  if (!integration?.refreshTokenEncrypted) return
+
+  const credentialGeneration = integration.refreshTokenEncrypted
+  const calendar = await getCalendarClient(identity, credentialGeneration)
+  if (!calendar) return
 
   const calendarId = integration.calendarId || 'primary'
 
@@ -768,10 +779,12 @@ export async function performIncrementalSync(identity: GoogleCalendarIntegration
         // If syncToken is invalid (410 Gone), clear it and do a full re-sync
         if (err && typeof err === 'object' && 'code' in err && (err as { code: number }).code === 410) {
           if (integration.syncToken) {
-            await db.update(calendarIntegration)
+            const cleared = await db.update(calendarIntegration)
               .set({ syncToken: null, updatedAt: new Date() })
-              .where(googleIntegrationWhere(identity))
-            return performIncrementalSync(identity)
+              .where(googleCredentialGenerationWhere(identity, credentialGeneration))
+              .returning({ id: calendarIntegration.id })
+            if (cleared[0]) return await performIncrementalSync(identity)
+            return
           }
           // Already cleared syncToken but still getting 410 — bail out
           logError('calendar.persistent_410_error', {
@@ -784,10 +797,20 @@ export async function performIncrementalSync(identity: GoogleCalendarIntegration
 
       const events = data.items ?? []
 
+      const generationStillCurrent = await db.query.calendarIntegration.findFirst({
+        where: googleCredentialGenerationWhere(identity, credentialGeneration),
+        columns: { id: true },
+      })
+      if (!generationStillCurrent) return
+
       for (const event of events) {
         if (!event.id) continue
         if (identity.organizationId !== null) {
-          await syncEventAttendeeStatus(event, identity.organizationId)
+          await syncEventAttendeeStatus(
+            event,
+            identity,
+            credentialGeneration,
+          )
         }
       }
 
@@ -799,7 +822,7 @@ export async function performIncrementalSync(identity: GoogleCalendarIntegration
     if (nextSyncToken) {
       await db.update(calendarIntegration)
         .set({ syncToken: nextSyncToken, updatedAt: new Date() })
-        .where(googleIntegrationWhere(identity))
+        .where(googleCredentialGenerationWhere(identity, credentialGeneration))
     }
   }
   catch (err) {
@@ -830,9 +853,12 @@ function mapAttendeeStatus(
  */
 async function syncEventAttendeeStatus(
   event: calendar_v3.Schema$Event,
-  organizationId: string,
+  identity: GoogleCalendarIntegrationIdentity,
+  credentialGeneration: string,
 ): Promise<void> {
   if (!event.id) return
+  if (identity.organizationId === null) return
+  const organizationId = identity.organizationId
 
   // Find the interview linked to this Google Calendar event
   const interviewRecord = await db.query.interview.findFirst({
@@ -874,6 +900,11 @@ async function syncEventAttendeeStatus(
     .where(and(
       eq(interview.id, interviewRecord.id),
       eq(interview.organizationId, organizationId),
+      exists(
+        db.select({ id: calendarIntegration.id })
+          .from(calendarIntegration)
+          .where(googleCredentialGenerationWhere(identity, credentialGeneration)),
+      ),
     ))
 
   console.info(

--- a/server/utils/google-calendar.ts
+++ b/server/utils/google-calendar.ts
@@ -15,6 +15,10 @@ export type GoogleCalendarIntegrationIdentity = Readonly<{
   organizationId: string | null
 }>
 
+export type GoogleCalendarIntegrationSnapshot = GoogleCalendarIntegrationIdentity & Readonly<{
+  connectionGeneration: string
+}>
+
 function googleIntegrationConditions(identity: GoogleCalendarIntegrationIdentity) {
   return [
     eq(calendarIntegration.id, identity.integrationId),
@@ -37,6 +41,13 @@ function googleCredentialGenerationWhere(
   return and(
     ...googleIntegrationConditions(identity),
     eq(calendarIntegration.refreshTokenEncrypted, refreshTokenEncrypted),
+  )
+}
+
+function googleConnectionGenerationWhere(identity: GoogleCalendarIntegrationSnapshot) {
+  return and(
+    ...googleIntegrationConditions(identity),
+    eq(calendarIntegration.connectionGeneration, identity.connectionGeneration),
   )
 }
 
@@ -164,6 +175,24 @@ export async function exchangeCodeForTokens(code: string): Promise<{
 // Token Management
 // ─────────────────────────────────────────────
 
+function calendarClientFromEncryptedTokens(
+  userId: string,
+  accessTokenEncrypted: string | null,
+  refreshTokenEncrypted: string | null,
+): calendar_v3.Calendar | null {
+  const secret = env.BETTER_AUTH_SECRET
+  const accessToken = accessTokenEncrypted ? decrypt(accessTokenEncrypted, secret) : null
+  const refreshToken = refreshTokenEncrypted ? decrypt(refreshTokenEncrypted, secret) : null
+  if (!accessToken || !refreshToken) {
+    logError('calendar.token_decrypt_failed', { posthog_distinct_id: userId })
+    return null
+  }
+
+  const oauth2Client = createOAuth2Client(getRedirectUri())
+  oauth2Client.setCredentials({ access_token: accessToken, refresh_token: refreshToken })
+  return google.calendar({ version: 'v3', auth: oauth2Client })
+}
+
 /**
  * Get an authenticated Google Calendar client for a user.
  * Decrypts stored tokens and handles automatic refresh.
@@ -258,6 +287,7 @@ export async function saveCalendarIntegration(userId: string, organizationId: st
   const secret = env.BETTER_AUTH_SECRET
   const accessTokenEncrypted = encrypt(params.accessToken, secret)
   const refreshTokenEncrypted = encrypt(params.refreshToken, secret)
+  const connectionGeneration = crypto.randomUUID()
 
   try {
     return await db.transaction(async (tx) => {
@@ -292,6 +322,7 @@ export async function saveCalendarIntegration(userId: string, organizationId: st
         const updated = await tx.update(calendarIntegration)
           .set({
             organizationId,
+            connectionGeneration,
             accessTokenEncrypted,
             refreshTokenEncrypted,
             accountEmail: params.email,
@@ -313,6 +344,7 @@ export async function saveCalendarIntegration(userId: string, organizationId: st
           userId,
           organizationId,
           provider: 'google',
+          connectionGeneration,
           accessTokenEncrypted,
           refreshTokenEncrypted,
           accountEmail: params.email,
@@ -334,23 +366,30 @@ export async function saveCalendarIntegration(userId: string, organizationId: st
  * Remove calendar integration for a user.
  * Stops the webhook channel and deletes stored credentials.
  */
-export async function removeCalendarIntegration(identity: GoogleCalendarIntegrationIdentity): Promise<void> {
+export async function removeCalendarIntegration(identity: GoogleCalendarIntegrationSnapshot): Promise<boolean> {
   const { userId } = identity
-  if (env.FACTORY_CALENDAR_TEST_MODE === 'mock') {
-    await db.delete(calendarIntegration).where(googleIntegrationWhere(identity))
-    return
-  }
-
-  const integration = await db.query.calendarIntegration.findFirst({
-    where: googleIntegrationWhere(identity),
-  })
-
-  if (!integration) return
+  const selectedWhere = googleConnectionGenerationWhere(identity)
+  const deleted = await db.delete(calendarIntegration)
+    .where(selectedWhere)
+    .returning({
+      id: calendarIntegration.id,
+      accessTokenEncrypted: calendarIntegration.accessTokenEncrypted,
+      refreshTokenEncrypted: calendarIntegration.refreshTokenEncrypted,
+      webhookChannelId: calendarIntegration.webhookChannelId,
+      webhookResourceId: calendarIntegration.webhookResourceId,
+    })
+  const integration = deleted[0]
+  if (!integration) return false
+  if (env.FACTORY_CALENDAR_TEST_MODE === 'mock') return true
 
   // Stop the webhook channel if active
   if (integration.webhookChannelId && integration.webhookResourceId) {
     try {
-      const calendar = await getCalendarClient(identity)
+      const calendar = calendarClientFromEncryptedTokens(
+        userId,
+        integration.accessTokenEncrypted,
+        integration.refreshTokenEncrypted,
+      )
       if (calendar) {
         await calendar.channels.stop({
           requestBody: {
@@ -369,7 +408,7 @@ export async function removeCalendarIntegration(identity: GoogleCalendarIntegrat
     }
   }
 
-  await db.delete(calendarIntegration).where(googleIntegrationWhere(identity))
+  return true
 }
 
 // ─────────────────────────────────────────────

--- a/server/utils/google-calendar.ts
+++ b/server/utils/google-calendar.ts
@@ -160,21 +160,35 @@ export async function exchangeCodeForTokens(code: string): Promise<{
  */
 export async function getCalendarClient(
   owner: string | GoogleCalendarIntegrationIdentity,
+  expectedAccessTokenEncrypted?: string,
 ): Promise<calendar_v3.Calendar | null> {
   const userId = typeof owner === 'string' ? owner : owner.userId
   const integration = await db.query.calendarIntegration.findFirst({
     where: typeof owner === 'string'
-      ? and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google'))
-      : googleIntegrationWhere(owner),
+      ? and(
+          eq(calendarIntegration.userId, userId),
+          eq(calendarIntegration.provider, 'google'),
+          ...(expectedAccessTokenEncrypted
+            ? [eq(calendarIntegration.accessTokenEncrypted, expectedAccessTokenEncrypted)]
+            : []),
+        )
+      : and(
+          ...googleIntegrationConditions(owner),
+          ...(expectedAccessTokenEncrypted
+            ? [eq(calendarIntegration.accessTokenEncrypted, expectedAccessTokenEncrypted)]
+            : []),
+        ),
   })
 
   if (!integration) return null
 
   const secret = env.BETTER_AUTH_SECRET
-  const accessToken = integration.accessTokenEncrypted ? decrypt(integration.accessTokenEncrypted, secret) : null
-  const refreshToken = integration.refreshTokenEncrypted ? decrypt(integration.refreshTokenEncrypted, secret) : null
+  const loadedAccessTokenEncrypted = integration.accessTokenEncrypted
+  const loadedRefreshTokenEncrypted = integration.refreshTokenEncrypted
+  const accessToken = loadedAccessTokenEncrypted ? decrypt(loadedAccessTokenEncrypted, secret) : null
+  const refreshToken = loadedRefreshTokenEncrypted ? decrypt(loadedRefreshTokenEncrypted, secret) : null
 
-  if (!accessToken || !refreshToken) {
+  if (!loadedAccessTokenEncrypted || !loadedRefreshTokenEncrypted || !accessToken || !refreshToken) {
     logError('calendar.token_decrypt_failed', {
       posthog_distinct_id: userId,
     })
@@ -182,6 +196,7 @@ export async function getCalendarClient(
   }
 
   const oauth2Client = createOAuth2Client(getRedirectUri())
+  let credentialVersion = loadedAccessTokenEncrypted
   oauth2Client.setCredentials({
     access_token: accessToken,
     refresh_token: refreshToken,
@@ -192,14 +207,23 @@ export async function getCalendarClient(
     if (tokens.access_token) {
       try {
         const newAccessTokenEncrypted = encrypt(tokens.access_token, secret)
-        await db.update(calendarIntegration)
+        const persisted = await db.update(calendarIntegration)
           .set({
             accessTokenEncrypted: newAccessTokenEncrypted,
             updatedAt: new Date(),
           })
           .where(typeof owner === 'string'
-            ? and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google'))
-            : googleIntegrationWhere(owner))
+            ? and(
+                eq(calendarIntegration.userId, userId),
+                eq(calendarIntegration.provider, 'google'),
+                eq(calendarIntegration.accessTokenEncrypted, credentialVersion),
+              )
+            : and(
+                ...googleIntegrationConditions(owner),
+                eq(calendarIntegration.accessTokenEncrypted, credentialVersion),
+              ))
+          .returning({ id: calendarIntegration.id })
+        if (persisted[0]) credentialVersion = newAccessTokenEncrypted
       }
       catch (err) {
         logError('calendar.token_refresh_persist_failed', {
@@ -261,6 +285,10 @@ export async function saveCalendarIntegration(userId: string, organizationId: st
             accessTokenEncrypted,
             refreshTokenEncrypted,
             accountEmail: params.email,
+            webhookChannelId: null,
+            webhookResourceId: null,
+            webhookExpiration: null,
+            syncToken: null,
             updatedAt: new Date(),
           })
           .where(googleIntegrationWhere(previousIdentity))
@@ -375,15 +403,16 @@ export async function createCalendarEvent(
     }
   }
 
-  const calendar = await getCalendarClient(owner)
-  if (!calendar) return null
-
   const integration = await db.query.calendarIntegration.findFirst({
     where: typeof owner === 'string'
       ? and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google'))
       : googleIntegrationWhere(owner),
-    columns: { calendarId: true },
+    columns: { accessTokenEncrypted: true, calendarId: true },
   })
+
+  if (!integration?.accessTokenEncrypted) return null
+  const calendar = await getCalendarClient(owner, integration.accessTokenEncrypted)
+  if (!calendar) return null
 
   const calendarId = integration?.calendarId || 'primary'
 
@@ -467,15 +496,16 @@ export async function updateCalendarEvent(
     return `https://calendar.test.local/events/${encodeURIComponent(eventId)}`
   }
 
-  const calendar = await getCalendarClient(owner)
-  if (!calendar) return null
-
   const integration = await db.query.calendarIntegration.findFirst({
     where: typeof owner === 'string'
       ? and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google'))
       : googleIntegrationWhere(owner),
-    columns: { calendarId: true },
+    columns: { accessTokenEncrypted: true, calendarId: true },
   })
+
+  if (!integration?.accessTokenEncrypted) return null
+  const calendar = await getCalendarClient(owner, integration.accessTokenEncrypted)
+  if (!calendar) return null
 
   const calendarId = integration?.calendarId || 'primary'
 
@@ -549,15 +579,16 @@ export async function cancelCalendarEvent(
   const userId = typeof owner === 'string' ? owner : owner.userId
   if (env.FACTORY_CALENDAR_TEST_MODE === 'mock') return true
 
-  const calendar = await getCalendarClient(owner)
-  if (!calendar) return false
-
   const integration = await db.query.calendarIntegration.findFirst({
     where: typeof owner === 'string'
       ? and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google'))
       : googleIntegrationWhere(owner),
-    columns: { calendarId: true },
+    columns: { accessTokenEncrypted: true, calendarId: true },
   })
+
+  if (!integration?.accessTokenEncrypted) return false
+  const calendar = await getCalendarClient(owner, integration.accessTokenEncrypted)
+  if (!calendar) return false
 
   const calendarId = integration?.calendarId || 'primary'
 
@@ -591,15 +622,20 @@ export async function setupCalendarWebhook(identity: GoogleCalendarIntegrationId
   if (env.FACTORY_CALENDAR_TEST_MODE === 'mock') return false
 
   const { userId } = identity
-  const calendar = await getCalendarClient(identity)
-  if (!calendar) return false
-
   const integration = await db.query.calendarIntegration.findFirst({
     where: googleIntegrationWhere(identity),
-    columns: { calendarId: true, webhookChannelId: true, webhookResourceId: true },
+    columns: {
+      accessTokenEncrypted: true,
+      calendarId: true,
+      webhookChannelId: true,
+      webhookResourceId: true,
+    },
   })
 
-  if (!integration) return false
+  if (!integration?.accessTokenEncrypted) return false
+
+  const calendar = await getCalendarClient(identity, integration.accessTokenEncrypted)
+  if (!calendar) return false
 
   // Stop existing channel if any
   if (integration.webhookChannelId && integration.webhookResourceId) {
@@ -649,6 +685,7 @@ export async function setupCalendarWebhook(identity: GoogleCalendarIntegrationId
       })
       .where(and(
         ...googleIntegrationConditions(identity),
+        eq(calendarIntegration.accessTokenEncrypted, integration.accessTokenEncrypted),
         integration.webhookChannelId === null
           ? isNull(calendarIntegration.webhookChannelId)
           : eq(calendarIntegration.webhookChannelId, integration.webhookChannelId),

--- a/server/utils/google-calendar.ts
+++ b/server/utils/google-calendar.ts
@@ -5,9 +5,43 @@
  * for two-way interview scheduling sync.
  */
 import { google, type calendar_v3 } from 'googleapis'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, isNull } from 'drizzle-orm'
 import { encrypt, decrypt } from './encryption'
 import { calendarIntegration, interview } from '../database/schema'
+
+export type GoogleCalendarIntegrationIdentity = Readonly<{
+  integrationId: string
+  userId: string
+  organizationId: string | null
+}>
+
+function googleIntegrationConditions(identity: GoogleCalendarIntegrationIdentity) {
+  return [
+    eq(calendarIntegration.id, identity.integrationId),
+    eq(calendarIntegration.userId, identity.userId),
+    eq(calendarIntegration.provider, 'google'),
+    identity.organizationId === null
+      ? isNull(calendarIntegration.organizationId)
+      : eq(calendarIntegration.organizationId, identity.organizationId),
+  ] as const
+}
+
+function googleIntegrationWhere(identity: GoogleCalendarIntegrationIdentity) {
+  return and(...googleIntegrationConditions(identity))
+}
+
+function calendarIntegrationConflict() {
+  return createError({
+    statusCode: 409,
+    statusMessage: 'Google Calendar is already connected to a different organization or account',
+  })
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  if ('code' in error && error.code === '23505') return true
+  return 'cause' in error && isUniqueViolation(error.cause)
+}
 
 // ─────────────────────────────────────────────
 // OAuth2 Client
@@ -124,9 +158,14 @@ export async function exchangeCodeForTokens(code: string): Promise<{
  * Get an authenticated Google Calendar client for a user.
  * Decrypts stored tokens and handles automatic refresh.
  */
-export async function getCalendarClient(userId: string): Promise<calendar_v3.Calendar | null> {
+export async function getCalendarClient(
+  owner: string | GoogleCalendarIntegrationIdentity,
+): Promise<calendar_v3.Calendar | null> {
+  const userId = typeof owner === 'string' ? owner : owner.userId
   const integration = await db.query.calendarIntegration.findFirst({
-    where: and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')),
+    where: typeof owner === 'string'
+      ? and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google'))
+      : googleIntegrationWhere(owner),
   })
 
   if (!integration) return null
@@ -158,7 +197,9 @@ export async function getCalendarClient(userId: string): Promise<calendar_v3.Cal
             accessTokenEncrypted: newAccessTokenEncrypted,
             updatedAt: new Date(),
           })
-          .where(and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')))
+          .where(typeof owner === 'string'
+            ? and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google'))
+            : googleIntegrationWhere(owner))
       }
       catch (err) {
         logError('calendar.token_refresh_persist_failed', {
@@ -175,39 +216,79 @@ export async function getCalendarClient(userId: string): Promise<calendar_v3.Cal
 /**
  * Save or update calendar integration credentials for a user.
  */
-export async function saveCalendarIntegration(userId: string, params: {
+export async function saveCalendarIntegration(userId: string, organizationId: string, params: {
   accessToken: string
   refreshToken: string
   email: string | null
-}): Promise<void> {
+}): Promise<GoogleCalendarIntegrationIdentity> {
   const secret = env.BETTER_AUTH_SECRET
   const accessTokenEncrypted = encrypt(params.accessToken, secret)
   const refreshTokenEncrypted = encrypt(params.refreshToken, secret)
 
-  // Upsert: update if exists, insert if not
-  const existing = await db.query.calendarIntegration.findFirst({
-    where: and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')),
-  })
-
-  if (existing) {
-    await db.update(calendarIntegration)
-      .set({
-        accessTokenEncrypted,
-        refreshTokenEncrypted,
-        accountEmail: params.email,
-        updatedAt: new Date(),
+  try {
+    return await db.transaction(async (tx) => {
+      const existingForUser = await tx.query.calendarIntegration.findFirst({
+        where: and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')),
       })
-      .where(and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')))
-  }
-  else {
-    await db.delete(calendarIntegration).where(eq(calendarIntegration.userId, userId))
-    await db.insert(calendarIntegration).values({
-      userId,
-      provider: 'google',
-      accessTokenEncrypted,
-      refreshTokenEncrypted,
-      accountEmail: params.email,
+      const existingForOrganization = await tx.query.calendarIntegration.findFirst({
+        where: and(
+          eq(calendarIntegration.organizationId, organizationId),
+          eq(calendarIntegration.provider, 'google'),
+        ),
+      })
+
+      if (existingForUser?.organizationId && existingForUser.organizationId !== organizationId) {
+        throw calendarIntegrationConflict()
+      }
+      if (existingForOrganization && existingForOrganization.id !== existingForUser?.id) {
+        throw calendarIntegrationConflict()
+      }
+
+      if (existingForUser) {
+        const previousIdentity: GoogleCalendarIntegrationIdentity = {
+          integrationId: existingForUser.id,
+          userId,
+          organizationId: existingForUser.organizationId,
+        }
+        const identity: GoogleCalendarIntegrationIdentity = {
+          integrationId: existingForUser.id,
+          userId,
+          organizationId,
+        }
+        const updated = await tx.update(calendarIntegration)
+          .set({
+            organizationId,
+            accessTokenEncrypted,
+            refreshTokenEncrypted,
+            accountEmail: params.email,
+            updatedAt: new Date(),
+          })
+          .where(googleIntegrationWhere(previousIdentity))
+          .returning({ id: calendarIntegration.id })
+
+        if (!updated[0]) throw calendarIntegrationConflict()
+        return identity
+      }
+
+      const inserted = await tx.insert(calendarIntegration)
+        .values({
+          userId,
+          organizationId,
+          provider: 'google',
+          accessTokenEncrypted,
+          refreshTokenEncrypted,
+          accountEmail: params.email,
+        })
+        .returning({ id: calendarIntegration.id })
+      const integrationId = inserted[0]?.id
+      if (!integrationId) throw new Error('Failed to save Google Calendar integration')
+
+      return { integrationId, userId, organizationId }
     })
+  }
+  catch (error) {
+    if (isUniqueViolation(error)) throw calendarIntegrationConflict()
+    throw error
   }
 }
 
@@ -215,14 +296,15 @@ export async function saveCalendarIntegration(userId: string, params: {
  * Remove calendar integration for a user.
  * Stops the webhook channel and deletes stored credentials.
  */
-export async function removeCalendarIntegration(userId: string): Promise<void> {
+export async function removeCalendarIntegration(identity: GoogleCalendarIntegrationIdentity): Promise<void> {
+  const { userId } = identity
   if (env.FACTORY_CALENDAR_TEST_MODE === 'mock') {
-    await db.delete(calendarIntegration).where(and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')))
+    await db.delete(calendarIntegration).where(googleIntegrationWhere(identity))
     return
   }
 
   const integration = await db.query.calendarIntegration.findFirst({
-    where: and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')),
+    where: googleIntegrationWhere(identity),
   })
 
   if (!integration) return
@@ -230,7 +312,7 @@ export async function removeCalendarIntegration(userId: string): Promise<void> {
   // Stop the webhook channel if active
   if (integration.webhookChannelId && integration.webhookResourceId) {
     try {
-      const calendar = await getCalendarClient(userId)
+      const calendar = await getCalendarClient(identity)
       if (calendar) {
         await calendar.channels.stop({
           requestBody: {
@@ -249,7 +331,7 @@ export async function removeCalendarIntegration(userId: string): Promise<void> {
     }
   }
 
-  await db.delete(calendarIntegration).where(and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')))
+  await db.delete(calendarIntegration).where(googleIntegrationWhere(identity))
 }
 
 // ─────────────────────────────────────────────
@@ -496,14 +578,15 @@ export async function cancelCalendarEvent(
  * Set up a Google Calendar webhook to receive push notifications
  * when events change (e.g., candidate accepts/declines via Google Calendar).
  */
-export async function setupCalendarWebhook(userId: string): Promise<boolean> {
+export async function setupCalendarWebhook(identity: GoogleCalendarIntegrationIdentity): Promise<boolean> {
   if (env.FACTORY_CALENDAR_TEST_MODE === 'mock') return false
 
-  const calendar = await getCalendarClient(userId)
+  const { userId } = identity
+  const calendar = await getCalendarClient(identity)
   if (!calendar) return false
 
   const integration = await db.query.calendarIntegration.findFirst({
-    where: and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')),
+    where: googleIntegrationWhere(identity),
     columns: { calendarId: true, webhookChannelId: true, webhookResourceId: true },
   })
 
@@ -546,7 +629,7 @@ export async function setupCalendarWebhook(userId: string): Promise<boolean> {
     })
 
     // Store the channel info for later stop/renewal
-    await db.update(calendarIntegration)
+    const updated = await db.update(calendarIntegration)
       .set({
         webhookChannelId: channelId,
         webhookResourceId: response.data.resourceId ?? null,
@@ -555,10 +638,25 @@ export async function setupCalendarWebhook(userId: string): Promise<boolean> {
           : null,
         updatedAt: new Date(),
       })
-      .where(and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')))
+      .where(and(
+        ...googleIntegrationConditions(identity),
+        integration.webhookChannelId === null
+          ? isNull(calendarIntegration.webhookChannelId)
+          : eq(calendarIntegration.webhookChannelId, integration.webhookChannelId),
+      ))
+      .returning({ id: calendarIntegration.id })
+
+    if (!updated[0]) {
+      if (response.data.resourceId) {
+        await calendar.channels.stop({
+          requestBody: { id: channelId, resourceId: response.data.resourceId },
+        }).catch(() => undefined)
+      }
+      return false
+    }
 
     // Do an initial sync to get the syncToken
-    await performIncrementalSync(userId)
+    await performIncrementalSync(identity)
 
     return true
   }
@@ -575,14 +673,15 @@ export async function setupCalendarWebhook(userId: string): Promise<boolean> {
  * Perform an incremental sync to process changes from Google Calendar.
  * Updates interview candidateResponse based on attendee RSVP status.
  */
-export async function performIncrementalSync(userId: string): Promise<void> {
+export async function performIncrementalSync(identity: GoogleCalendarIntegrationIdentity): Promise<void> {
   if (env.FACTORY_CALENDAR_TEST_MODE === 'mock') return
 
-  const calendar = await getCalendarClient(userId)
+  const { userId } = identity
+  const calendar = await getCalendarClient(identity)
   if (!calendar) return
 
   const integration = await db.query.calendarIntegration.findFirst({
-    where: and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')),
+    where: googleIntegrationWhere(identity),
   })
 
   if (!integration) return
@@ -625,8 +724,8 @@ export async function performIncrementalSync(userId: string): Promise<void> {
           if (integration.syncToken) {
             await db.update(calendarIntegration)
               .set({ syncToken: null, updatedAt: new Date() })
-              .where(and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')))
-            return performIncrementalSync(userId)
+              .where(googleIntegrationWhere(identity))
+            return performIncrementalSync(identity)
           }
           // Already cleared syncToken but still getting 410 — bail out
           logError('calendar.persistent_410_error', {
@@ -641,7 +740,7 @@ export async function performIncrementalSync(userId: string): Promise<void> {
 
       for (const event of events) {
         if (!event.id) continue
-        await syncEventAttendeeStatus(event)
+        await syncEventAttendeeStatus(event, identity.organizationId)
       }
 
       pageToken = data.nextPageToken ?? undefined
@@ -652,7 +751,7 @@ export async function performIncrementalSync(userId: string): Promise<void> {
     if (nextSyncToken) {
       await db.update(calendarIntegration)
         .set({ syncToken: nextSyncToken, updatedAt: new Date() })
-        .where(and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'google')))
+        .where(googleIntegrationWhere(identity))
     }
   }
   catch (err) {
@@ -681,12 +780,20 @@ function mapAttendeeStatus(
 /**
  * Sync a single Google Calendar event's attendee status back to the interview.
  */
-async function syncEventAttendeeStatus(event: calendar_v3.Schema$Event): Promise<void> {
+async function syncEventAttendeeStatus(
+  event: calendar_v3.Schema$Event,
+  organizationId: string | null,
+): Promise<void> {
   if (!event.id) return
 
   // Find the interview linked to this Google Calendar event
   const interviewRecord = await db.query.interview.findFirst({
-    where: eq(interview.googleCalendarEventId, event.id),
+    where: organizationId === null
+      ? eq(interview.googleCalendarEventId, event.id)
+      : and(
+          eq(interview.googleCalendarEventId, event.id),
+          eq(interview.organizationId, organizationId),
+        ),
     with: {
       application: {
         with: {

--- a/server/utils/httpCache.ts
+++ b/server/utils/httpCache.ts
@@ -14,18 +14,27 @@ function escapeCacheKeyPart(value: string): string {
 }
 
 async function getOrgDashboardCacheVersion(orgId: string): Promise<number> {
-  const stored = await useStorage().getItem<number>(`${ORG_DASHBOARD_CACHE_VERSION_PREFIX}${orgId}`)
+  const stored = await useStorage().getItem<number>(
+    `${ORG_DASHBOARD_CACHE_VERSION_PREFIX}${orgId}`,
+  )
   return typeof stored === 'number' && Number.isFinite(stored) ? stored : 0
 }
 
 /** Bump the org cache generation so new list/stats reads miss prior Nitro entries. */
-export async function bumpOrgDashboardCacheVersion(orgId: string): Promise<void> {
+export async function bumpOrgDashboardCacheVersion(
+  orgId: string,
+): Promise<void> {
   const current = await getOrgDashboardCacheVersion(orgId)
-  await useStorage().setItem(`${ORG_DASHBOARD_CACHE_VERSION_PREFIX}${orgId}`, current + 1)
+  await useStorage().setItem(
+    `${ORG_DASHBOARD_CACHE_VERSION_PREFIX}${orgId}`,
+    current + 1,
+  )
 }
 
 /** Invalidate org-scoped dashboard list/stats caches for the active session org. */
-export async function invalidateOrgScopedDashboardCache(event: H3Event): Promise<void> {
+export async function invalidateOrgScopedDashboardCache(
+  event: H3Event,
+): Promise<void> {
   const session = await auth.api.getSession({ headers: event.headers })
   if (!session) return
 
@@ -36,26 +45,29 @@ export async function invalidateOrgScopedDashboardCache(event: H3Event): Promise
 }
 
 /** Invalidate org-scoped dashboard caches when only the organization id is known (e.g. public apply). */
-export async function invalidateOrgScopedDashboardCacheForOrg(orgId: string): Promise<void> {
+export async function invalidateOrgScopedDashboardCacheForOrg(
+  orgId: string,
+): Promise<void> {
   if (!orgId) return
   await bumpOrgDashboardCacheVersion(orgId)
 }
 
 /**
- * Nitro `defineCachedEventHandler` defaults for authenticated, org-scoped read APIs.
- * Cache keys include the active organization and a generation counter bumped on writes.
+ * Cache org-scoped dashboard data after the caller has authorized the request.
+ * Loaders receive only the authorized organization id and normalized route input.
  */
-export const orgScopedCacheOptions = {
-  maxAge: ORG_SCOPED_CACHE_MAX_AGE_SECONDS,
-  swr: true,
-  varies: ['cookie', 'authorization'] as const,
-  name: ORG_SCOPED_DASHBOARD_CACHE_NAME,
-  async getKey(event: H3Event) {
-    const session = await auth.api.getSession({ headers: event.headers })
-    const orgId = session ? await resolveActiveOrganizationId(session) : null
-    const orgPart = escapeCacheKeyPart(orgId ?? 'none')
-    const version = orgId ? await getOrgDashboardCacheVersion(orgId) : 0
-    const path = event.node.req.originalUrl || event.node.req.url || event.path
-    return `${orgPart}:v${version}:${hash(path)}`
-  },
+export function defineOrgScopedCachedFunction<Input, Result>(
+  name: string,
+  loader: (organizationId: string, input: Input) => Result | Promise<Result>,
+) {
+  return defineCachedFunction(loader, {
+    maxAge: ORG_SCOPED_CACHE_MAX_AGE_SECONDS,
+    swr: true,
+    name: `${ORG_SCOPED_DASHBOARD_CACHE_NAME}-${escapeCacheKeyPart(name)}`,
+    getKey: async (organizationId: string, input: Input) => {
+      const orgPart = escapeCacheKeyPart(organizationId)
+      const version = await getOrgDashboardCacheVersion(organizationId)
+      return `${orgPart}:v${version}:${hash(input)}`
+    },
+  })
 }

--- a/server/utils/httpCache.ts
+++ b/server/utils/httpCache.ts
@@ -65,9 +65,8 @@ export function defineOrgScopedCachedFunction<Input, Result>(
     swr: true,
     name: `${ORG_SCOPED_DASHBOARD_CACHE_NAME}-${escapeCacheKeyPart(name)}`,
     getKey: async (organizationId: string, input: Input) => {
-      const orgPart = escapeCacheKeyPart(organizationId)
       const version = await getOrgDashboardCacheVersion(organizationId)
-      return `${orgPart}:v${version}:${hash(input)}`
+      return hash({ organizationId, version, input })
     },
   })
 }

--- a/server/utils/microsoft-calendar.ts
+++ b/server/utils/microsoft-calendar.ts
@@ -53,6 +53,30 @@ type MicrosoftGraphContext = {
   accessToken: string
   integrationId: string
   calendarId: string
+  userId: string | null
+  organizationId: string | null
+  connectionGeneration: string
+}
+
+export type MicrosoftCalendarIntegrationIdentity = Readonly<{
+  integrationId: string
+  userId: string | null
+  organizationId: string | null
+  connectionGeneration: string
+}>
+
+function microsoftIntegrationGenerationWhere(identity: MicrosoftCalendarIntegrationIdentity) {
+  return and(
+    eq(calendarIntegration.id, identity.integrationId),
+    eq(calendarIntegration.provider, 'microsoft'),
+    identity.userId === null
+      ? isNull(calendarIntegration.userId)
+      : eq(calendarIntegration.userId, identity.userId),
+    identity.organizationId === null
+      ? isNull(calendarIntegration.organizationId)
+      : eq(calendarIntegration.organizationId, identity.organizationId),
+    eq(calendarIntegration.connectionGeneration, identity.connectionGeneration),
+  )
 }
 
 export type MicrosoftCalendarSyncResult = {
@@ -260,20 +284,39 @@ async function refreshMicrosoftAccessToken(userId: string, organizationId?: stri
 
     if (!tokens.access_token) return null
 
-    await db.update(calendarIntegration)
+    const refreshedAccessTokenEncrypted = encrypt(tokens.access_token, secret)
+    const refreshedRefreshTokenEncrypted = tokens.refresh_token
+      ? encrypt(tokens.refresh_token, secret)
+      : integration.refreshTokenEncrypted
+    const identity: MicrosoftCalendarIntegrationIdentity = {
+      integrationId: integration.id,
+      userId: integration.userId,
+      organizationId: integration.organizationId,
+      connectionGeneration: integration.connectionGeneration,
+    }
+    const persisted = await db.update(calendarIntegration)
       .set({
-        accessTokenEncrypted: encrypt(tokens.access_token, secret),
+        accessTokenEncrypted: refreshedAccessTokenEncrypted,
         ...(tokens.refresh_token
-          ? { refreshTokenEncrypted: encrypt(tokens.refresh_token, secret) }
+          ? { refreshTokenEncrypted: refreshedRefreshTokenEncrypted }
           : {}),
         updatedAt: new Date(),
       })
-      .where(eq(calendarIntegration.id, integration.id))
+      .where(and(
+        microsoftIntegrationGenerationWhere(identity),
+        eq(calendarIntegration.refreshTokenEncrypted, integration.refreshTokenEncrypted),
+      ))
+      .returning({ id: calendarIntegration.id })
+
+    if (!persisted[0]) return null
 
     return {
       accessToken: tokens.access_token,
       integrationId: integration.id,
       calendarId: integration.calendarId,
+      userId: integration.userId,
+      organizationId: integration.organizationId,
+      connectionGeneration: integration.connectionGeneration,
     }
   }
   catch (err) {
@@ -384,12 +427,19 @@ async function graphFetchGroupCalendar<T>(
   if (!groupId) {
     const group = await resolveMicrosoftCalendarGroup(context.accessToken)
     groupId = group.id
-    await db.update(calendarIntegration)
+    const updated = await db.update(calendarIntegration)
       .set({
         calendarId: group.id,
         updatedAt: new Date(),
       })
-      .where(eq(calendarIntegration.id, context.integrationId))
+      .where(microsoftIntegrationGenerationWhere({
+        integrationId: context.integrationId,
+        userId: context.userId,
+        organizationId: context.organizationId,
+        connectionGeneration: context.connectionGeneration,
+      }))
+      .returning({ id: calendarIntegration.id })
+    if (!updated[0]) throw new Error('Microsoft Calendar credentials changed during group resolution')
   }
 
   return await microsoftGraphFetchWithAccessToken<T>(
@@ -547,6 +597,7 @@ export async function saveMicrosoftCalendarIntegration(userId: string, organizat
     userId,
     organizationId,
     provider: 'microsoft' as const,
+    connectionGeneration: crypto.randomUUID(),
     accessTokenEncrypted: encrypt(params.accessToken, secret),
     refreshTokenEncrypted: encrypt(params.refreshToken, secret),
     calendarId: group.id,
@@ -613,43 +664,11 @@ function isMicrosoftCalendarUniqueViolation(error: unknown): boolean {
   return 'cause' in error && isMicrosoftCalendarUniqueViolation(error.cause)
 }
 
-export async function removeMicrosoftCalendarIntegration(userId: string, organizationId?: string | null): Promise<void> {
-  await db.delete(calendarIntegration)
-    .where(organizationId
-      ? and(eq(calendarIntegration.organizationId, organizationId), eq(calendarIntegration.provider, 'microsoft'))
-      : and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'microsoft')))
-}
-
-/**
- * Enable Microsoft Calendar integration at the organization level using application (app-only) permissions.
- * This is used when MICROSOFT_CALENDAR_AUTH_MODE=application.
- * No user tokens are stored; the system uses client_credentials from the pre-configured app registration.
- */
-export async function enableMicrosoftCalendarAppIntegration(organizationId: string): Promise<void> {
-  // Obtain an app token to resolve the target calendar/group
-  let accessToken: string
-  try {
-    accessToken = await getMicrosoftApplicationAccessToken()
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    throw new Error(`Failed to obtain app token for Microsoft Calendar: ${message}`)
-  }
-
-  const group = await resolveMicrosoftCalendarGroup(accessToken)
-  const expectedEmail = getMicrosoftCalendarAccountEmail()
-
-  await db.delete(calendarIntegration)
-    .where(and(eq(calendarIntegration.organizationId, organizationId), eq(calendarIntegration.provider, 'microsoft')))
-
-  await db.insert(calendarIntegration).values({
-    userId: null, // organization-level / app-only
-    organizationId,
-    provider: 'microsoft',
-    accessTokenEncrypted: null,
-    refreshTokenEncrypted: null,
-    calendarId: group.id,
-    accountEmail: normalizeEmail(expectedEmail) || expectedEmail,
-  })
+export async function removeMicrosoftCalendarIntegration(identity: MicrosoftCalendarIntegrationIdentity): Promise<boolean> {
+  const deleted = await db.delete(calendarIntegration)
+    .where(microsoftIntegrationGenerationWhere(identity))
+    .returning({ id: calendarIntegration.id })
+  return Boolean(deleted[0])
 }
 
 export async function createMicrosoftCalendarEvent(

--- a/server/utils/microsoft-calendar.ts
+++ b/server/utils/microsoft-calendar.ts
@@ -5,7 +5,7 @@
  * calendar APIs to create, update, and cancel interview events on Factory's
  * shared Microsoft 365 group calendar.
  */
-import { and, eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import { env } from './env'
 import { encrypt, decrypt } from './encryption'
 import { calendarIntegration, orgSettings } from '../database/schema'
@@ -543,20 +543,74 @@ export async function saveMicrosoftCalendarIntegration(userId: string, organizat
 }): Promise<void> {
   const secret = env.BETTER_AUTH_SECRET
   const group = await resolveMicrosoftCalendarGroup(params.accessToken)
-
-  await db.delete(calendarIntegration)
-    .where(and(eq(calendarIntegration.organizationId, organizationId), eq(calendarIntegration.provider, 'microsoft')))
-  await db.delete(calendarIntegration)
-    .where(and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'microsoft')))
-  await db.insert(calendarIntegration).values({
+  const values = {
     userId,
     organizationId,
-    provider: 'microsoft',
+    provider: 'microsoft' as const,
     accessTokenEncrypted: encrypt(params.accessToken, secret),
     refreshTokenEncrypted: encrypt(params.refreshToken, secret),
     calendarId: group.id,
     accountEmail: normalizeEmail(params.email) || params.email,
+    updatedAt: new Date(),
+  }
+
+  try {
+    await db.transaction(async (tx) => {
+      const existingForUser = await tx.query.calendarIntegration.findFirst({
+        where: and(eq(calendarIntegration.userId, userId), eq(calendarIntegration.provider, 'microsoft')),
+      })
+      const existingForOrganization = await tx.query.calendarIntegration.findFirst({
+        where: and(
+          eq(calendarIntegration.organizationId, organizationId),
+          eq(calendarIntegration.provider, 'microsoft'),
+        ),
+      })
+
+      if (existingForUser?.organizationId && existingForUser.organizationId !== organizationId) {
+        throw microsoftCalendarIntegrationConflict()
+      }
+      if (existingForOrganization && existingForOrganization.id !== existingForUser?.id) {
+        throw microsoftCalendarIntegrationConflict()
+      }
+
+      if (existingForUser) {
+        const updated = await tx.update(calendarIntegration)
+          .set(values)
+          .where(and(
+            eq(calendarIntegration.id, existingForUser.id),
+            eq(calendarIntegration.userId, userId),
+            eq(calendarIntegration.provider, 'microsoft'),
+            existingForUser.organizationId === null
+              ? isNull(calendarIntegration.organizationId)
+              : eq(calendarIntegration.organizationId, existingForUser.organizationId),
+          ))
+          .returning({ id: calendarIntegration.id })
+        if (!updated[0]) throw microsoftCalendarIntegrationConflict()
+        return
+      }
+
+      await tx.insert(calendarIntegration).values(values)
+    })
+  }
+  catch (error) {
+    if (isMicrosoftCalendarUniqueViolation(error)) {
+      throw microsoftCalendarIntegrationConflict()
+    }
+    throw error
+  }
+}
+
+function microsoftCalendarIntegrationConflict() {
+  return createError({
+    statusCode: 409,
+    statusMessage: 'Microsoft Calendar is already connected to a different organization or account',
   })
+}
+
+function isMicrosoftCalendarUniqueViolation(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  if ('code' in error && error.code === '23505') return true
+  return 'cause' in error && isMicrosoftCalendarUniqueViolation(error.cause)
 }
 
 export async function removeMicrosoftCalendarIntegration(userId: string, organizationId?: string | null): Promise<void> {

--- a/server/utils/rateLimit.ts
+++ b/server/utils/rateLimit.ts
@@ -42,6 +42,15 @@ interface RateLimitEntry {
   timestamps: number[]
 }
 
+export interface RateLimitReservation {
+  commit: () => void
+}
+
+export interface RateLimiter {
+  (event: H3Event): Promise<void>
+  reserve: (event: H3Event) => RateLimitReservation
+}
+
 const DEFAULT_MAX_TRACKED_KEYS = 10_000
 const MAX_RATE_LIMIT_KEY_LENGTH = 256
 const OVERFLOW_KEY = Symbol('rate-limit-overflow')
@@ -73,7 +82,7 @@ const OVERFLOW_KEY = Symbol('rate-limit-overflow')
  * })
  * ```
  */
-export function createRateLimiter(config: RateLimitConfig) {
+export function createRateLimiter(config: RateLimitConfig): RateLimiter {
   const {
     windowMs,
     maxRequests,
@@ -85,18 +94,30 @@ export function createRateLimiter(config: RateLimitConfig) {
     ? config.maxTrackedKeys!
     : DEFAULT_MAX_TRACKED_KEYS
   const store = new Map<string | typeof OVERFLOW_KEY, RateLimitEntry>()
+  let nextExpiryAt = Number.POSITIVE_INFINITY
+
+  function pruneExpired(now: number): void {
+    if (now < nextExpiryAt) return
+
+    let earliestRemainingExpiry = Number.POSITIVE_INFINITY
+    for (const [key, entry] of store) {
+      entry.timestamps = entry.timestamps.filter(timestamp => now - timestamp < windowMs)
+      if (entry.timestamps.length === 0) {
+        store.delete(key)
+        continue
+      }
+      earliestRemainingExpiry = Math.min(
+        earliestRemainingExpiry,
+        entry.timestamps[0]! + windowMs,
+      )
+    }
+    nextExpiryAt = earliestRemainingExpiry
+  }
 
   // Periodically prune stale entries to prevent unbounded memory growth
   const PRUNE_INTERVAL = Math.max(windowMs * 2, 60_000)
   setInterval(() => {
-    const now = Date.now()
-    for (const [key, entry] of store) {
-      // Remove entries with no timestamps within the window
-      entry.timestamps = entry.timestamps.filter((t) => now - t < windowMs)
-      if (entry.timestamps.length === 0) {
-        store.delete(key)
-      }
-    }
+    pruneExpired(Date.now())
   }, PRUNE_INTERVAL).unref() // .unref() prevents the timer from keeping the process alive
 
   /**
@@ -104,7 +125,7 @@ export function createRateLimiter(config: RateLimitConfig) {
    * Throws a 429 error if the limit is exceeded.
    * Sets standard rate limit headers on every response.
    */
-  return async function rateLimit(event: H3Event): Promise<void> {
+  function reserve(event: H3Event): RateLimitReservation {
     let resolvedKey: string | undefined
     if (keyResolver) {
       try {
@@ -117,27 +138,22 @@ export function createRateLimiter(config: RateLimitConfig) {
     const boundedKey = resolvedKey
       ? resolvedKey.slice(0, MAX_RATE_LIMIT_KEY_LENGTH)
       : getClientIp(event)
-    const key = !store.has(boundedKey) && store.size >= maxTrackedKeys
+    const now = Date.now()
+    pruneExpired(now)
+
+    const trackedKeyCount = store.size - (store.has(OVERFLOW_KEY) ? 1 : 0)
+    const key = !store.has(boundedKey) && trackedKeyCount >= maxTrackedKeys
       ? OVERFLOW_KEY
       : boundedKey
-    const now = Date.now()
-
-    let entry = store.get(key)
-    if (!entry) {
-      entry = { timestamps: [] }
-      store.set(key, entry)
-    }
-
-    // Remove timestamps outside the current window
-    entry.timestamps = entry.timestamps.filter((t) => now - t < windowMs)
+    const timestamps = store.get(key)?.timestamps ?? []
 
     // Set rate limit headers (draft RFC 7.2 / common convention)
-    const remaining = Math.max(0, maxRequests - entry.timestamps.length)
-    const resetSeconds = entry.timestamps.length > 0
-      ? Math.ceil((entry.timestamps[0]! + windowMs - now) / 1000)
+    const remaining = Math.max(0, maxRequests - timestamps.length)
+    const resetSeconds = timestamps.length > 0
+      ? Math.ceil((timestamps[0]! + windowMs - now) / 1000)
       : Math.ceil(windowMs / 1000)
 
-    const isLimited = entry.timestamps.length >= maxRequests
+    const isLimited = timestamps.length >= maxRequests
     if (headerMode === 'always' || isLimited) {
       setResponseHeaders(event, {
         'X-RateLimit-Limit': String(maxRequests),
@@ -154,9 +170,24 @@ export function createRateLimiter(config: RateLimitConfig) {
       })
     }
 
-    // Record this request
-    entry.timestamps.push(now)
+    return {
+      commit() {
+        let entry = store.get(key)
+        if (!entry) {
+          entry = { timestamps: [] }
+          store.set(key, entry)
+        }
+        entry.timestamps.push(now)
+        nextExpiryAt = Math.min(nextExpiryAt, now + windowMs)
+      },
+    }
   }
+
+  const rateLimit = (async (event: H3Event): Promise<void> => {
+    reserve(event).commit()
+  }) as RateLimiter
+  rateLimit.reserve = reserve
+  return rateLimit
 }
 
 /**

--- a/server/utils/rateLimit.ts
+++ b/server/utils/rateLimit.ts
@@ -34,6 +34,8 @@ export interface RateLimitConfig {
   keyResolver?: (event: H3Event) => string | undefined
   /** Maximum distinct resolved keys retained before new keys share an overflow bucket. */
   maxTrackedKeys?: number
+  /** Emit headers on every request (default) or only when this limiter rejects. */
+  headerMode?: 'always' | 'on-limit'
 }
 
 interface RateLimitEntry {
@@ -77,6 +79,7 @@ export function createRateLimiter(config: RateLimitConfig) {
     maxRequests,
     message = 'Too many requests, please try again later',
     keyResolver,
+    headerMode = 'always',
   } = config
   const maxTrackedKeys = Number.isInteger(config.maxTrackedKeys) && config.maxTrackedKeys! > 0
     ? config.maxTrackedKeys!
@@ -134,13 +137,16 @@ export function createRateLimiter(config: RateLimitConfig) {
       ? Math.ceil((entry.timestamps[0]! + windowMs - now) / 1000)
       : Math.ceil(windowMs / 1000)
 
-    setResponseHeaders(event, {
-      'X-RateLimit-Limit': String(maxRequests),
-      'X-RateLimit-Remaining': String(remaining),
-      'X-RateLimit-Reset': String(resetSeconds),
-    })
+    const isLimited = entry.timestamps.length >= maxRequests
+    if (headerMode === 'always' || isLimited) {
+      setResponseHeaders(event, {
+        'X-RateLimit-Limit': String(maxRequests),
+        'X-RateLimit-Remaining': String(remaining),
+        'X-RateLimit-Reset': String(resetSeconds),
+      })
+    }
 
-    if (entry.timestamps.length >= maxRequests) {
+    if (isLimited) {
       setResponseHeader(event, 'Retry-After', resetSeconds)
       throw createError({
         statusCode: 429,

--- a/server/utils/rateLimit.ts
+++ b/server/utils/rateLimit.ts
@@ -26,18 +26,27 @@ if (_replicaCount > 1) {
  * @param maxRequests - Maximum number of requests allowed within the window
  * @param message - Error message returned when the limit is exceeded
  */
-interface RateLimitConfig {
+export interface RateLimitConfig {
   windowMs: number
   maxRequests: number
   message?: string
+  /** Override the secure socket-IP key for routes with a stronger composite policy. */
+  keyResolver?: (event: H3Event) => string | undefined
+  /** Maximum distinct resolved keys retained before new keys share an overflow bucket. */
+  maxTrackedKeys?: number
 }
 
 interface RateLimitEntry {
   timestamps: number[]
 }
 
+const DEFAULT_MAX_TRACKED_KEYS = 10_000
+const MAX_RATE_LIMIT_KEY_LENGTH = 256
+const OVERFLOW_KEY = Symbol('rate-limit-overflow')
+
 /**
- * Create a reusable rate limiter scoped by client IP.
+ * Create a reusable rate limiter scoped by client IP by default, or by an
+ * explicit bounded key resolver for routes with a layered abuse policy.
  *
  * Uses a sliding window algorithm — each request records a timestamp,
  * and only timestamps within the current window are counted.
@@ -63,8 +72,16 @@ interface RateLimitEntry {
  * ```
  */
 export function createRateLimiter(config: RateLimitConfig) {
-  const { windowMs, maxRequests, message = 'Too many requests, please try again later' } = config
-  const store = new Map<string, RateLimitEntry>()
+  const {
+    windowMs,
+    maxRequests,
+    message = 'Too many requests, please try again later',
+    keyResolver,
+  } = config
+  const maxTrackedKeys = Number.isInteger(config.maxTrackedKeys) && config.maxTrackedKeys! > 0
+    ? config.maxTrackedKeys!
+    : DEFAULT_MAX_TRACKED_KEYS
+  const store = new Map<string | typeof OVERFLOW_KEY, RateLimitEntry>()
 
   // Periodically prune stale entries to prevent unbounded memory growth
   const PRUNE_INTERVAL = Math.max(windowMs * 2, 60_000)
@@ -85,13 +102,27 @@ export function createRateLimiter(config: RateLimitConfig) {
    * Sets standard rate limit headers on every response.
    */
   return async function rateLimit(event: H3Event): Promise<void> {
-    const ip = getClientIp(event)
+    let resolvedKey: string | undefined
+    if (keyResolver) {
+      try {
+        resolvedKey = keyResolver(event)?.trim()
+      }
+      catch {
+        // A route-specific resolver must never disable the secure default.
+      }
+    }
+    const boundedKey = resolvedKey
+      ? resolvedKey.slice(0, MAX_RATE_LIMIT_KEY_LENGTH)
+      : getClientIp(event)
+    const key = !store.has(boundedKey) && store.size >= maxTrackedKeys
+      ? OVERFLOW_KEY
+      : boundedKey
     const now = Date.now()
 
-    let entry = store.get(ip)
+    let entry = store.get(key)
     if (!entry) {
       entry = { timestamps: [] }
-      store.set(ip, entry)
+      store.set(key, entry)
     }
 
     // Remove timestamps outside the current window

--- a/tests/unit/analytics-proxy-node-stream.test.ts
+++ b/tests/unit/analytics-proxy-node-stream.test.ts
@@ -1,7 +1,7 @@
 import { once } from 'node:events'
 import { createServer, request as httpRequest } from 'node:http'
 import type { AddressInfo } from 'node:net'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
 import {
   AnalyticsProxyError,
   MAX_ANALYTICS_REQUEST_BYTES,
@@ -9,6 +9,126 @@ import {
 } from '../../server/utils/analyticsProxyPolicy'
 
 const openServers = new Set<ReturnType<typeof createServer>>()
+
+type RouteEvent = {
+  method: string
+  path: string
+  url: string
+  requestHeaders: Record<string, string | string[] | undefined>
+  responseStatus?: number
+  responseStatusText?: string
+  node: {
+    req: Parameters<Parameters<typeof createServer>[0]>[0]
+    res: Parameters<Parameters<typeof createServer>[0]>[1]
+  }
+}
+
+const routeFetchMock = vi.fn(async () => new Response('{}', {
+  status: 200,
+  headers: { 'content-type': 'application/json' },
+}))
+const routeTimeoutControllers: AbortController[] = []
+const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockImplementation(() => {
+  const controller = new AbortController()
+  routeTimeoutControllers.push(controller)
+  return controller.signal
+})
+vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
+vi.stubGlobal('getRouterParam', (event: RouteEvent) => event.path)
+vi.stubGlobal('getRequestURL', (event: RouteEvent) => new URL(event.url))
+vi.stubGlobal('getRequestHeaders', (event: RouteEvent) => event.requestHeaders)
+vi.stubGlobal('getRequestIP', (event: RouteEvent) => event.node.req.socket.remoteAddress)
+vi.stubGlobal('getHeader', (event: RouteEvent, name: string) => event.requestHeaders[name.toLowerCase()])
+vi.stubGlobal('setResponseHeaders', (event: RouteEvent, headers: Record<string, string | number>) => {
+  for (const [name, value] of Object.entries(headers)) event.node.res.setHeader(name, String(value))
+})
+vi.stubGlobal('setResponseHeader', (event: RouteEvent, name: string, value: string | number) => {
+  event.node.res.setHeader(name, String(value))
+})
+vi.stubGlobal('setResponseStatus', (event: RouteEvent, status: number, statusText?: string) => {
+  event.responseStatus = status
+  event.responseStatusText = statusText
+})
+vi.stubGlobal('createError', (options: { statusCode: number, statusMessage?: string, message?: string }) =>
+  Object.assign(new Error(options.message ?? options.statusMessage), options),
+)
+vi.stubGlobal('env', { TRUSTED_PROXY_IP: undefined })
+vi.stubGlobal('fetch', routeFetchMock)
+
+const { default: analyticsRouteHandler } = await import('../../server/routes/ingest/[...path]') as {
+  default: (event: RouteEvent) => Promise<Uint8Array>
+}
+
+afterAll(() => timeoutSpy.mockRestore())
+
+async function startAnalyticsRouteServer() {
+  const server = createServer(async (incoming, response) => {
+    const event: RouteEvent = {
+      method: incoming.method ?? 'GET',
+      path: incoming.url?.split('?', 1)[0]?.replace(/^\/ingest\//, '') ?? '',
+      url: `http://127.0.0.1${incoming.url ?? '/'}`,
+      requestHeaders: incoming.headers,
+      node: { req: incoming, res: response },
+    }
+    try {
+      const body = await analyticsRouteHandler(event)
+      response.statusCode = event.responseStatus ?? 200
+      if (event.responseStatusText) response.statusMessage = event.responseStatusText
+      response.end(body)
+    }
+    catch (error) {
+      response.statusCode = typeof error === 'object' && error && 'statusCode' in error
+        ? Number(error.statusCode)
+        : 500
+      response.end()
+    }
+  })
+  openServers.add(server)
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  return (server.address() as AddressInfo).port
+}
+
+async function sendRequest(options: {
+  port: number
+  method: string
+  path?: string
+  headers?: Record<string, string>
+  chunks?: Buffer[]
+}) {
+  return await new Promise<{ statusCode?: number, body: string }>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('Timed out waiting for HTTP policy response')), 2_000)
+    const clientRequest = httpRequest({
+      host: '127.0.0.1',
+      port: options.port,
+      path: options.path ?? '/ingest/e',
+      method: options.method,
+      agent: false,
+      headers: options.headers,
+    }, (response) => {
+      const chunks: Buffer[] = []
+      response.on('data', chunk => chunks.push(Buffer.from(chunk)))
+      response.on('end', () => {
+        clearTimeout(timeout)
+        resolve({
+          statusCode: response.statusCode,
+          body: Buffer.concat(chunks).toString('utf8'),
+        })
+      })
+    })
+    clientRequest.on('error', (error: NodeJS.ErrnoException) => {
+      // The server may finish an early policy response while Node is still
+      // flushing already-buffered upload bytes. Preserve that response; fail
+      // only if it never arrives or the error is unrelated.
+      if (error.code !== 'EPIPE' && error.code !== 'ECONNRESET') {
+        clearTimeout(timeout)
+        reject(error)
+      }
+    })
+    for (const chunk of options.chunks ?? []) clientRequest.write(chunk)
+    clientRequest.end()
+  })
+}
 
 afterEach(async () => {
   await Promise.all([...openServers].map(async (server) => {
@@ -39,16 +159,19 @@ describe('bounded analytics request stream', () => {
     expect(resume).toHaveBeenCalledTimes(1)
   })
 
-  it('returns HTTP 413 without resetting a chunked Node client connection', async () => {
-    let requestDestroyedAtLimit: boolean | undefined
+  it('reaches the 413 policy without destroying a chunked Node request socket', async () => {
+    let resolveObserved: ((value: { statusCode: number, destroyed: boolean }) => void) | undefined
+    const observed = new Promise<{ statusCode: number, destroyed: boolean }>((resolve) => {
+      resolveObserved = resolve
+    })
     const server = createServer(async (incoming, response) => {
       try {
         await readBoundedAnalyticsRequestBody(incoming, MAX_ANALYTICS_REQUEST_BYTES)
         response.statusCode = 204
       }
       catch (error) {
-        requestDestroyedAtLimit = incoming.destroyed
         response.statusCode = error instanceof AnalyticsProxyError ? error.statusCode : 500
+        resolveObserved?.({ statusCode: response.statusCode, destroyed: incoming.destroyed })
       }
       response.setHeader('Connection', 'close')
       response.end()
@@ -58,30 +181,101 @@ describe('bounded analytics request stream', () => {
     await once(server, 'listening')
 
     const { port } = server.address() as AddressInfo
-    const result = await new Promise<{ statusCode?: number, body: string }>((resolve, reject) => {
-      const clientRequest = httpRequest({
-        host: '127.0.0.1',
-        port,
-        method: 'POST',
-        agent: false,
-        headers: { 'transfer-encoding': 'chunked' },
-      }, (response) => {
-        const chunks: Buffer[] = []
-        response.on('data', chunk => chunks.push(Buffer.from(chunk)))
-        response.on('end', () => resolve({
-          statusCode: response.statusCode,
-          body: Buffer.concat(chunks).toString('utf8'),
-        }))
-      })
-      clientRequest.on('error', reject)
+    const clientRequest = httpRequest({
+      host: '127.0.0.1',
+      port,
+      method: 'POST',
+      agent: false,
+      headers: { 'transfer-encoding': 'chunked' },
+    })
+    clientRequest.on('error', () => undefined)
+    for (let chunk = 0; chunk < 20; chunk += 1) {
+      clientRequest.write(Buffer.alloc(64 * 1024, 1))
+    }
+    clientRequest.end()
 
-      for (let chunk = 0; chunk < 20; chunk += 1) {
-        clientRequest.write(Buffer.alloc(64 * 1024, 1))
-      }
-      clientRequest.end()
+    await expect(observed).resolves.toEqual({ statusCode: 413, destroyed: false })
+    clientRequest.destroy()
+  })
+
+  it('drains a chunked missing-length request through the real route before returning 411', async () => {
+    routeFetchMock.mockClear()
+    const port = await startAnalyticsRouteServer()
+
+    const result = await sendRequest({
+      port,
+      method: 'POST',
+      headers: { 'transfer-encoding': 'chunked' },
+      chunks: [Buffer.alloc(64 * 1024, 1)],
+    })
+
+    expect(result).toEqual({ statusCode: 411, body: '' })
+    expect(routeFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('drains a declared oversized request through the real route before returning 413', async () => {
+    routeFetchMock.mockClear()
+    const port = await startAnalyticsRouteServer()
+    const body = Buffer.alloc(MAX_ANALYTICS_REQUEST_BYTES + 1, 1)
+
+    const result = await sendRequest({
+      port,
+      method: 'POST',
+      headers: { 'content-length': String(body.byteLength) },
+      chunks: [body],
     })
 
     expect(result).toEqual({ statusCode: 413, body: '' })
-    expect(requestDestroyedAtLimit).toBe(false)
+    expect(routeFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 408 through the real route when a declared upload stalls', async () => {
+    routeFetchMock.mockClear()
+    const port = await startAnalyticsRouteServer()
+    const controllerCount = routeTimeoutControllers.length
+
+    const resultPromise = new Promise<{ statusCode?: number, body: string }>((resolve, reject) => {
+      const clientRequest = httpRequest({
+        host: '127.0.0.1',
+        port,
+        path: '/ingest/e',
+        method: 'POST',
+        agent: false,
+        headers: { 'content-length': '100' },
+      }, (response) => {
+        const chunks: Buffer[] = []
+        response.on('data', chunk => chunks.push(Buffer.from(chunk)))
+        response.on('end', () => {
+          clientRequest.destroy()
+          resolve({ statusCode: response.statusCode, body: Buffer.concat(chunks).toString('utf8') })
+        })
+      })
+      clientRequest.on('error', (error) => {
+        if ((error as NodeJS.ErrnoException).code !== 'ECONNRESET') reject(error)
+      })
+      clientRequest.write(Buffer.from([1]))
+    })
+
+    await vi.waitFor(() => expect(routeTimeoutControllers.length).toBe(controllerCount + 1))
+    routeTimeoutControllers.at(-1)!.abort()
+
+    await expect(resultPromise).resolves.toEqual({ statusCode: 408, body: '' })
+    expect(routeFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('drains an unknown-path body through the real route before returning 404', async () => {
+    routeFetchMock.mockClear()
+    const port = await startAnalyticsRouteServer()
+
+    const result = await sendRequest({
+      port,
+      path: '/ingest/api/projects',
+      method: 'POST',
+      headers: { 'content-length': '2' },
+      chunks: [Buffer.from('{}')],
+    })
+
+    expect(result).toEqual({ statusCode: 404, body: '' })
+    expect(routeFetchMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/analytics-proxy-node-stream.test.ts
+++ b/tests/unit/analytics-proxy-node-stream.test.ts
@@ -1,0 +1,87 @@
+import { once } from 'node:events'
+import { createServer, request as httpRequest } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  AnalyticsProxyError,
+  MAX_ANALYTICS_REQUEST_BYTES,
+  readBoundedAnalyticsRequestBody,
+} from '../../server/utils/analyticsProxyPolicy'
+
+const openServers = new Set<ReturnType<typeof createServer>>()
+
+afterEach(async () => {
+  await Promise.all([...openServers].map(async (server) => {
+    server.closeAllConnections()
+    await new Promise<void>(resolve => server.close(() => resolve()))
+    openServers.delete(server)
+  }))
+})
+
+describe('bounded analytics request stream', () => {
+  it('releases and drains after a non-policy iterator read error without masking the 400', async () => {
+    const releaseIterator = vi.fn(async () => ({ done: true, value: undefined }))
+    const resume = vi.fn()
+    const stream = {
+      iterator: () => ({
+        next: vi.fn(async () => { throw new Error('socket read detail') }),
+        return: releaseIterator,
+      }),
+      resume,
+      async *[Symbol.asyncIterator]() {},
+    }
+
+    await expect(readBoundedAnalyticsRequestBody(stream)).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'Unable to read analytics request body',
+    })
+    expect(releaseIterator).toHaveBeenCalledTimes(1)
+    expect(resume).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns HTTP 413 without resetting a chunked Node client connection', async () => {
+    let requestDestroyedAtLimit: boolean | undefined
+    const server = createServer(async (incoming, response) => {
+      try {
+        await readBoundedAnalyticsRequestBody(incoming, MAX_ANALYTICS_REQUEST_BYTES)
+        response.statusCode = 204
+      }
+      catch (error) {
+        requestDestroyedAtLimit = incoming.destroyed
+        response.statusCode = error instanceof AnalyticsProxyError ? error.statusCode : 500
+      }
+      response.setHeader('Connection', 'close')
+      response.end()
+    })
+    openServers.add(server)
+    server.listen(0, '127.0.0.1')
+    await once(server, 'listening')
+
+    const { port } = server.address() as AddressInfo
+    const result = await new Promise<{ statusCode?: number, body: string }>((resolve, reject) => {
+      const clientRequest = httpRequest({
+        host: '127.0.0.1',
+        port,
+        method: 'POST',
+        agent: false,
+        headers: { 'transfer-encoding': 'chunked' },
+      }, (response) => {
+        const chunks: Buffer[] = []
+        response.on('data', chunk => chunks.push(Buffer.from(chunk)))
+        response.on('end', () => resolve({
+          statusCode: response.statusCode,
+          body: Buffer.concat(chunks).toString('utf8'),
+        }))
+      })
+      clientRequest.on('error', reject)
+
+      for (let chunk = 0; chunk < 20; chunk += 1) {
+        clientRequest.write(Buffer.alloc(64 * 1024, 1))
+      }
+      clientRequest.end()
+    })
+
+    expect(result).toEqual({ statusCode: 413, body: '' })
+    expect(requestDestroyedAtLimit).toBe(false)
+  })
+})

--- a/tests/unit/analytics-proxy-policy.test.ts
+++ b/tests/unit/analytics-proxy-policy.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it, vi } from 'vitest'
+
+type PolicyModule = typeof import('../../server/utils/analyticsProxyPolicy')
+
+async function loadPolicy(): Promise<PolicyModule | null> {
+  return import('../../server/utils/analyticsProxyPolicy').catch(() => null)
+}
+
+describe('analytics proxy policy', () => {
+  it('allowlists the deployed PostHog browser SDK route families and methods', async () => {
+    const policy = await loadPolicy()
+
+    expect([
+      policy?.classifyAnalyticsProxyRequest('e', 'POST'),
+      policy?.classifyAnalyticsProxyRequest('e/', 'POST'),
+      policy?.classifyAnalyticsProxyRequest('flags', 'POST'),
+      policy?.classifyAnalyticsProxyRequest('flags/', 'POST'),
+      policy?.classifyAnalyticsProxyRequest('static/1.390.0/exception-autocapture.js', 'GET'),
+      policy?.classifyAnalyticsProxyRequest('static/exception-autocapture.js', 'HEAD'),
+      policy?.classifyAnalyticsProxyRequest('array/phc_project/config', 'GET'),
+      policy?.classifyAnalyticsProxyRequest('array/phc_project/config.js', 'HEAD'),
+    ]).toEqual([
+      expect.objectContaining({ family: 'capture', upstreamOrigin: 'https://eu.i.posthog.com', rateLimitBucket: 'ingestion' }),
+      expect.objectContaining({ family: 'capture', upstreamOrigin: 'https://eu.i.posthog.com', rateLimitBucket: 'ingestion' }),
+      expect.objectContaining({ family: 'flags', upstreamOrigin: 'https://eu.i.posthog.com', rateLimitBucket: 'ingestion' }),
+      expect.objectContaining({ family: 'flags', upstreamOrigin: 'https://eu.i.posthog.com', rateLimitBucket: 'ingestion' }),
+      expect.objectContaining({ family: 'static', upstreamOrigin: 'https://eu-assets.i.posthog.com', rateLimitBucket: 'assets' }),
+      expect.objectContaining({ family: 'static', upstreamOrigin: 'https://eu-assets.i.posthog.com', rateLimitBucket: 'assets' }),
+      expect.objectContaining({ family: 'array-config', upstreamOrigin: 'https://eu-assets.i.posthog.com', rateLimitBucket: 'assets' }),
+      expect.objectContaining({ family: 'array-config', upstreamOrigin: 'https://eu-assets.i.posthog.com', rateLimitBucket: 'assets' }),
+    ])
+  })
+
+  it('rejects unknown paths, unsupported methods, empty assets, and traversal', async () => {
+    const policy = await loadPolicy()
+
+    const attempts = [
+      ['decide', 'POST'],
+      ['api/surveys', 'GET'],
+      ['e', 'GET'],
+      ['flags', 'HEAD'],
+      ['static/app.js', 'POST'],
+      ['array/phc_project/config', 'POST'],
+      ['static/', 'GET'],
+      ['static/../api/surveys', 'GET'],
+      ['static/%2e%2e/api/surveys', 'GET'],
+      ['static/app%2Fsecret.js', 'GET'],
+      ['static/app\\secret.js', 'GET'],
+      ['array/../config', 'GET'],
+      ['array/phc_project%2Fother/config', 'GET'],
+      ['array/phc_project/other', 'GET'],
+    ] as const
+
+    for (const [path, method] of attempts) {
+      expect(() => policy?.classifyAnalyticsProxyRequest(path, method)).toThrow()
+    }
+  })
+
+  it('preserves repeated query parameters without lossy casting', async () => {
+    const policy = await loadPolicy()
+    const query = new URLSearchParams()
+    query.append('ip', 'one')
+    query.append('ip', 'two')
+    query.append('v', '2')
+
+    const target = policy?.buildAnalyticsProxyTarget(
+      policy.classifyAnalyticsProxyRequest('flags/', 'POST'),
+      query,
+    )
+
+    expect(target).toBe('https://eu.i.posthog.com/flags/?ip=one&ip=two&v=2')
+  })
+
+  it('forwards only the minimal safe request headers', async () => {
+    const policy = await loadPolicy()
+    const headers = policy?.filterAnalyticsProxyRequestHeaders({
+      accept: 'application/json',
+      'accept-language': 'en-US',
+      'content-type': 'application/json',
+      origin: 'https://careers.thefactoryhq.com',
+      referer: 'https://careers.thefactoryhq.com/dashboard',
+      'user-agent': 'browser',
+      cookie: 'session=secret',
+      authorization: 'Bearer secret',
+      'cf-connecting-ip': '203.0.113.7',
+      'x-forwarded-for': '203.0.113.7',
+      host: 'careers.thefactoryhq.com',
+    })
+
+    expect(Object.fromEntries(headers?.entries() ?? [])).toEqual({
+      accept: 'application/json',
+      'accept-language': 'en-US',
+      'content-type': 'application/json',
+      origin: 'https://careers.thefactoryhq.com',
+      referer: 'https://careers.thefactoryhq.com/dashboard',
+      'user-agent': 'browser',
+    })
+  })
+})
+
+describe('analytics proxy execution', () => {
+  async function setup() {
+    const policy = await loadPolicy()
+    expect(policy).not.toBeNull()
+    return policy!
+  }
+
+  function makeRequest(overrides: Record<string, unknown> = {}) {
+    return {
+      path: 'e',
+      method: 'POST',
+      query: new URLSearchParams(),
+      headers: { 'content-length': '2', 'content-type': 'application/json' },
+      readBody: vi.fn(async () => new Uint8Array([123, 125])),
+      ...overrides,
+    }
+  }
+
+  function makeDependencies(response = new Response('{}', {
+    status: 200,
+    headers: { 'content-type': 'application/json', 'content-length': '2' },
+  })) {
+    return {
+      fetch: vi.fn(async () => response),
+      enforceRateLimit: vi.fn(async () => undefined),
+    }
+  }
+
+  it.each([
+    [undefined, 411],
+    ['', 411],
+    ['wat', 411],
+    ['-1', 411],
+    ['1.5', 411],
+    [String(1024 * 1024 + 1), 413],
+  ])('rejects POST Content-Length %j before reading or fetching', async (contentLength, statusCode) => {
+    const policy = await setup()
+    const request = makeRequest({
+      headers: contentLength === undefined ? {} : { 'content-length': contentLength },
+    })
+    const dependencies = makeDependencies()
+
+    await expect(policy.executeAnalyticsProxyRequest(request, dependencies)).rejects.toMatchObject({ statusCode })
+    expect(request.readBody).not.toHaveBeenCalled()
+    expect(dependencies.fetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects an actual body over 1 MiB even when the declared length lies', async () => {
+    const policy = await setup()
+    const request = makeRequest({
+      headers: { 'content-length': '1' },
+      readBody: vi.fn(async () => new Uint8Array(1024 * 1024 + 1)),
+    })
+    const dependencies = makeDependencies()
+
+    await expect(policy.executeAnalyticsProxyRequest(request, dependencies)).rejects.toMatchObject({ statusCode: 413 })
+    expect(dependencies.fetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects a declared and actual body length mismatch', async () => {
+    const policy = await setup()
+    const dependencies = makeDependencies()
+
+    await expect(policy.executeAnalyticsProxyRequest(makeRequest({
+      headers: { 'content-length': '1' },
+    }), dependencies)).rejects.toMatchObject({ statusCode: 400 })
+    expect(dependencies.fetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown paths and unsupported methods without rate limiting, body reads, or upstream fetches', async () => {
+    const policy = await setup()
+    const dependencies = makeDependencies()
+    const unknown = makeRequest({ path: 'api/projects', method: 'POST' })
+    const wrongMethod = makeRequest({ path: 'e', method: 'GET', headers: {} })
+
+    await expect(policy.executeAnalyticsProxyRequest(unknown, dependencies)).rejects.toMatchObject({ statusCode: 404 })
+    await expect(policy.executeAnalyticsProxyRequest(wrongMethod, dependencies)).rejects.toMatchObject({ statusCode: 405 })
+    expect(dependencies.enforceRateLimit).not.toHaveBeenCalled()
+    expect(unknown.readBody).not.toHaveBeenCalled()
+    expect(wrongMethod.readBody).not.toHaveBeenCalled()
+    expect(dependencies.fetch).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['e', 'POST', 'ingestion'],
+    ['flags/', 'POST', 'ingestion'],
+    ['static/exception-autocapture.js', 'GET', 'assets'],
+    ['static/1.390.0/exception-autocapture.js', 'HEAD', 'assets'],
+    ['array/phc_project/config', 'GET', 'assets'],
+    ['array/phc_project/config.js', 'HEAD', 'assets'],
+  ])('selects the %s %s rate bucket before fetching', async (path, method, rateLimitBucket) => {
+    const policy = await setup()
+    const dependencies = makeDependencies()
+    const request = makeRequest({
+      path,
+      method,
+      headers: method === 'POST' ? { 'content-length': '2' } : {},
+    })
+
+    await policy.executeAnalyticsProxyRequest(request, dependencies)
+
+    expect(dependencies.enforceRateLimit).toHaveBeenCalledWith(rateLimitBucket)
+    expect(dependencies.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the fixed assets host, preserves query arrays, strips sensitive headers, and disables redirect following', async () => {
+    const policy = await setup()
+    const dependencies = makeDependencies()
+    const query = new URLSearchParams([['v', '1'], ['v', '2']])
+
+    await policy.executeAnalyticsProxyRequest(makeRequest({
+      path: 'array/phc_project/config.js',
+      method: 'GET',
+      query,
+      headers: {
+        accept: 'application/javascript',
+        authorization: 'secret',
+        cookie: 'secret',
+        'x-forwarded-for': '203.0.113.1',
+      },
+    }), dependencies)
+
+    const [target, init] = dependencies.fetch.mock.calls[0]!
+    expect(target).toBe('https://eu-assets.i.posthog.com/array/phc_project/config.js?v=1&v=2')
+    expect(init).toMatchObject({ method: 'GET', redirect: 'manual' })
+    expect(Object.fromEntries((init!.headers as Headers).entries())).toEqual({ accept: 'application/javascript' })
+  })
+
+  it('returns a generic 502 when the upstream fetch fails', async () => {
+    const policy = await setup()
+    const dependencies = makeDependencies()
+    dependencies.fetch.mockRejectedValueOnce(new Error('upstream token or DNS detail'))
+
+    await expect(policy.executeAnalyticsProxyRequest(makeRequest(), dependencies)).rejects.toMatchObject({
+      statusCode: 502,
+      statusMessage: 'Bad Gateway',
+      message: 'Analytics upstream request failed',
+    })
+  })
+
+  it('does not relay an upstream redirect or its Location header', async () => {
+    const policy = await setup()
+    const dependencies = makeDependencies(new Response('moved', {
+      status: 302,
+      headers: { location: 'https://unexpected.example/private' },
+    }))
+
+    await expect(policy.executeAnalyticsProxyRequest(makeRequest(), dependencies)).rejects.toMatchObject({
+      statusCode: 502,
+      statusMessage: 'Bad Gateway',
+      message: 'Analytics upstream returned an unexpected redirect',
+    })
+  })
+
+  it('rejects an upstream Content-Length over 2 MiB before reading the stream', async () => {
+    const policy = await setup()
+    const cancel = vi.fn(async () => undefined)
+    const response = {
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-length': String(2 * 1024 * 1024 + 1) }),
+      body: { cancel },
+    } as unknown as Response
+    const dependencies = makeDependencies(response)
+
+    await expect(policy.executeAnalyticsProxyRequest(makeRequest(), dependencies)).rejects.toMatchObject({ statusCode: 502 })
+    expect(cancel).toHaveBeenCalled()
+  })
+
+  it('cancels and rejects a streamed upstream response once it crosses 2 MiB', async () => {
+    const policy = await setup()
+    const cancel = vi.fn(async () => undefined)
+    const read = vi.fn()
+      .mockResolvedValueOnce({ done: false, value: new Uint8Array(2 * 1024 * 1024) })
+      .mockResolvedValueOnce({ done: false, value: new Uint8Array([1]) })
+    const response = {
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      body: { getReader: () => ({ read, cancel }) },
+    } as unknown as Response
+    const dependencies = makeDependencies(response)
+
+    await expect(policy.executeAnalyticsProxyRequest(makeRequest(), dependencies)).rejects.toMatchObject({ statusCode: 502 })
+    expect(cancel).toHaveBeenCalled()
+  })
+
+  it('returns a bounded body and only safe upstream response headers', async () => {
+    const policy = await setup()
+    const response = new Response('ok', {
+      status: 202,
+      statusText: 'Accepted',
+      headers: {
+        'content-type': 'application/json',
+        'cache-control': 'no-store',
+        'set-cookie': 'upstream=secret',
+        location: 'https://attacker.example',
+        'x-upstream-secret': 'secret',
+      },
+    })
+
+    const result = await policy.executeAnalyticsProxyRequest(makeRequest(), makeDependencies(response))
+
+    expect(result).toMatchObject({ status: 202, statusText: 'Accepted' })
+    expect(new TextDecoder().decode(result.body)).toBe('ok')
+    expect(Object.fromEntries(result.headers.entries())).toEqual({
+      'cache-control': 'no-store',
+      'content-type': 'application/json',
+    })
+  })
+})

--- a/tests/unit/analytics-proxy-policy.test.ts
+++ b/tests/unit/analytics-proxy-policy.test.ts
@@ -78,7 +78,7 @@ describe('analytics proxy policy', () => {
       'accept-language': 'en-US',
       'content-type': 'application/json',
       origin: 'https://careers.thefactoryhq.com',
-      referer: 'https://careers.thefactoryhq.com/dashboard',
+      referer: 'https://careers.thefactoryhq.com/dashboard/candidates/candidate-secret?token=private',
       'user-agent': 'browser',
       cookie: 'session=secret',
       authorization: 'Bearer secret',
@@ -92,9 +92,19 @@ describe('analytics proxy policy', () => {
       'accept-language': 'en-US',
       'content-type': 'application/json',
       origin: 'https://careers.thefactoryhq.com',
-      referer: 'https://careers.thefactoryhq.com/dashboard',
       'user-agent': 'browser',
     })
+  })
+
+  it('never forwards same-origin dashboard paths or query secrets through Referer', async () => {
+    const policy = await loadPolicy()
+    const headers = policy?.filterAnalyticsProxyRequestHeaders({
+      origin: 'https://careers.thefactoryhq.com',
+      referer: 'https://careers.thefactoryhq.com/dashboard/applications/application-id?token=secret#candidate-id',
+    })
+
+    expect(headers?.get('origin')).toBe('https://careers.thefactoryhq.com')
+    expect(headers?.has('referer')).toBe(false)
   })
 })
 
@@ -112,6 +122,7 @@ describe('analytics proxy execution', () => {
       query: new URLSearchParams(),
       headers: { 'content-length': '2', 'content-type': 'application/json' },
       readBody: vi.fn(async () => new Uint8Array([123, 125])),
+      drainBody: vi.fn(),
       ...overrides,
     }
   }
@@ -132,7 +143,6 @@ describe('analytics proxy execution', () => {
     ['wat', 411],
     ['-1', 411],
     ['1.5', 411],
-    [String(1024 * 1024 + 1), 413],
   ])('rejects POST Content-Length %j before reading or fetching', async (contentLength, statusCode) => {
     const policy = await setup()
     const request = makeRequest({
@@ -143,6 +153,49 @@ describe('analytics proxy execution', () => {
     await expect(policy.executeAnalyticsProxyRequest(request, dependencies)).rejects.toMatchObject({ statusCode })
     expect(dependencies.enforceRateLimit).toHaveBeenCalledWith('ingestion')
     expect(request.readBody).not.toHaveBeenCalled()
+    expect(request.drainBody).toHaveBeenCalledTimes(1)
+    expect(dependencies.fetch).not.toHaveBeenCalled()
+  })
+
+  it('bounded-reads a declared oversized POST before returning 413', async () => {
+    const policy = await setup()
+    const request = makeRequest({
+      headers: { 'content-length': String(1024 * 1024 + 1) },
+    })
+    const dependencies = makeDependencies()
+
+    await expect(policy.executeAnalyticsProxyRequest(request, dependencies))
+      .rejects.toMatchObject({ statusCode: 413 })
+    expect(request.readBody).toHaveBeenCalledTimes(1)
+    expect(dependencies.fetch).not.toHaveBeenCalled()
+  })
+
+  it.each(['GET', 'HEAD'])('drains and rejects a body on an allowed %s asset request', async (method) => {
+    const policy = await setup()
+    const request = makeRequest({
+      path: 'static/exception-autocapture.js',
+      method,
+      headers: { 'content-length': '2' },
+    })
+    const dependencies = makeDependencies()
+
+    await expect(policy.executeAnalyticsProxyRequest(request, dependencies)).rejects.toMatchObject({ statusCode: 400 })
+    expect(request.drainBody).toHaveBeenCalledTimes(1)
+    expect(request.readBody).not.toHaveBeenCalled()
+    expect(dependencies.fetch).not.toHaveBeenCalled()
+  })
+
+  it('drains and returns 413 for a declared oversized asset request body', async () => {
+    const policy = await setup()
+    const request = makeRequest({
+      path: 'array/phc_project/config.js',
+      method: 'GET',
+      headers: { 'content-length': String(1024 * 1024 + 1) },
+    })
+    const dependencies = makeDependencies()
+
+    await expect(policy.executeAnalyticsProxyRequest(request, dependencies)).rejects.toMatchObject({ statusCode: 413 })
+    expect(request.drainBody).toHaveBeenCalledTimes(1)
     expect(dependencies.fetch).not.toHaveBeenCalled()
   })
 
@@ -155,6 +208,29 @@ describe('analytics proxy execution', () => {
     const dependencies = makeDependencies()
 
     await expect(policy.executeAnalyticsProxyRequest(request, dependencies)).rejects.toMatchObject({ statusCode: 413 })
+    expect(dependencies.fetch).not.toHaveBeenCalled()
+  })
+
+  it('times out and drains an inbound body that never finishes', async () => {
+    const policy = await setup()
+    const timeout = new AbortController()
+    const request = makeRequest({
+      readBody: vi.fn(async () => await new Promise<Uint8Array>(() => {})),
+    })
+    const dependencies = makeDependencies()
+
+    const execution = policy.executeAnalyticsProxyRequest(request, {
+      ...dependencies,
+      timeoutSignal: timeout.signal,
+    })
+    timeout.abort(new Error('private client detail'))
+
+    await expect(execution).rejects.toMatchObject({
+      statusCode: 408,
+      statusMessage: 'Request Timeout',
+      message: 'Analytics request body timed out',
+    })
+    expect(request.drainBody).toHaveBeenCalledTimes(1)
     expect(dependencies.fetch).not.toHaveBeenCalled()
   })
 
@@ -179,6 +255,8 @@ describe('analytics proxy execution', () => {
     expect(dependencies.enforceRateLimit).not.toHaveBeenCalled()
     expect(unknown.readBody).not.toHaveBeenCalled()
     expect(wrongMethod.readBody).not.toHaveBeenCalled()
+    expect(unknown.drainBody).toHaveBeenCalledTimes(1)
+    expect(wrongMethod.drainBody).toHaveBeenCalledTimes(1)
     expect(dependencies.fetch).not.toHaveBeenCalled()
   })
 
@@ -237,6 +315,54 @@ describe('analytics proxy execution', () => {
       statusMessage: 'Bad Gateway',
       message: 'Analytics upstream request failed',
     })
+  })
+
+  it('times out a fetch that never returns headers without leaking upstream details', async () => {
+    const policy = await setup()
+    const timeout = new AbortController()
+    const dependencies = makeDependencies()
+    dependencies.fetch.mockImplementationOnce(async () => await new Promise<Response>(() => {}))
+
+    const execution = policy.executeAnalyticsProxyRequest(makeRequest(), {
+      ...dependencies,
+      timeoutSignal: timeout.signal,
+    })
+    await vi.waitFor(() => expect(dependencies.fetch).toHaveBeenCalledTimes(1))
+    timeout.abort(new Error('private upstream timeout detail'))
+
+    await expect(execution).rejects.toMatchObject({
+      statusCode: 502,
+      statusMessage: 'Bad Gateway',
+      message: 'Analytics upstream request timed out',
+    })
+  })
+
+  it('times out and cancels an upstream body that stalls after headers', async () => {
+    const policy = await setup()
+    const timeout = new AbortController()
+    const cancel = vi.fn(async () => undefined)
+    const read = vi.fn()
+      .mockResolvedValueOnce({ done: false, value: new Uint8Array([1]) })
+      .mockImplementationOnce(async () => await new Promise(() => {}))
+    const response = {
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers(),
+      body: { getReader: () => ({ read, cancel }) },
+    } as unknown as Response
+    const execution = policy.executeAnalyticsProxyRequest(makeRequest(), {
+      ...makeDependencies(response),
+      timeoutSignal: timeout.signal,
+    })
+
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(2))
+    timeout.abort(new Error('private body timeout detail'))
+
+    await expect(execution).rejects.toMatchObject({
+      statusCode: 502,
+      message: 'Analytics upstream response timed out',
+    })
+    expect(cancel).toHaveBeenCalledTimes(1)
   })
 
   it('does not relay an upstream redirect or its Location header', async () => {

--- a/tests/unit/analytics-proxy-policy.test.ts
+++ b/tests/unit/analytics-proxy-policy.test.ts
@@ -141,6 +141,7 @@ describe('analytics proxy execution', () => {
     const dependencies = makeDependencies()
 
     await expect(policy.executeAnalyticsProxyRequest(request, dependencies)).rejects.toMatchObject({ statusCode })
+    expect(dependencies.enforceRateLimit).toHaveBeenCalledWith('ingestion')
     expect(request.readBody).not.toHaveBeenCalled()
     expect(dependencies.fetch).not.toHaveBeenCalled()
   })

--- a/tests/unit/analytics-proxy-rate-limit.test.ts
+++ b/tests/unit/analytics-proxy-rate-limit.test.ts
@@ -34,13 +34,14 @@ function makeEvent(clientIp: string, socketIp = '10.0.0.5', headerName = 'cf-con
 }
 
 async function setup(options: {
+  windowMs?: number
   ingestionPerClient?: number
   ingestionGlobal?: number
   assetsPerClient?: number
   assetsGlobal?: number
 } = {}) {
   return createAnalyticsProxyRateLimitGuard({
-    windowMs: 60_000,
+    windowMs: options.windowMs ?? 60_000,
     ingestionPerClient: options.ingestionPerClient ?? 1,
     ingestionGlobal: options.ingestionGlobal ?? 100,
     assetsPerClient: options.assetsPerClient ?? 1,
@@ -89,6 +90,30 @@ describe('analytics proxy rate limits', () => {
     await expect(guard(makeEvent('203.0.113.2'), 'ingestion')).resolves.toBeUndefined()
     await expect(guard(makeEvent('203.0.113.3'), 'ingestion')).resolves.toBeUndefined()
     await expect(guard(makeEvent('203.0.113.4'), 'ingestion')).rejects.toMatchObject({ statusCode: 429 })
+  })
+
+  it('does not spend client allowance on a request rejected by the global budget', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-07-16T12:00:00.000Z'))
+      const guard = await setup({
+        windowMs: 1_000,
+        ingestionPerClient: 1,
+        ingestionGlobal: 1,
+      })
+      const firstClient = makeEvent('203.0.113.1')
+      const globallyRejectedClient = makeEvent('203.0.113.2')
+
+      await expect(guard(firstClient, 'ingestion')).resolves.toBeUndefined()
+      vi.setSystemTime(new Date('2026-07-16T12:00:00.500Z'))
+      await expect(guard(globallyRejectedClient, 'ingestion')).rejects.toMatchObject({ statusCode: 429 })
+
+      vi.setSystemTime(new Date('2026-07-16T12:00:01.001Z'))
+      await expect(guard(globallyRejectedClient, 'ingestion')).resolves.toBeUndefined()
+    }
+    finally {
+      vi.useRealTimers()
+    }
   })
 
   it('keeps ingestion and asset global backstops independent', async () => {

--- a/tests/unit/analytics-proxy-rate-limit.test.ts
+++ b/tests/unit/analytics-proxy-rate-limit.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { H3Event, EventHandlerRequest } from 'h3'
+
+interface FakeEvent {
+  socketIp: string
+  headers: Record<string, string>
+  responseHeaders: Record<string, string>
+}
+
+vi.stubGlobal('env', { TRUSTED_PROXY_IP: undefined })
+vi.stubGlobal('getRequestIP', (event: FakeEvent) => event.socketIp)
+vi.stubGlobal('getHeader', (event: FakeEvent, name: string) => event.headers[name.toLowerCase()])
+vi.stubGlobal('setResponseHeaders', (event: FakeEvent, headers: Record<string, string | number>) => {
+  for (const [name, value] of Object.entries(headers)) event.responseHeaders[name] = String(value)
+})
+vi.stubGlobal('setResponseHeader', (event: FakeEvent, name: string, value: string | number) => {
+  event.responseHeaders[name] = String(value)
+})
+vi.stubGlobal('createError', (options: { statusCode: number, statusMessage?: string }) =>
+  Object.assign(new Error(options.statusMessage), options),
+)
+
+const {
+  buildAnalyticsClientRateLimitKey,
+  createAnalyticsProxyRateLimitGuard,
+} = await import('../../server/utils/analyticsProxyRateLimit')
+
+function makeEvent(clientIp: string, socketIp = '10.0.0.5', headerName = 'cf-connecting-ip') {
+  return {
+    socketIp,
+    headers: { [headerName]: clientIp },
+    responseHeaders: {},
+  } as unknown as FakeEvent & H3Event<EventHandlerRequest>
+}
+
+async function setup(options: {
+  ingestionPerClient?: number
+  ingestionGlobal?: number
+  assetsPerClient?: number
+  assetsGlobal?: number
+} = {}) {
+  return createAnalyticsProxyRateLimitGuard({
+    windowMs: 60_000,
+    ingestionPerClient: options.ingestionPerClient ?? 1,
+    ingestionGlobal: options.ingestionGlobal ?? 100,
+    assetsPerClient: options.assetsPerClient ?? 1,
+    assetsGlobal: options.assetsGlobal ?? 100,
+  })
+}
+
+describe('analytics proxy rate limits', () => {
+  it('separates honest Cloudflare clients sharing one Render socket', async () => {
+    const guard = await setup()
+    const a = makeEvent('203.0.113.1')
+    const b = makeEvent('203.0.113.2')
+
+    await expect(guard(a, 'ingestion')).resolves.toBeUndefined()
+    await expect(guard(b, 'ingestion')).resolves.toBeUndefined()
+    await expect(guard(a, 'ingestion')).rejects.toMatchObject({ statusCode: 429 })
+    await expect(guard(b, 'ingestion')).rejects.toMatchObject({ statusCode: 429 })
+  })
+
+  it('uses the first forwarded client when Cloudflare does not provide a hint', async () => {
+    const guard = await setup()
+    const a = makeEvent('203.0.113.10, 10.0.0.1', '10.0.0.5', 'x-forwarded-for')
+    const b = makeEvent('203.0.113.11, 10.0.0.1', '10.0.0.5', 'x-forwarded-for')
+
+    await expect(guard(a, 'assets')).resolves.toBeUndefined()
+    await expect(guard(b, 'assets')).resolves.toBeUndefined()
+  })
+
+  it('bounds spoofed client hints with a higher global family cap', async () => {
+    const guard = await setup({ ingestionPerClient: 10, ingestionGlobal: 2 })
+
+    await expect(guard(makeEvent('203.0.113.1'), 'ingestion')).resolves.toBeUndefined()
+    await expect(guard(makeEvent('203.0.113.2'), 'ingestion')).resolves.toBeUndefined()
+    await expect(guard(makeEvent('203.0.113.3'), 'ingestion')).rejects.toMatchObject({ statusCode: 429 })
+  })
+
+  it('keeps ingestion and asset global backstops independent', async () => {
+    const guard = await setup({
+      ingestionPerClient: 10,
+      ingestionGlobal: 1,
+      assetsPerClient: 10,
+      assetsGlobal: 1,
+    })
+
+    await expect(guard(makeEvent('203.0.113.1'), 'ingestion')).resolves.toBeUndefined()
+    await expect(guard(makeEvent('203.0.113.1'), 'assets')).resolves.toBeUndefined()
+    await expect(guard(makeEvent('203.0.113.2'), 'ingestion')).rejects.toMatchObject({ statusCode: 429 })
+    await expect(guard(makeEvent('203.0.113.2'), 'assets')).rejects.toMatchObject({ statusCode: 429 })
+  })
+
+  it('rejects invalid or oversized client hints instead of expanding the key space', async () => {
+    expect(buildAnalyticsClientRateLimitKey({
+      socketIp: '10.0.0.5',
+      cfConnectingIp: 'not-an-ip',
+      forwardedFor: `${'1'.repeat(600)}, 203.0.113.7`,
+    })).toBe('socket:10.0.0.5|client:unknown')
+  })
+})

--- a/tests/unit/analytics-proxy-rate-limit.test.ts
+++ b/tests/unit/analytics-proxy-rate-limit.test.ts
@@ -77,6 +77,20 @@ describe('analytics proxy rate limits', () => {
     await expect(guard(makeEvent('203.0.113.3'), 'ingestion')).rejects.toMatchObject({ statusCode: 429 })
   })
 
+  it('does not spend global allowance on requests already rejected by one client budget', async () => {
+    const guard = await setup({ ingestionPerClient: 1, ingestionGlobal: 3 })
+    const noisyClient = makeEvent('203.0.113.1')
+
+    await expect(guard(noisyClient, 'ingestion')).resolves.toBeUndefined()
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await expect(guard(noisyClient, 'ingestion')).rejects.toMatchObject({ statusCode: 429 })
+    }
+
+    await expect(guard(makeEvent('203.0.113.2'), 'ingestion')).resolves.toBeUndefined()
+    await expect(guard(makeEvent('203.0.113.3'), 'ingestion')).resolves.toBeUndefined()
+    await expect(guard(makeEvent('203.0.113.4'), 'ingestion')).rejects.toMatchObject({ statusCode: 429 })
+  })
+
   it('keeps ingestion and asset global backstops independent', async () => {
     const guard = await setup({
       ingestionPerClient: 10,

--- a/tests/unit/analytics-proxy-route.test.ts
+++ b/tests/unit/analytics-proxy-route.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface FakeEvent {
+  method: string
+  path: string
+  url: string
+  requestHeaders: Record<string, string>
+  responseHeaders: Record<string, string>
+  responseStatus?: number
+  responseStatusText?: string
+  node: {
+    req: FakeRequestStream
+  }
+}
+
+interface FakeRequestStream extends AsyncIterable<Uint8Array> {
+  destroy: ReturnType<typeof vi.fn>
+  consumedChunks: number
+}
+
+function makeRequestStream(chunks: Uint8Array[]): FakeRequestStream {
+  const stream: FakeRequestStream = {
+    destroy: vi.fn(),
+    consumedChunks: 0,
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) {
+        stream.consumedChunks += 1
+        yield chunk
+      }
+    },
+  }
+  return stream
+}
+
+const fetchMock = vi.fn()
+
+vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
+vi.stubGlobal('getRouterParam', (event: FakeEvent) => event.path)
+vi.stubGlobal('getRequestURL', (event: FakeEvent) => new URL(event.url))
+vi.stubGlobal('getRequestHeaders', (event: FakeEvent) => event.requestHeaders)
+vi.stubGlobal('getRequestIP', () => '198.51.100.10')
+vi.stubGlobal('getHeader', (event: FakeEvent, name: string) => event.requestHeaders[name.toLowerCase()])
+vi.stubGlobal('setResponseHeaders', (event: FakeEvent, headers: Record<string, string | number>) => {
+  for (const [name, value] of Object.entries(headers)) event.responseHeaders[name] = String(value)
+})
+vi.stubGlobal('setResponseHeader', (event: FakeEvent, name: string, value: string | number) => {
+  event.responseHeaders[name] = String(value)
+})
+vi.stubGlobal('setResponseStatus', (event: FakeEvent, status: number, statusText?: string) => {
+  event.responseStatus = status
+  event.responseStatusText = statusText
+})
+vi.stubGlobal('createError', (options: { statusCode: number, statusMessage?: string, message?: string }) =>
+  Object.assign(new Error(options.message ?? options.statusMessage), options),
+)
+vi.stubGlobal('env', { TRUSTED_PROXY_IP: undefined })
+vi.stubGlobal('fetch', fetchMock)
+
+const { default: handler } = await import('../../server/routes/ingest/[...path]') as {
+  default: (event: FakeEvent) => Promise<Uint8Array>
+}
+
+function makeEvent(overrides: Partial<FakeEvent> = {}): FakeEvent {
+  return {
+    method: 'POST',
+    path: 'e',
+    url: 'https://careers.thefactoryhq.com/ingest/e',
+    requestHeaders: {
+      'content-length': '2',
+      'content-type': 'application/json',
+    },
+    responseHeaders: {},
+    node: { req: makeRequestStream([new Uint8Array([123, 125])]) },
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValue(new Response('{}', {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  }))
+})
+
+describe('PostHog ingest route adapter', () => {
+  it('rejects an unknown path without calling upstream', async () => {
+    const event = makeEvent({ path: 'api/projects', url: 'https://careers.thefactoryhq.com/ingest/api/projects' })
+
+    await expect(handler(event)).rejects.toMatchObject({ statusCode: 404 })
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(event.node.req.consumedChunks).toBe(0)
+  })
+
+  it('rejects a capture request without Content-Length before calling upstream', async () => {
+    const event = makeEvent({ requestHeaders: {} })
+
+    await expect(handler(event)).rejects.toMatchObject({ statusCode: 411 })
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(event.node.req.consumedChunks).toBe(0)
+  })
+
+  it('destroys a chunked request stream as soon as its actual body crosses 1 MiB', async () => {
+    const requestStream = makeRequestStream([
+      new Uint8Array(700 * 1024),
+      new Uint8Array(400 * 1024),
+      new Uint8Array(10),
+    ])
+    const event = makeEvent({
+      requestHeaders: { 'content-length': '1' },
+      node: { req: requestStream },
+    })
+
+    await expect(handler(event)).rejects.toMatchObject({ statusCode: 413 })
+    expect(requestStream.destroy).toHaveBeenCalledTimes(1)
+    expect(requestStream.consumedChunks).toBe(2)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('adapts a capture request with repeated query values and the ingestion limiter', async () => {
+    const event = makeEvent({
+      url: 'https://careers.thefactoryhq.com/ingest/e?ip=one&ip=two',
+      requestHeaders: {
+        'content-length': '2',
+        'content-type': 'application/json',
+        cookie: 'session=secret',
+        authorization: 'Bearer secret',
+        'cf-ray': 'secret',
+        'x-forwarded-for': '203.0.113.7',
+      },
+    })
+
+    const body = await handler(event)
+
+    const [target, init] = fetchMock.mock.calls[0]!
+    expect(target).toBe('https://eu.i.posthog.com/e?ip=one&ip=two')
+    expect(init).toMatchObject({ method: 'POST', redirect: 'manual' })
+    expect(Object.fromEntries((init.headers as Headers).entries())).toEqual({ 'content-type': 'application/json' })
+    expect(event.responseHeaders['X-RateLimit-Limit']).toBe('120')
+    expect(event.responseStatus).toBe(200)
+    expect(event.responseHeaders['content-type']).toBe('application/json')
+    expect(new TextDecoder().decode(body)).toBe('{}')
+  })
+
+  it('routes static HEAD requests through the assets host and higher asset limiter without reading a body', async () => {
+    const event = makeEvent({
+      method: 'HEAD',
+      path: 'static/1.390.0/exception-autocapture.js',
+      url: 'https://careers.thefactoryhq.com/ingest/static/1.390.0/exception-autocapture.js?v=1',
+      requestHeaders: { accept: 'application/javascript' },
+    })
+
+    await handler(event)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://eu-assets.i.posthog.com/static/1.390.0/exception-autocapture.js?v=1',
+      expect.objectContaining({ method: 'HEAD', redirect: 'manual' }),
+    )
+    expect(event.responseHeaders['X-RateLimit-Limit']).toBe('600')
+    expect(event.node.req.consumedChunks).toBe(0)
+  })
+})

--- a/tests/unit/analytics-proxy-route.test.ts
+++ b/tests/unit/analytics-proxy-route.test.ts
@@ -16,20 +16,29 @@ interface FakeEvent {
 
 interface FakeRequestStream extends AsyncIterable<Uint8Array> {
   destroy: ReturnType<typeof vi.fn>
+  resume: ReturnType<typeof vi.fn>
   consumedChunks: number
+  iterator: (options: { destroyOnReturn: boolean }) => AsyncIterator<Uint8Array>
 }
 
 function makeRequestStream(chunks: Uint8Array[]): FakeRequestStream {
-  const stream: FakeRequestStream = {
-    destroy: vi.fn(),
-    consumedChunks: 0,
-    async *[Symbol.asyncIterator]() {
-      for (const chunk of chunks) {
-        stream.consumedChunks += 1
-        yield chunk
-      }
-    },
+  async function* chunksIterator() {
+    for (const chunk of chunks) {
+      stream.consumedChunks += 1
+      yield chunk
+    }
   }
+
+  const stream = {
+    destroy: vi.fn(),
+    resume: vi.fn(),
+    consumedChunks: 0,
+    iterator: vi.fn((options: { destroyOnReturn: boolean }) => {
+      expect(options).toEqual({ destroyOnReturn: false })
+      return chunksIterator()
+    }),
+    [Symbol.asyncIterator]: chunksIterator,
+  } satisfies FakeRequestStream
   return stream
 }
 
@@ -103,7 +112,7 @@ describe('PostHog ingest route adapter', () => {
     expect(event.node.req.consumedChunks).toBe(0)
   })
 
-  it('destroys a chunked request stream as soon as its actual body crosses 1 MiB', async () => {
+  it('stops retaining and drains a chunked request stream as soon as its actual body crosses 1 MiB', async () => {
     const requestStream = makeRequestStream([
       new Uint8Array(700 * 1024),
       new Uint8Array(400 * 1024),
@@ -115,7 +124,8 @@ describe('PostHog ingest route adapter', () => {
     })
 
     await expect(handler(event)).rejects.toMatchObject({ statusCode: 413 })
-    expect(requestStream.destroy).toHaveBeenCalledTimes(1)
+    expect(requestStream.destroy).not.toHaveBeenCalled()
+    expect(requestStream.resume).toHaveBeenCalledTimes(1)
     expect(requestStream.consumedChunks).toBe(2)
     expect(fetchMock).not.toHaveBeenCalled()
   })

--- a/tests/unit/analytics-proxy-route.test.ts
+++ b/tests/unit/analytics-proxy-route.test.ts
@@ -4,6 +4,7 @@ interface FakeEvent {
   method: string
   path: string
   url: string
+  socketIp: string
   requestHeaders: Record<string, string>
   responseHeaders: Record<string, string>
   responseStatus?: number
@@ -38,7 +39,7 @@ vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
 vi.stubGlobal('getRouterParam', (event: FakeEvent) => event.path)
 vi.stubGlobal('getRequestURL', (event: FakeEvent) => new URL(event.url))
 vi.stubGlobal('getRequestHeaders', (event: FakeEvent) => event.requestHeaders)
-vi.stubGlobal('getRequestIP', () => '198.51.100.10')
+vi.stubGlobal('getRequestIP', (event: FakeEvent) => event.socketIp)
 vi.stubGlobal('getHeader', (event: FakeEvent, name: string) => event.requestHeaders[name.toLowerCase()])
 vi.stubGlobal('setResponseHeaders', (event: FakeEvent, headers: Record<string, string | number>) => {
   for (const [name, value] of Object.entries(headers)) event.responseHeaders[name] = String(value)
@@ -65,6 +66,7 @@ function makeEvent(overrides: Partial<FakeEvent> = {}): FakeEvent {
     method: 'POST',
     path: 'e',
     url: 'https://careers.thefactoryhq.com/ingest/e',
+    socketIp: '198.51.100.10',
     requestHeaders: {
       'content-length': '2',
       'content-type': 'application/json',
@@ -77,7 +79,7 @@ function makeEvent(overrides: Partial<FakeEvent> = {}): FakeEvent {
 
 beforeEach(() => {
   fetchMock.mockReset()
-  fetchMock.mockResolvedValue(new Response('{}', {
+  fetchMock.mockImplementation(async () => new Response('{}', {
     status: 200,
     headers: { 'content-type': 'application/json' },
   }))
@@ -96,6 +98,7 @@ describe('PostHog ingest route adapter', () => {
     const event = makeEvent({ requestHeaders: {} })
 
     await expect(handler(event)).rejects.toMatchObject({ statusCode: 411 })
+    expect(event.responseHeaders['X-RateLimit-Limit']).toBe('120')
     expect(fetchMock).not.toHaveBeenCalled()
     expect(event.node.req.consumedChunks).toBe(0)
   })
@@ -140,6 +143,29 @@ describe('PostHog ingest route adapter', () => {
     expect(event.responseStatus).toBe(200)
     expect(event.responseHeaders['content-type']).toBe('application/json')
     expect(new TextDecoder().decode(body)).toBe('{}')
+  })
+
+  it('does not make honest Cloudflare clients on one Render socket share the per-client budget', async () => {
+    const socketIp = '10.0.0.9'
+    for (let requestNumber = 0; requestNumber < 120; requestNumber += 1) {
+      await handler(makeEvent({
+        socketIp,
+        requestHeaders: {
+          'content-length': '2',
+          'cf-connecting-ip': '203.0.113.20',
+        },
+      }))
+    }
+
+    const secondClient = makeEvent({
+      socketIp,
+      requestHeaders: {
+        'content-length': '2',
+        'cf-connecting-ip': '203.0.113.21',
+      },
+    })
+    await expect(handler(secondClient)).resolves.toBeInstanceOf(Buffer)
+    expect(secondClient.responseHeaders['X-RateLimit-Limit']).toBe('120')
   })
 
   it('routes static HEAD requests through the assets host and higher asset limiter without reading a body', async () => {

--- a/tests/unit/analytics-proxy-route.test.ts
+++ b/tests/unit/analytics-proxy-route.test.ts
@@ -11,6 +11,9 @@ interface FakeEvent {
   responseStatusText?: string
   node: {
     req: FakeRequestStream
+    res?: {
+      once: (event: 'finish' | 'close', listener: () => void) => unknown
+    }
   }
 }
 
@@ -42,6 +45,21 @@ function makeRequestStream(chunks: Uint8Array[]): FakeRequestStream {
   return stream
 }
 
+function makeResponseLifecycle() {
+  const listeners = new Map<'finish' | 'close', Array<() => void>>()
+  return {
+    response: {
+      once(event: 'finish' | 'close', listener: () => void) {
+        listeners.set(event, [...(listeners.get(event) ?? []), listener])
+      },
+    },
+    emit(event: 'finish' | 'close') {
+      for (const listener of listeners.get(event) ?? []) listener()
+      listeners.delete(event)
+    },
+  }
+}
+
 const fetchMock = vi.fn()
 
 vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
@@ -69,9 +87,10 @@ vi.stubGlobal('fetch', fetchMock)
 const { default: handler } = await import('../../server/routes/ingest/[...path]') as {
   default: (event: FakeEvent) => Promise<Uint8Array>
 }
+const { holdAnalyticsProxyLeaseUntilResponse } = await import('../../server/utils/analyticsProxyConcurrency')
 
 function makeEvent(overrides: Partial<FakeEvent> = {}): FakeEvent {
-  return {
+  const base: FakeEvent = {
     method: 'POST',
     path: 'e',
     url: 'https://careers.thefactoryhq.com/ingest/e',
@@ -81,8 +100,19 @@ function makeEvent(overrides: Partial<FakeEvent> = {}): FakeEvent {
       'content-type': 'application/json',
     },
     responseHeaders: {},
-    node: { req: makeRequestStream([new Uint8Array([123, 125])]) },
+    node: {
+      req: makeRequestStream([new Uint8Array([123, 125])]),
+      res: {
+        once(event, listener) {
+          if (event === 'finish') queueMicrotask(listener)
+        },
+      },
+    },
+  }
+  return {
+    ...base,
     ...overrides,
+    node: { ...base.node, ...overrides.node },
   }
 }
 
@@ -95,12 +125,33 @@ beforeEach(() => {
 })
 
 describe('PostHog ingest route adapter', () => {
+  it('destroys a stalled downstream response and releases its lease at the request deadline', () => {
+    const timeout = new AbortController()
+    const release = vi.fn()
+    const destroy = vi.fn()
+    const listeners = new Map<string, () => void>()
+    const response = {
+      once: (event: string, listener: () => void) => listeners.set(event, listener),
+      removeListener: (event: string) => listeners.delete(event),
+      destroy,
+    }
+
+    holdAnalyticsProxyLeaseUntilResponse(response, timeout.signal, release)
+    timeout.abort()
+
+    expect(destroy).toHaveBeenCalledTimes(1)
+    expect(release).toHaveBeenCalledTimes(1)
+    listeners.get('close')?.()
+    expect(release).toHaveBeenCalledTimes(1)
+  })
+
   it('rejects an unknown path without calling upstream', async () => {
     const event = makeEvent({ path: 'api/projects', url: 'https://careers.thefactoryhq.com/ingest/api/projects' })
 
     await expect(handler(event)).rejects.toMatchObject({ statusCode: 404 })
     expect(fetchMock).not.toHaveBeenCalled()
     expect(event.node.req.consumedChunks).toBe(0)
+    expect(event.node.req.resume).toHaveBeenCalledTimes(1)
   })
 
   it('rejects a capture request without Content-Length before calling upstream', async () => {
@@ -110,6 +161,7 @@ describe('PostHog ingest route adapter', () => {
     expect(event.responseHeaders['X-RateLimit-Limit']).toBe('120')
     expect(fetchMock).not.toHaveBeenCalled()
     expect(event.node.req.consumedChunks).toBe(0)
+    expect(event.node.req.resume).toHaveBeenCalledTimes(1)
   })
 
   it('stops retaining and drains a chunked request stream as soon as its actual body crosses 1 MiB', async () => {
@@ -176,6 +228,20 @@ describe('PostHog ingest route adapter', () => {
     })
     await expect(handler(secondClient)).resolves.toBeInstanceOf(Buffer)
     expect(secondClient.responseHeaders['X-RateLimit-Limit']).toBe('120')
+
+    const rejectedStream = makeRequestStream([new Uint8Array([123, 125])])
+    const rejected = makeEvent({
+      socketIp,
+      requestHeaders: {
+        'content-length': '2',
+        'cf-connecting-ip': '203.0.113.20',
+      },
+      node: { req: rejectedStream },
+    })
+    const fetchCountBeforeRejection = fetchMock.mock.calls.length
+    await expect(handler(rejected)).rejects.toMatchObject({ statusCode: 429 })
+    expect(rejectedStream.resume).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(fetchCountBeforeRejection)
   })
 
   it('routes static HEAD requests through the assets host and higher asset limiter without reading a body', async () => {
@@ -194,5 +260,83 @@ describe('PostHog ingest route adapter', () => {
     )
     expect(event.responseHeaders['X-RateLimit-Limit']).toBe('600')
     expect(event.node.req.consumedChunks).toBe(0)
+  })
+
+  it('drains and rejects bodies on GET asset requests before upstream fetch', async () => {
+    const requestStream = makeRequestStream([new Uint8Array([1])])
+    const event = makeEvent({
+      method: 'GET',
+      path: 'static/exception-autocapture.js',
+      url: 'https://careers.thefactoryhq.com/ingest/static/exception-autocapture.js',
+      requestHeaders: { 'content-length': '1' },
+      node: { req: requestStream },
+    })
+
+    await expect(handler(event)).rejects.toMatchObject({ statusCode: 400 })
+    expect(requestStream.resume).toHaveBeenCalledTimes(1)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('caps buffered proxy responses until slow downstream responses finish', async () => {
+    const lifecycles = Array.from({ length: 33 }, () => makeResponseLifecycle())
+
+    for (let index = 0; index < 32; index += 1) {
+      const event = makeEvent({
+        socketIp: `198.51.100.${index + 1}`,
+        node: {
+          req: makeRequestStream([new Uint8Array([123, 125])]),
+          res: lifecycles[index]!.response,
+        },
+      })
+      await expect(handler(event)).resolves.toBeInstanceOf(Buffer)
+    }
+
+    const saturated = makeEvent({
+      socketIp: '203.0.113.250',
+      node: {
+        req: makeRequestStream([new Uint8Array([123, 125])]),
+        res: lifecycles[32]!.response,
+      },
+    })
+    await expect(handler(saturated)).rejects.toMatchObject({ statusCode: 503 })
+    expect(fetchMock).toHaveBeenCalledTimes(32)
+    expect(saturated.node.req.resume).toHaveBeenCalledTimes(1)
+
+    lifecycles[0]!.emit('finish')
+    await expect(handler(saturated)).resolves.toBeInstanceOf(Buffer)
+
+    for (const lifecycle of lifecycles) lifecycle.emit('finish')
+  })
+
+  it('releases buffered-response capacity when downstream closes early', async () => {
+    const lifecycles = Array.from({ length: 33 }, () => makeResponseLifecycle())
+    for (let index = 0; index < 32; index += 1) {
+      await handler(makeEvent({
+        socketIp: `192.0.2.${index + 1}`,
+        node: {
+          req: makeRequestStream([new Uint8Array([123, 125])]),
+          res: lifecycles[index]!.response,
+        },
+      }))
+    }
+
+    lifecycles[0]!.emit('close')
+    await expect(handler(makeEvent({
+      socketIp: '192.0.2.200',
+      node: {
+        req: makeRequestStream([new Uint8Array([123, 125])]),
+        res: lifecycles[32]!.response,
+      },
+    }))).resolves.toBeInstanceOf(Buffer)
+
+    for (const lifecycle of lifecycles) lifecycle.emit('close')
+  })
+
+  it('releases concurrency capacity after an execution error', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('upstream private detail'))
+    await expect(handler(makeEvent({ socketIp: '198.18.0.1' })))
+      .rejects.toMatchObject({ statusCode: 502, message: 'Analytics upstream request failed' })
+
+    await expect(handler(makeEvent({ socketIp: '198.18.0.2' }))).resolves.toBeInstanceOf(Buffer)
   })
 })

--- a/tests/unit/calendar-connection-generation-migration.test.ts
+++ b/tests/unit/calendar-connection-generation-migration.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = resolve(import.meta.dirname, '../..')
+
+describe('calendar connection generation migration', () => {
+  it('backfills a stable non-null connection generation for every existing integration', () => {
+    const migration = readFileSync(
+      resolve(root, 'server/database/migrations/0050_calendar_connection_generation.sql'),
+      'utf8',
+    )
+    const schema = readFileSync(resolve(root, 'server/database/schema/app.ts'), 'utf8')
+    const journal = readFileSync(resolve(root, 'server/database/migrations/meta/_journal.json'), 'utf8')
+
+    expect(migration).toContain('ADD COLUMN "connection_generation" text')
+    expect(migration).toContain('SET "connection_generation" = "id"')
+    expect(migration).toContain('ALTER COLUMN "connection_generation" SET NOT NULL')
+    expect(schema).toContain("connectionGeneration: text('connection_generation').notNull().$defaultFn(() => crypto.randomUUID())")
+    expect(journal).toContain('0050_calendar_connection_generation')
+  })
+})

--- a/tests/unit/calendar-disconnect.test.ts
+++ b/tests/unit/calendar-disconnect.test.ts
@@ -73,7 +73,7 @@ describe('calendar disconnect', () => {
     expect(calendarProviderMocks.removeGoogleCalendarIntegration).not.toHaveBeenCalled()
   })
 
-  it('removes a user Microsoft integration when no org integration is connected', async () => {
+  it('does not fall back to a user Microsoft integration when an org context is present', async () => {
     const findFirst = vi.fn()
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
@@ -93,11 +93,11 @@ describe('calendar disconnect', () => {
 
     await removeConnectedCalendarIntegration('user-1', 'org-1')
 
-    expect(calendarProviderMocks.removeMicrosoftCalendarIntegration).toHaveBeenCalledWith('user-1', undefined)
+    expect(calendarProviderMocks.removeMicrosoftCalendarIntegration).not.toHaveBeenCalled()
     expect(calendarProviderMocks.removeGoogleCalendarIntegration).not.toHaveBeenCalled()
   })
 
-  it('removes a user Google integration when no org integration is connected', async () => {
+  it('does not fall back to a user Google integration when an org context is present', async () => {
     const findFirst = vi.fn()
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
@@ -118,7 +118,42 @@ describe('calendar disconnect', () => {
 
     await removeConnectedCalendarIntegration('user-1', 'org-1')
 
-    expect(calendarProviderMocks.removeGoogleCalendarIntegration).toHaveBeenCalledWith('user-1')
+    expect(calendarProviderMocks.removeGoogleCalendarIntegration).not.toHaveBeenCalled()
     expect(calendarProviderMocks.removeMicrosoftCalendarIntegration).not.toHaveBeenCalled()
+  })
+
+  it('retains user Microsoft fallback only without an organization context', async () => {
+    const findFirst = vi.fn().mockResolvedValueOnce({
+      provider: 'microsoft',
+      userId: 'user-1',
+      organizationId: null,
+    })
+    vi.stubGlobal('db', { query: { calendarIntegration: { findFirst } } })
+
+    const { removeConnectedCalendarIntegration } = await import('../../server/utils/calendar')
+    await removeConnectedCalendarIntegration('user-1')
+
+    expect(calendarProviderMocks.removeMicrosoftCalendarIntegration).toHaveBeenCalledWith('user-1', undefined)
+  })
+
+  it('retains exact user Google fallback only without an organization context', async () => {
+    const findFirst = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'google-user-row',
+        provider: 'google',
+        userId: 'user-1',
+        organizationId: null,
+      })
+    vi.stubGlobal('db', { query: { calendarIntegration: { findFirst } } })
+
+    const { removeConnectedCalendarIntegration } = await import('../../server/utils/calendar')
+    await removeConnectedCalendarIntegration('user-1')
+
+    expect(calendarProviderMocks.removeGoogleCalendarIntegration).toHaveBeenCalledWith({
+      integrationId: 'google-user-row',
+      userId: 'user-1',
+      organizationId: null,
+    })
   })
 })

--- a/tests/unit/calendar-disconnect.test.ts
+++ b/tests/unit/calendar-disconnect.test.ts
@@ -25,17 +25,25 @@ vi.mock('../../server/utils/microsoft-calendar', () => ({
   isMicrosoftCalendarApplicationMode: vi.fn(() => false),
 }))
 
+vi.stubGlobal('createError', (options: { statusCode: number, statusMessage?: string }) =>
+  Object.assign(new Error(options.statusMessage), options),
+)
+
 describe('calendar disconnect', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    calendarProviderMocks.removeGoogleCalendarIntegration.mockResolvedValue(true)
+    calendarProviderMocks.removeMicrosoftCalendarIntegration.mockResolvedValue(true)
   })
 
   it('removes only the connected org Microsoft integration when one exists', async () => {
     const findFirst = vi.fn()
       .mockResolvedValueOnce({
+        id: 'microsoft-org-row',
         provider: 'microsoft',
         userId: null,
         organizationId: 'org-1',
+        connectionGeneration: 'microsoft-generation',
       })
 
     vi.stubGlobal('db', {
@@ -48,16 +56,23 @@ describe('calendar disconnect', () => {
 
     await removeConnectedCalendarIntegration('user-1', 'org-1')
 
-    expect(calendarProviderMocks.removeMicrosoftCalendarIntegration).toHaveBeenCalledWith('user-1', 'org-1')
+    expect(calendarProviderMocks.removeMicrosoftCalendarIntegration).toHaveBeenCalledWith({
+      integrationId: 'microsoft-org-row',
+      userId: null,
+      organizationId: 'org-1',
+      connectionGeneration: 'microsoft-generation',
+    })
     expect(calendarProviderMocks.removeGoogleCalendarIntegration).not.toHaveBeenCalled()
   })
 
   it('does not remove a user Google integration when the connected org integration is Microsoft', async () => {
     const findFirst = vi.fn()
       .mockResolvedValueOnce({
+        id: 'microsoft-org-row',
         provider: 'microsoft',
         userId: null,
         organizationId: 'org-1',
+        connectionGeneration: 'microsoft-generation',
       })
 
     vi.stubGlobal('db', {
@@ -124,16 +139,23 @@ describe('calendar disconnect', () => {
 
   it('retains user Microsoft fallback only without an organization context', async () => {
     const findFirst = vi.fn().mockResolvedValueOnce({
+      id: 'microsoft-user-row',
       provider: 'microsoft',
       userId: 'user-1',
       organizationId: null,
+      connectionGeneration: 'user-generation',
     })
     vi.stubGlobal('db', { query: { calendarIntegration: { findFirst } } })
 
     const { removeConnectedCalendarIntegration } = await import('../../server/utils/calendar')
     await removeConnectedCalendarIntegration('user-1')
 
-    expect(calendarProviderMocks.removeMicrosoftCalendarIntegration).toHaveBeenCalledWith('user-1', undefined)
+    expect(calendarProviderMocks.removeMicrosoftCalendarIntegration).toHaveBeenCalledWith({
+      integrationId: 'microsoft-user-row',
+      userId: 'user-1',
+      organizationId: null,
+      connectionGeneration: 'user-generation',
+    })
   })
 
   it('retains exact user Google fallback only without an organization context', async () => {
@@ -144,6 +166,7 @@ describe('calendar disconnect', () => {
         provider: 'google',
         userId: 'user-1',
         organizationId: null,
+        connectionGeneration: 'google-generation',
       })
     vi.stubGlobal('db', { query: { calendarIntegration: { findFirst } } })
 
@@ -154,6 +177,23 @@ describe('calendar disconnect', () => {
       integrationId: 'google-user-row',
       userId: 'user-1',
       organizationId: null,
+      connectionGeneration: 'google-generation',
     })
+  })
+
+  it('returns a conflict instead of false success when reconnect wins the disconnect CAS', async () => {
+    const findFirst = vi.fn().mockResolvedValueOnce({
+      id: 'google-raced-row',
+      provider: 'google',
+      userId: 'user-1',
+      organizationId: 'org-1',
+      connectionGeneration: 'connection-before-reconnect',
+    })
+    vi.stubGlobal('db', { query: { calendarIntegration: { findFirst } } })
+    calendarProviderMocks.removeGoogleCalendarIntegration.mockResolvedValueOnce(false)
+
+    const { removeConnectedCalendarIntegration } = await import('../../server/utils/calendar')
+    await expect(removeConnectedCalendarIntegration('user-1', 'org-1'))
+      .rejects.toMatchObject({ statusCode: 409 })
   })
 })

--- a/tests/unit/calendar-integration-backfill.test.ts
+++ b/tests/unit/calendar-integration-backfill.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const migrationPath = join(
+  process.cwd(),
+  'server/database/migrations/0049_google_calendar_organization_backfill.sql',
+)
+
+describe('Google Calendar organization backfill migration', () => {
+  it('backfills only unowned Google integrations with exactly one membership', () => {
+    expect(existsSync(migrationPath)).toBe(true)
+
+    const migration = readFileSync(migrationPath, 'utf8')
+
+    expect(migration).toContain('FROM "member"')
+    expect(migration).toContain('GROUP BY "user_id"')
+    expect(migration).toContain('HAVING COUNT(*) = 1')
+    expect(migration).toContain('UPDATE "calendar_integration" AS "integration"')
+    expect(migration).toContain('"integration"."provider" = \'google\'')
+    expect(migration).toContain('"integration"."organization_id" IS NULL')
+  })
+
+  it('avoids organization-provider conflicts instead of guessing ownership', () => {
+    expect(existsSync(migrationPath)).toBe(true)
+
+    const migration = readFileSync(migrationPath, 'utf8')
+
+    expect(migration).toContain('COUNT(*) OVER (PARTITION BY "membership"."organization_id")')
+    expect(migration).toContain('"organization_candidate_count" = 1')
+    expect(migration).toContain('NOT EXISTS')
+    expect(migration).toContain('"existing"."provider" = \'google\'')
+  })
+
+  it('registers migration 0049 in the Drizzle journal', () => {
+    const journal = JSON.parse(readFileSync(
+      join(process.cwd(), 'server/database/migrations/meta/_journal.json'),
+      'utf8',
+    )) as { entries: Array<{ idx: number, tag: string }> }
+
+    expect(journal.entries).toContainEqual(expect.objectContaining({
+      idx: 49,
+      tag: '0049_google_calendar_organization_backfill',
+    }))
+  })
+})

--- a/tests/unit/calendar-integration-permissions.test.ts
+++ b/tests/unit/calendar-integration-permissions.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('calendar integration organization permissions', () => {
+  it('guards composable mutations with organization update permission', () => {
+    const composable = read('app/composables/useCalendarIntegration.ts')
+
+    expect(composable).toContain("usePermission({ organization: ['update'] })")
+    expect(composable).toMatch(/function connect\(\)[\s\S]*?if \(!canManageCalendar\.value\) return/)
+    expect(composable).toMatch(/async function disconnect\(\)[\s\S]*?if \(!canManageCalendar\.value\) return/)
+  })
+
+  it('does not render organization-wide connect or disconnect controls to ordinary members', () => {
+    const page = read('app/pages/dashboard/settings/integrations.vue')
+
+    expect(page).toContain('canManageCalendar')
+    expect(page).toMatch(/v-if="!isAdminManagedCalendar && !isCalendarPermissionLoading && canManageCalendar"/)
+    expect(page).toMatch(/v-if="!isMicrosoftAppMode && !isCalendarPermissionLoading && canManageCalendar"/)
+    expect(page).toContain('Only organization administrators can change the shared calendar connection.')
+  })
+})

--- a/tests/unit/calendar-integration-resolution-scope.test.ts
+++ b/tests/unit/calendar-integration-resolution-scope.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const providerMocks = vi.hoisted(() => ({
+  updateGoogleCalendarEvent: vi.fn(),
+}))
+
+vi.mock('../../server/utils/google-calendar', () => ({
+  createCalendarEvent: vi.fn(),
+  updateCalendarEvent: providerMocks.updateGoogleCalendarEvent,
+  cancelCalendarEvent: vi.fn(),
+  removeCalendarIntegration: vi.fn(),
+  setupCalendarWebhook: vi.fn(),
+  isGoogleCalendarConfigured: vi.fn(() => true),
+}))
+
+vi.mock('../../server/utils/microsoft-calendar', () => ({
+  createMicrosoftCalendarEvents: vi.fn(),
+  updateMicrosoftCalendarEvent: vi.fn(),
+  cancelMicrosoftCalendarEvent: vi.fn(),
+  updateMicrosoftMailboxCalendarEvent: vi.fn(),
+  cancelMicrosoftMailboxCalendarEvent: vi.fn(),
+  removeMicrosoftCalendarIntegration: vi.fn(),
+  isMicrosoftCalendarConfigured: vi.fn(() => true),
+  isMicrosoftCalendarApplicationMode: vi.fn(() => false),
+}))
+
+const calendar = await import('../../server/utils/calendar')
+
+describe('calendar integration organization resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not fall back to another organization user row when org resolution misses', async () => {
+    const findFirst = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'integration-org-a',
+        userId: 'user-multi-org',
+        organizationId: 'org-a',
+        provider: 'google',
+      })
+    vi.stubGlobal('db', {
+      query: { calendarIntegration: { findFirst } },
+    })
+
+    await expect(calendar.getConnectedCalendarIntegration(
+      'user-multi-org',
+      'org-b',
+    )).resolves.toBeNull()
+
+    expect(findFirst).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not use a provider-specific user row after an organization miss', async () => {
+    const findFirst = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'integration-org-a',
+        userId: 'user-multi-org',
+        organizationId: 'org-a',
+        provider: 'google',
+      })
+    vi.stubGlobal('db', {
+      query: { calendarIntegration: { findFirst } },
+    })
+
+    await expect(calendar.updateConnectedCalendarEvent(
+      'user-multi-org',
+      'org-b',
+      'event-1',
+      {},
+      'google',
+    )).resolves.toBeNull()
+
+    expect(findFirst).toHaveBeenCalledTimes(1)
+    expect(providerMocks.updateGoogleCalendarEvent).not.toHaveBeenCalled()
+  })
+
+  it('retains user-scoped fallback only when no organization context exists', async () => {
+    const userGoogleIntegration = {
+      id: 'integration-user-google',
+      userId: 'user-1',
+      organizationId: null,
+      provider: 'google',
+    }
+    const findFirst = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(userGoogleIntegration)
+    vi.stubGlobal('db', {
+      query: { calendarIntegration: { findFirst } },
+    })
+
+    await expect(calendar.getConnectedCalendarIntegration('user-1')).resolves.toBe(
+      userGoogleIntegration,
+    )
+
+    expect(findFirst).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/unit/calendar-integration-resolution-scope.test.ts
+++ b/tests/unit/calendar-integration-resolution-scope.test.ts
@@ -98,4 +98,30 @@ describe('calendar integration organization resolution', () => {
 
     expect(findFirst).toHaveBeenCalledTimes(2)
   })
+
+  it('passes the exact resolved Google identity through event operations', async () => {
+    const integration = {
+      id: 'integration-org-exact',
+      userId: 'user-1',
+      organizationId: 'org-exact',
+      provider: 'google',
+    }
+    const findFirst = vi.fn().mockResolvedValueOnce(integration)
+    vi.stubGlobal('db', { query: { calendarIntegration: { findFirst } } })
+    providerMocks.updateGoogleCalendarEvent.mockResolvedValue('https://calendar/event-1')
+
+    await expect(calendar.updateConnectedCalendarEvent(
+      'user-1',
+      'org-exact',
+      'event-1',
+      {},
+      'google',
+    )).resolves.toBe('https://calendar/event-1')
+
+    expect(providerMocks.updateGoogleCalendarEvent).toHaveBeenCalledWith({
+      integrationId: 'integration-org-exact',
+      userId: 'user-1',
+      organizationId: 'org-exact',
+    }, 'event-1', {})
+  })
 })

--- a/tests/unit/calendar-organization-mutation-auth.test.ts
+++ b/tests/unit/calendar-organization-mutation-auth.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const providerMocks = vi.hoisted(() => ({
+  enableMicrosoftCalendarAppIntegration: vi.fn(),
+  getMicrosoftAuthUrl: vi.fn(),
+  isMicrosoftCalendarApplicationMode: vi.fn(() => false),
+  isMicrosoftCalendarConfigured: vi.fn(() => true),
+  exchangeMicrosoftCodeForTokens: vi.fn(),
+  saveMicrosoftCalendarIntegration: vi.fn(),
+  isCalendarConfigured: vi.fn(() => true),
+  removeConnectedCalendarIntegration: vi.fn(),
+  initiateCalendarOAuth: vi.fn(),
+  handleCalendarOAuthCallback: vi.fn(),
+}))
+
+vi.mock('../../server/utils/microsoft-calendar', () => ({
+  enableMicrosoftCalendarAppIntegration: providerMocks.enableMicrosoftCalendarAppIntegration,
+  getMicrosoftAuthUrl: providerMocks.getMicrosoftAuthUrl,
+  isMicrosoftCalendarApplicationMode: providerMocks.isMicrosoftCalendarApplicationMode,
+  isMicrosoftCalendarConfigured: providerMocks.isMicrosoftCalendarConfigured,
+  exchangeMicrosoftCodeForTokens: providerMocks.exchangeMicrosoftCodeForTokens,
+  saveMicrosoftCalendarIntegration: providerMocks.saveMicrosoftCalendarIntegration,
+}))
+vi.mock('../../server/utils/calendar', () => ({
+  isCalendarConfigured: providerMocks.isCalendarConfigured,
+  removeConnectedCalendarIntegration: providerMocks.removeConnectedCalendarIntegration,
+}))
+vi.mock('../../server/utils/calendarOAuth', () => ({
+  initiateCalendarOAuth: providerMocks.initiateCalendarOAuth,
+  handleCalendarOAuthCallback: providerMocks.handleCalendarOAuthCallback,
+}))
+
+const requirePermissionMock = vi.fn()
+vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
+vi.stubGlobal('requirePermission', requirePermissionMock)
+vi.stubGlobal('createError', (options: { statusCode: number, statusMessage?: string }) =>
+  Object.assign(new Error(options.statusMessage), options),
+)
+
+const microsoftConnect = (await import('../../server/api/calendar/microsoft/connect.get')).default as
+  (event: unknown) => Promise<unknown>
+const microsoftCallback = (await import('../../server/api/calendar/microsoft/callback.get')).default as
+  (event: unknown) => Promise<unknown>
+const disconnect = (await import('../../server/api/calendar/disconnect.post')).default as
+  (event: unknown) => Promise<unknown>
+
+describe('organization-wide calendar mutation authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  for (const [name, handler] of [
+    ['Microsoft OAuth initiation', microsoftConnect],
+    ['Microsoft OAuth callback', microsoftCallback],
+    ['calendar disconnect', disconnect],
+  ] as const) {
+    it(`denies ${name} before provider or database work`, async () => {
+      const event = { route: name }
+      const forbidden = Object.assign(new Error('Forbidden'), { statusCode: 403 })
+      requirePermissionMock.mockRejectedValue(forbidden)
+
+      await expect(handler(event)).rejects.toBe(forbidden)
+
+      expect(requirePermissionMock).toHaveBeenCalledWith(event, {
+        organization: ['update'],
+      })
+      expect(providerMocks.enableMicrosoftCalendarAppIntegration).not.toHaveBeenCalled()
+      expect(providerMocks.initiateCalendarOAuth).not.toHaveBeenCalled()
+      expect(providerMocks.handleCalendarOAuthCallback).not.toHaveBeenCalled()
+      expect(providerMocks.removeConnectedCalendarIntegration).not.toHaveBeenCalled()
+    })
+  }
+})

--- a/tests/unit/calendar-organization-mutation-auth.test.ts
+++ b/tests/unit/calendar-organization-mutation-auth.test.ts
@@ -47,6 +47,12 @@ const disconnect = (await import('../../server/api/calendar/disconnect.post')).d
 describe('organization-wide calendar mutation authorization', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    providerMocks.exchangeMicrosoftCodeForTokens.mockResolvedValue({
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      email: 'calendar@example.com',
+    })
+    providerMocks.saveMicrosoftCalendarIntegration.mockResolvedValue(undefined)
   })
 
   for (const [name, handler] of [
@@ -70,4 +76,47 @@ describe('organization-wide calendar mutation authorization', () => {
       expect(providerMocks.removeConnectedCalendarIntegration).not.toHaveBeenCalled()
     })
   }
+
+  it.each([
+    ['missing', undefined],
+    ['mismatched', 'org-other'],
+  ])('rejects a %s Microsoft OAuth organization cookie before provider work', async (_label, cookieOrg) => {
+    requirePermissionMock.mockResolvedValue({
+      user: { id: 'user-1' },
+      session: { activeOrganizationId: 'org-active' },
+    })
+    providerMocks.handleCalendarOAuthCallback.mockImplementation(async (_event, options) => {
+      await options.onSuccess({
+        code: 'authorization-code',
+        extraCookies: { mscal_oauth_org: cookieOrg },
+      })
+    })
+
+    await expect(microsoftCallback({})).rejects.toThrow(
+      'Microsoft Calendar organization changed during authorization',
+    )
+    expect(providerMocks.exchangeMicrosoftCodeForTokens).not.toHaveBeenCalled()
+    expect(providerMocks.saveMicrosoftCalendarIntegration).not.toHaveBeenCalled()
+  })
+
+  it('saves Microsoft OAuth credentials only for the matching authorized organization', async () => {
+    requirePermissionMock.mockResolvedValue({
+      user: { id: 'user-1' },
+      session: { activeOrganizationId: 'org-active' },
+    })
+    providerMocks.handleCalendarOAuthCallback.mockImplementation(async (_event, options) => {
+      await options.onSuccess({
+        code: 'authorization-code',
+        extraCookies: { mscal_oauth_org: 'org-active' },
+      })
+    })
+
+    await microsoftCallback({})
+
+    expect(providerMocks.saveMicrosoftCalendarIntegration).toHaveBeenCalledWith(
+      'user-1',
+      'org-active',
+      expect.objectContaining({ accessToken: 'access' }),
+    )
+  })
 })

--- a/tests/unit/calendar-organization-mutation-auth.test.ts
+++ b/tests/unit/calendar-organization-mutation-auth.test.ts
@@ -36,6 +36,8 @@ vi.stubGlobal('requirePermission', requirePermissionMock)
 vi.stubGlobal('createError', (options: { statusCode: number, statusMessage?: string }) =>
   Object.assign(new Error(options.statusMessage), options),
 )
+const sendRedirectMock = vi.fn(async (_event, location: string) => ({ location }))
+vi.stubGlobal('sendRedirect', sendRedirectMock)
 
 const microsoftConnect = (await import('../../server/api/calendar/microsoft/connect.get')).default as
   (event: unknown) => Promise<unknown>
@@ -117,6 +119,23 @@ describe('organization-wide calendar mutation authorization', () => {
       'user-1',
       'org-active',
       expect.objectContaining({ accessToken: 'access' }),
+    )
+  })
+
+  it('keeps Microsoft application-mode GET connection handling read-only', async () => {
+    requirePermissionMock.mockResolvedValue({
+      user: { id: 'user-1', email: 'admin@example.com' },
+      session: { activeOrganizationId: 'org-active' },
+    })
+    providerMocks.isMicrosoftCalendarApplicationMode.mockReturnValueOnce(true)
+
+    await microsoftConnect({})
+
+    expect(providerMocks.enableMicrosoftCalendarAppIntegration).not.toHaveBeenCalled()
+    expect(providerMocks.initiateCalendarOAuth).not.toHaveBeenCalled()
+    expect(sendRedirectMock).toHaveBeenCalledWith(
+      {},
+      '/dashboard/settings/integrations?success=connected&provider=microsoft',
     )
   })
 })

--- a/tests/unit/calendar-renewal-scope.test.ts
+++ b/tests/unit/calendar-renewal-scope.test.ts
@@ -3,8 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const drizzleMocks = vi.hoisted(() => ({
   and: vi.fn((...conditions: unknown[]) => ({ operator: 'and', conditions })),
   eq: vi.fn((column: unknown, value: unknown) => ({ operator: 'eq', column, value })),
-  isNotNull: vi.fn((column: unknown) => ({ operator: 'isNotNull', column })),
+  isNull: vi.fn((column: unknown) => ({ operator: 'isNull', column })),
   lt: vi.fn((column: unknown, value: unknown) => ({ operator: 'lt', column, value })),
+  or: vi.fn((...conditions: unknown[]) => ({ operator: 'or', conditions })),
 }))
 
 vi.mock('drizzle-orm', async (importOriginal) => {
@@ -77,8 +78,14 @@ describe('calendar webhook renewal scope', () => {
             column: calendarIntegration.provider,
             value: 'google',
           },
-          expect.objectContaining({ operator: 'isNotNull' }),
-          expect.objectContaining({ operator: 'lt' }),
+          expect.objectContaining({
+            operator: 'or',
+            conditions: expect.arrayContaining([
+              { operator: 'isNull', column: calendarIntegration.webhookChannelId },
+              { operator: 'isNull', column: calendarIntegration.webhookExpiration },
+              expect.objectContaining({ operator: 'lt' }),
+            ]),
+          }),
         ],
       },
       columns: { id: true, userId: true, organizationId: true },
@@ -122,6 +129,30 @@ describe('calendar webhook renewal scope', () => {
       integrationId: 'integration-interactive',
       userId: 'user-interactive',
       organizationId: activeOrganizationId,
+    })
+  })
+
+  it('retries a connected Google integration whose initial webhook setup is still pending', async () => {
+    requirePermissionMock.mockResolvedValue({
+      session: { activeOrganizationId: 'org-pending' },
+    })
+    findManyMock.mockResolvedValue([{
+      id: 'integration-pending',
+      userId: 'user-pending',
+      organizationId: 'org-pending',
+    }])
+
+    await expect(renewWebhooksHandler({})).resolves.toEqual({
+      total: 1,
+      renewed: 1,
+      failed: 0,
+    })
+
+    expect(drizzleMocks.isNull).toHaveBeenCalledWith(calendarIntegration.webhookChannelId)
+    expect(setupCalendarWebhookMock).toHaveBeenCalledWith({
+      integrationId: 'integration-pending',
+      userId: 'user-pending',
+      organizationId: 'org-pending',
     })
   })
 

--- a/tests/unit/calendar-renewal-scope.test.ts
+++ b/tests/unit/calendar-renewal-scope.test.ts
@@ -63,15 +63,25 @@ describe('calendar webhook renewal scope', () => {
     })
 
     expect(requirePermissionMock).not.toHaveBeenCalled()
-    expect(drizzleMocks.eq).not.toHaveBeenCalled()
+    expect(drizzleMocks.eq).toHaveBeenCalledWith(calendarIntegration.provider, 'google')
+    expect(drizzleMocks.eq).not.toHaveBeenCalledWith(
+      calendarIntegration.organizationId,
+      expect.anything(),
+    )
     expect(findManyMock).toHaveBeenCalledWith(expect.objectContaining({
       where: {
         operator: 'and',
         conditions: [
+          {
+            operator: 'eq',
+            column: calendarIntegration.provider,
+            value: 'google',
+          },
           expect.objectContaining({ operator: 'isNotNull' }),
           expect.objectContaining({ operator: 'lt' }),
         ],
       },
+      columns: { id: true, userId: true, organizationId: true },
     }))
   })
 
@@ -81,6 +91,11 @@ describe('calendar webhook renewal scope', () => {
     requirePermissionMock.mockResolvedValue({
       session: { activeOrganizationId },
     })
+    findManyMock.mockResolvedValue([{
+      id: 'integration-interactive',
+      userId: 'user-interactive',
+      organizationId: activeOrganizationId,
+    }])
 
     await renewWebhooksHandler(event)
 
@@ -91,6 +106,7 @@ describe('calendar webhook renewal scope', () => {
       calendarIntegration.organizationId,
       activeOrganizationId,
     )
+    expect(drizzleMocks.eq).toHaveBeenCalledWith(calendarIntegration.provider, 'google')
     expect(findManyMock).toHaveBeenCalledWith(expect.objectContaining({
       where: expect.objectContaining({
         operator: 'and',
@@ -102,6 +118,11 @@ describe('calendar webhook renewal scope', () => {
         ]),
       }),
     }))
+    expect(setupCalendarWebhookMock).toHaveBeenCalledWith({
+      integrationId: 'integration-interactive',
+      userId: 'user-interactive',
+      organizationId: activeOrganizationId,
+    })
   })
 
   it('does no database or provider work when interactive permission is denied', async () => {
@@ -147,10 +168,10 @@ describe('calendar webhook renewal scope', () => {
     vi.setSystemTime(new Date('2026-07-16T12:00:00.000Z'))
     envStub.CRON_SECRET = 'configured-cron-secret'
     findManyMock.mockResolvedValue([
-      { userId: 'user-renewed' },
-      { userId: 'user-provider-failed' },
-      { userId: 'user-provider-threw' },
-      { userId: null },
+      { id: 'integration-renewed', userId: 'user-renewed', organizationId: 'org-a' },
+      { id: 'integration-provider-failed', userId: 'user-provider-failed', organizationId: 'org-b' },
+      { id: 'integration-provider-threw', userId: 'user-provider-threw', organizationId: null },
+      { id: 'integration-without-user', userId: null, organizationId: 'org-c' },
     ])
     setupCalendarWebhookMock
       .mockResolvedValueOnce(true)
@@ -165,10 +186,22 @@ describe('calendar webhook renewal scope', () => {
       expect.anything(),
       new Date('2026-07-17T12:00:00.000Z'),
     )
-    expect(setupCalendarWebhookMock.mock.calls.map(([userId]) => userId)).toEqual([
-      'user-renewed',
-      'user-provider-failed',
-      'user-provider-threw',
+    expect(setupCalendarWebhookMock.mock.calls.map(([identity]) => identity)).toEqual([
+      {
+        integrationId: 'integration-renewed',
+        userId: 'user-renewed',
+        organizationId: 'org-a',
+      },
+      {
+        integrationId: 'integration-provider-failed',
+        userId: 'user-provider-failed',
+        organizationId: 'org-b',
+      },
+      {
+        integrationId: 'integration-provider-threw',
+        userId: 'user-provider-threw',
+        organizationId: null,
+      },
     ])
     expect(result).toEqual({ total: 4, renewed: 1, failed: 3 })
   })

--- a/tests/unit/calendar-renewal-scope.test.ts
+++ b/tests/unit/calendar-renewal-scope.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const drizzleMocks = vi.hoisted(() => ({
+  and: vi.fn((...conditions: unknown[]) => ({ operator: 'and', conditions })),
+  eq: vi.fn((column: unknown, value: unknown) => ({ operator: 'eq', column, value })),
+  isNotNull: vi.fn((column: unknown) => ({ operator: 'isNotNull', column })),
+  lt: vi.fn((column: unknown, value: unknown) => ({ operator: 'lt', column, value })),
+}))
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const original = await importOriginal<typeof import('drizzle-orm')>()
+  return { ...original, ...drizzleMocks }
+})
+
+const setupCalendarWebhookMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../server/utils/google-calendar', () => ({
+  setupCalendarWebhook: setupCalendarWebhookMock,
+}))
+
+const requirePermissionMock = vi.fn()
+const findManyMock = vi.fn()
+const envStub: { CRON_SECRET?: string } = {}
+
+type TestEvent = {
+  headers?: Record<string, string | undefined>
+}
+
+vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
+vi.stubGlobal('getHeader', (event: TestEvent, name: string) => event.headers?.[name.toLowerCase()])
+vi.stubGlobal('requirePermission', requirePermissionMock)
+vi.stubGlobal('createError', (options: { statusCode: number, statusMessage?: string }) =>
+  Object.assign(new Error(options.statusMessage), options),
+)
+vi.stubGlobal('env', envStub)
+vi.stubGlobal('db', {
+  query: {
+    calendarIntegration: {
+      findMany: findManyMock,
+    },
+  },
+})
+
+const renewWebhooksHandler = (
+  await import('../../server/api/calendar/renew-webhooks.post')
+).default as (event: TestEvent) => Promise<{ total: number, renewed: number, failed: number }>
+const { calendarIntegration } = await import('../../server/database/schema')
+
+describe('calendar webhook renewal scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+    delete envStub.CRON_SECRET
+    findManyMock.mockResolvedValue([])
+    setupCalendarWebhookMock.mockResolvedValue(true)
+  })
+
+  it('uses a valid configured cron secret to renew globally without an organization predicate', async () => {
+    envStub.CRON_SECRET = 'configured-cron-secret'
+
+    await renewWebhooksHandler({
+      headers: { 'x-cron-secret': 'configured-cron-secret' },
+    })
+
+    expect(requirePermissionMock).not.toHaveBeenCalled()
+    expect(drizzleMocks.eq).not.toHaveBeenCalled()
+    expect(findManyMock).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        operator: 'and',
+        conditions: [
+          expect.objectContaining({ operator: 'isNotNull' }),
+          expect.objectContaining({ operator: 'lt' }),
+        ],
+      },
+    }))
+  })
+
+  it('scopes an interactive renewal to the exact active organization', async () => {
+    const event = {}
+    const activeOrganizationId = 'org-authorized-exactly'
+    requirePermissionMock.mockResolvedValue({
+      session: { activeOrganizationId },
+    })
+
+    await renewWebhooksHandler(event)
+
+    expect(requirePermissionMock).toHaveBeenCalledWith(event, {
+      organization: ['update'],
+    })
+    expect(drizzleMocks.eq).toHaveBeenCalledWith(
+      calendarIntegration.organizationId,
+      activeOrganizationId,
+    )
+    expect(findManyMock).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        operator: 'and',
+        conditions: expect.arrayContaining([
+          expect.objectContaining({
+            operator: 'eq',
+            value: activeOrganizationId,
+          }),
+        ]),
+      }),
+    }))
+  })
+
+  it('does no database or provider work when interactive permission is denied', async () => {
+    const forbidden = Object.assign(new Error('Forbidden'), { statusCode: 403 })
+    requirePermissionMock.mockRejectedValue(forbidden)
+
+    await expect(renewWebhooksHandler({})).rejects.toBe(forbidden)
+
+    expect(findManyMock).not.toHaveBeenCalled()
+    expect(setupCalendarWebhookMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid supplied cron secret before auth, database, or provider work', async () => {
+    envStub.CRON_SECRET = 'configured-cron-secret'
+
+    await expect(renewWebhooksHandler({
+      headers: { 'x-cron-secret': 'invalid-cron-secret' },
+    })).rejects.toMatchObject({
+      statusCode: 403,
+      message: 'Invalid cron secret',
+    })
+
+    expect(requirePermissionMock).not.toHaveBeenCalled()
+    expect(findManyMock).not.toHaveBeenCalled()
+    expect(setupCalendarWebhookMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a supplied cron secret when CRON_SECRET is not configured', async () => {
+    await expect(renewWebhooksHandler({
+      headers: { 'x-cron-secret': 'supplied-cron-secret' },
+    })).rejects.toMatchObject({
+      statusCode: 403,
+      message: 'Invalid cron secret',
+    })
+
+    expect(requirePermissionMock).not.toHaveBeenCalled()
+    expect(findManyMock).not.toHaveBeenCalled()
+    expect(setupCalendarWebhookMock).not.toHaveBeenCalled()
+  })
+
+  it('preserves the 24-hour threshold and exact renewal result counts', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-16T12:00:00.000Z'))
+    envStub.CRON_SECRET = 'configured-cron-secret'
+    findManyMock.mockResolvedValue([
+      { userId: 'user-renewed' },
+      { userId: 'user-provider-failed' },
+      { userId: 'user-provider-threw' },
+      { userId: null },
+    ])
+    setupCalendarWebhookMock
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockRejectedValueOnce(new Error('provider unavailable'))
+
+    const result = await renewWebhooksHandler({
+      headers: { 'x-cron-secret': 'configured-cron-secret' },
+    })
+
+    expect(drizzleMocks.lt).toHaveBeenCalledWith(
+      expect.anything(),
+      new Date('2026-07-17T12:00:00.000Z'),
+    )
+    expect(setupCalendarWebhookMock.mock.calls.map(([userId]) => userId)).toEqual([
+      'user-renewed',
+      'user-provider-failed',
+      'user-provider-threw',
+    ])
+    expect(result).toEqual({ total: 4, renewed: 1, failed: 3 })
+  })
+})

--- a/tests/unit/calendar-webhook-scope.test.ts
+++ b/tests/unit/calendar-webhook-scope.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const drizzleMocks = vi.hoisted(() => ({
+  and: vi.fn((...conditions: unknown[]) => ({ operator: 'and', conditions })),
+  eq: vi.fn((column: unknown, value: unknown) => ({ operator: 'eq', column, value })),
+}))
+vi.mock('drizzle-orm', async (importOriginal) => ({
+  ...await importOriginal<typeof import('drizzle-orm')>(),
+  ...drizzleMocks,
+}))
+
+const performIncrementalSyncMock = vi.hoisted(() => vi.fn())
+vi.mock('../../server/utils/google-calendar', () => ({
+  performIncrementalSync: performIncrementalSyncMock,
+}))
+
+const findFirstMock = vi.fn()
+vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
+vi.stubGlobal('getHeader', (_event: unknown, name: string) => ({
+  'x-goog-channel-id': 'channel-exact',
+  'x-goog-resource-state': 'exists',
+  'x-goog-resource-id': 'resource-exact',
+}[name]))
+vi.stubGlobal('setResponseStatus', vi.fn())
+vi.stubGlobal('logError', vi.fn())
+vi.stubGlobal('db', { query: { calendarIntegration: { findFirst: findFirstMock } } })
+
+const handler = (await import('../../server/api/calendar/webhook.post')).default as
+  (event: unknown) => Promise<unknown>
+const { calendarIntegration } = await import('../../server/database/schema')
+
+describe('Google Calendar webhook integration scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    findFirstMock.mockResolvedValue({
+      id: 'integration-exact',
+      userId: 'user-exact',
+      organizationId: 'org-exact',
+      webhookResourceId: 'resource-exact',
+    })
+    performIncrementalSyncMock.mockResolvedValue(undefined)
+  })
+
+  it('filters the public channel lookup to Google and passes exact identity to sync', async () => {
+    await handler({})
+
+    expect(findFirstMock).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        operator: 'and',
+        conditions: expect.arrayContaining([
+          { operator: 'eq', column: calendarIntegration.webhookChannelId, value: 'channel-exact' },
+          { operator: 'eq', column: calendarIntegration.provider, value: 'google' },
+        ]),
+      },
+    }))
+    expect(performIncrementalSyncMock).toHaveBeenCalledWith({
+      integrationId: 'integration-exact',
+      userId: 'user-exact',
+      organizationId: 'org-exact',
+    })
+  })
+})

--- a/tests/unit/compliance-reporting.test.ts
+++ b/tests/unit/compliance-reporting.test.ts
@@ -5,21 +5,22 @@ import {
   type ComplianceReportingBreakdownsInput,
 } from '../../server/utils/complianceReporting'
 
-function makeBreakdowns(
+function makeCoherentBreakdowns(
+  totalResponses: number,
   overrides: Partial<ComplianceReportingBreakdownsInput> = {},
 ): ComplianceReportingBreakdownsInput {
   return {
-    sex: [],
-    raceEthnicity: [],
-    veteranStatus: [],
-    disabilityStatus: [],
+    sex: [{ value: null, count: totalResponses }],
+    raceEthnicity: [{ value: null, count: totalResponses }],
+    veteranStatus: [{ value: null, count: totalResponses }],
+    disabilityStatus: [{ value: null, count: totalResponses }],
     ...overrides,
   }
 }
 
 describe('compliance reporting privacy policy', () => {
-  it('suppresses all breakdowns when the response cohort is below five', () => {
-    const result = protectComplianceReporting(4, makeBreakdowns({
+  it('protects the total and every dimension when the response cohort is below five', () => {
+    const result = protectComplianceReporting(4, makeCoherentBreakdowns(4, {
       sex: [
         { value: 'female', count: 3 },
         { value: 'male', count: 1 },
@@ -28,38 +29,20 @@ describe('compliance reporting privacy policy', () => {
 
     expect(MIN_COMPLIANCE_REPORTING_COHORT).toBe(5)
     expect(result).toEqual({
+      totalResponses: null,
       suppressed: true,
       minimumCohortSize: 5,
       breakdowns: {
-        sex: [],
-        raceEthnicity: [],
-        veteranStatus: [],
-        disabilityStatus: [],
+        sex: { suppressed: true, buckets: [] },
+        raceEthnicity: { suppressed: true, buckets: [] },
+        veteranStatus: { suppressed: true, buckets: [] },
+        disabilityStatus: { suppressed: true, buckets: [] },
       },
     })
   })
 
-  it('hides small cells and complementarily suppresses the next-smallest cell', () => {
-    const result = protectComplianceReporting(20, makeBreakdowns({
-      raceEthnicity: [
-        { value: 'small-cell', count: 1 },
-        { value: 'largest-cell', count: 14 },
-        { value: 'next-smallest-cell', count: 5 },
-      ],
-    }))
-
-    expect(result.suppressed).toBe(true)
-    expect(result.breakdowns.raceEthnicity).toEqual([
-      { value: 'largest-cell', count: 14, suppressed: false },
-      { value: 'suppressed', count: null, suppressed: true },
-      { value: 'suppressed', count: null, suppressed: true },
-    ])
-    expect(JSON.stringify(result)).not.toContain('small-cell')
-    expect(JSON.stringify(result)).not.toContain('next-smallest-cell')
-  })
-
-  it('omits null buckets without confusing them with suppressed cells', () => {
-    const result = protectComplianceReporting(13, makeBreakdowns({
+  it('suppresses a complete dimension when its null bucket is below five', () => {
+    const result = protectComplianceReporting(13, makeCoherentBreakdowns(13, {
       veteranStatus: [
         { value: null, count: 3 },
         { value: 'protected_veteran', count: 5 },
@@ -67,37 +50,118 @@ describe('compliance reporting privacy policy', () => {
       ],
     }))
 
-    expect(result.suppressed).toBe(false)
-    expect(result.breakdowns.veteranStatus).toEqual([
-      { value: 'not_protected_veteran', count: 5, suppressed: false },
-      { value: 'protected_veteran', count: 5, suppressed: false },
-    ])
-    expect(result.breakdowns.veteranStatus).not.toContainEqual(
-      expect.objectContaining({ value: null }),
-    )
+    expect(result.totalResponses).toBe(13)
+    expect(result.suppressed).toBe(true)
+    expect(result.breakdowns.veteranStatus).toEqual({
+      suppressed: true,
+      buckets: [],
+    })
+    expect(JSON.stringify(result.breakdowns.veteranStatus)).not.toContain('protected_veteran')
   })
 
-  it('returns normal counts in a deterministic order when every cell is reportable', () => {
-    const result = protectComplianceReporting(18, makeBreakdowns({
-      disabilityStatus: [
-        { value: 'yes', count: 6 },
-        { value: 'prefer_not_to_answer', count: 6 },
-        { value: 'no', count: 6 },
+  it('reveals no bucket values, counts, or cardinality when multiple cells are small', () => {
+    const result = protectComplianceReporting(20, makeCoherentBreakdowns(20, {
+      raceEthnicity: [
+        { value: 'largest-cell', count: 14 },
+        { value: 'small-cell-one', count: 3 },
+        { value: 'small-cell-two', count: 3 },
       ],
     }))
 
+    expect(result.totalResponses).toBe(20)
+    expect(result.breakdowns.raceEthnicity).toEqual({
+      suppressed: true,
+      buckets: [],
+    })
+  })
+
+  it('reveals no within-dimension subtraction signal when exactly one cell is small', () => {
+    const result = protectComplianceReporting(20, makeCoherentBreakdowns(20, {
+      sex: [
+        { value: 'female', count: 19 },
+        { value: 'male', count: 1 },
+      ],
+    }))
+
+    expect(result.totalResponses).toBe(20)
+    expect(result.breakdowns.sex).toEqual({
+      suppressed: true,
+      buckets: [],
+    })
+  })
+
+  it('suppresses a dimension whose rows do not sum to the protected total', () => {
+    const result = protectComplianceReporting(20, makeCoherentBreakdowns(20, {
+      disabilityStatus: [
+        { value: 'no', count: 10 },
+        { value: 'yes', count: 5 },
+      ],
+    }))
+
+    expect(result.totalResponses).toBe(20)
+    expect(result.breakdowns.disabilityStatus).toEqual({
+      suppressed: true,
+      buckets: [],
+    })
+  })
+
+  it('returns every coherent reportable bucket deterministically, including no-answer counts', () => {
+    const result = protectComplianceReporting(20, {
+      sex: [
+        { value: 'male', count: 10 },
+        { value: 'female', count: 10 },
+      ],
+      raceEthnicity: [
+        { value: null, count: 5 },
+        { value: 'white', count: 10 },
+        { value: 'black_or_african_american', count: 5 },
+      ],
+      veteranStatus: [
+        { value: 'protected_veteran', count: 5 },
+        { value: 'not_protected_veteran', count: 15 },
+      ],
+      disabilityStatus: [
+        { value: null, count: 5 },
+        { value: 'prefer_not_to_answer', count: 10 },
+        { value: 'no', count: 5 },
+      ],
+    })
+
     expect(result).toEqual({
+      totalResponses: 20,
       suppressed: false,
       minimumCohortSize: 5,
       breakdowns: {
-        sex: [],
-        raceEthnicity: [],
-        veteranStatus: [],
-        disabilityStatus: [
-          { value: 'no', count: 6, suppressed: false },
-          { value: 'prefer_not_to_answer', count: 6, suppressed: false },
-          { value: 'yes', count: 6, suppressed: false },
-        ],
+        sex: {
+          suppressed: false,
+          buckets: [
+            { value: 'female', count: 10, suppressed: false },
+            { value: 'male', count: 10, suppressed: false },
+          ],
+        },
+        raceEthnicity: {
+          suppressed: false,
+          buckets: [
+            { value: 'white', count: 10, suppressed: false },
+            { value: 'black_or_african_american', count: 5, suppressed: false },
+            { value: null, count: 5, suppressed: false },
+          ],
+        },
+        veteranStatus: {
+          suppressed: false,
+          buckets: [
+            { value: 'not_protected_veteran', count: 15, suppressed: false },
+            { value: 'protected_veteran', count: 5, suppressed: false },
+          ],
+        },
+        disabilityStatus: {
+          suppressed: false,
+          buckets: [
+            { value: 'prefer_not_to_answer', count: 10, suppressed: false },
+            { value: 'no', count: 5, suppressed: false },
+            { value: null, count: 5, suppressed: false },
+          ],
+        },
       },
     })
   })

--- a/tests/unit/compliance-reporting.test.ts
+++ b/tests/unit/compliance-reporting.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MIN_COMPLIANCE_REPORTING_COHORT,
+  protectComplianceReporting,
+  type ComplianceReportingBreakdownsInput,
+} from '../../server/utils/complianceReporting'
+
+function makeBreakdowns(
+  overrides: Partial<ComplianceReportingBreakdownsInput> = {},
+): ComplianceReportingBreakdownsInput {
+  return {
+    sex: [],
+    raceEthnicity: [],
+    veteranStatus: [],
+    disabilityStatus: [],
+    ...overrides,
+  }
+}
+
+describe('compliance reporting privacy policy', () => {
+  it('suppresses all breakdowns when the response cohort is below five', () => {
+    const result = protectComplianceReporting(4, makeBreakdowns({
+      sex: [
+        { value: 'female', count: 3 },
+        { value: 'male', count: 1 },
+      ],
+    }))
+
+    expect(MIN_COMPLIANCE_REPORTING_COHORT).toBe(5)
+    expect(result).toEqual({
+      suppressed: true,
+      minimumCohortSize: 5,
+      breakdowns: {
+        sex: [],
+        raceEthnicity: [],
+        veteranStatus: [],
+        disabilityStatus: [],
+      },
+    })
+  })
+
+  it('hides small cells and complementarily suppresses the next-smallest cell', () => {
+    const result = protectComplianceReporting(20, makeBreakdowns({
+      raceEthnicity: [
+        { value: 'small-cell', count: 1 },
+        { value: 'largest-cell', count: 14 },
+        { value: 'next-smallest-cell', count: 5 },
+      ],
+    }))
+
+    expect(result.suppressed).toBe(true)
+    expect(result.breakdowns.raceEthnicity).toEqual([
+      { value: 'largest-cell', count: 14, suppressed: false },
+      { value: 'suppressed', count: null, suppressed: true },
+      { value: 'suppressed', count: null, suppressed: true },
+    ])
+    expect(JSON.stringify(result)).not.toContain('small-cell')
+    expect(JSON.stringify(result)).not.toContain('next-smallest-cell')
+  })
+
+  it('omits null buckets without confusing them with suppressed cells', () => {
+    const result = protectComplianceReporting(13, makeBreakdowns({
+      veteranStatus: [
+        { value: null, count: 3 },
+        { value: 'protected_veteran', count: 5 },
+        { value: 'not_protected_veteran', count: 5 },
+      ],
+    }))
+
+    expect(result.suppressed).toBe(false)
+    expect(result.breakdowns.veteranStatus).toEqual([
+      { value: 'not_protected_veteran', count: 5, suppressed: false },
+      { value: 'protected_veteran', count: 5, suppressed: false },
+    ])
+    expect(result.breakdowns.veteranStatus).not.toContainEqual(
+      expect.objectContaining({ value: null }),
+    )
+  })
+
+  it('returns normal counts in a deterministic order when every cell is reportable', () => {
+    const result = protectComplianceReporting(18, makeBreakdowns({
+      disabilityStatus: [
+        { value: 'yes', count: 6 },
+        { value: 'prefer_not_to_answer', count: 6 },
+        { value: 'no', count: 6 },
+      ],
+    }))
+
+    expect(result).toEqual({
+      suppressed: false,
+      minimumCohortSize: 5,
+      breakdowns: {
+        sex: [],
+        raceEthnicity: [],
+        veteranStatus: [],
+        disabilityStatus: [
+          { value: 'no', count: 6, suppressed: false },
+          { value: 'prefer_not_to_answer', count: 6, suppressed: false },
+          { value: 'yes', count: 6, suppressed: false },
+        ],
+      },
+    })
+  })
+})

--- a/tests/unit/compliance-summary-authorization.test.ts
+++ b/tests/unit/compliance-summary-authorization.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const eqMock = vi.hoisted(() =>
+  vi.fn((column: unknown, value: unknown) => ({ column, value })),
+)
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const original = await importOriginal<typeof import('drizzle-orm')>()
+
+  return {
+    ...original,
+    eq: eqMock,
+  }
+})
+
+const requirePermissionMock = vi.fn()
+const countQueryMock = vi.fn()
+const selectQueryMock = vi.fn()
+const aggregateWhereMocks: Array<ReturnType<typeof vi.fn>> = []
+
+function makeAggregateQuery() {
+  const query = {
+    from: vi.fn(),
+    where: vi.fn(),
+    groupBy: vi.fn(),
+    orderBy: vi.fn().mockResolvedValue([]),
+  }
+  query.from.mockReturnValue(query)
+  query.where.mockReturnValue(query)
+  query.groupBy.mockReturnValue(query)
+  aggregateWhereMocks.push(query.where)
+  return query
+}
+
+vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
+vi.stubGlobal('requirePermission', requirePermissionMock)
+vi.stubGlobal('db', {
+  $count: countQueryMock,
+  select: selectQueryMock,
+})
+
+const complianceSummaryHandler = (
+  await import('../../server/api/compliance/applications/summary.get')
+).default as (event: unknown) => Promise<unknown>
+
+describe('compliance summary authorization boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    aggregateWhereMocks.length = 0
+    countQueryMock.mockResolvedValue(5)
+    selectQueryMock.mockImplementation(makeAggregateQuery)
+  })
+
+  it('requires organization update permission before starting any aggregate query', async () => {
+    const event = { path: '/api/compliance/applications/summary' }
+    const forbidden = Object.assign(new Error('Forbidden'), { statusCode: 403 })
+    requirePermissionMock.mockRejectedValue(forbidden)
+
+    await expect(complianceSummaryHandler(event)).rejects.toBe(forbidden)
+
+    expect(requirePermissionMock).toHaveBeenCalledWith(event, {
+      organization: ['update'],
+    })
+    expect(countQueryMock).not.toHaveBeenCalled()
+    expect(selectQueryMock).not.toHaveBeenCalled()
+    expect(eqMock).not.toHaveBeenCalled()
+  })
+
+  it('scopes every aggregate query to the exact authorized organization ID', async () => {
+    const activeOrganizationId = 'org-authorized-exactly'
+    requirePermissionMock.mockResolvedValue({
+      session: { activeOrganizationId },
+    })
+
+    await complianceSummaryHandler({})
+
+    expect(countQueryMock).toHaveBeenCalledTimes(1)
+    expect(selectQueryMock).toHaveBeenCalledTimes(4)
+    expect(eqMock).toHaveBeenCalledTimes(5)
+    for (const [, organizationId] of eqMock.mock.calls) {
+      expect(organizationId).toBe(activeOrganizationId)
+    }
+
+    const organizationPredicates = eqMock.mock.results.map(result => result.value)
+    expect(countQueryMock.mock.calls[0]?.[1]).toBe(organizationPredicates[0])
+    expect(aggregateWhereMocks).toHaveLength(4)
+    aggregateWhereMocks.forEach((whereMock, index) => {
+      expect(whereMock).toHaveBeenCalledWith(organizationPredicates[index + 1])
+    })
+  })
+})

--- a/tests/unit/compliance-summary-authorization.test.ts
+++ b/tests/unit/compliance-summary-authorization.test.ts
@@ -18,12 +18,12 @@ const countQueryMock = vi.fn()
 const selectQueryMock = vi.fn()
 const aggregateWhereMocks: Array<ReturnType<typeof vi.fn>> = []
 
-function makeAggregateQuery() {
+function makeAggregateQuery(rows: Array<{ value: string | null, count: number }> = []) {
   const query = {
     from: vi.fn(),
     where: vi.fn(),
     groupBy: vi.fn(),
-    orderBy: vi.fn().mockResolvedValue([]),
+    orderBy: vi.fn().mockResolvedValue(rows),
   }
   query.from.mockReturnValue(query)
   query.where.mockReturnValue(query)
@@ -48,7 +48,7 @@ describe('compliance summary authorization boundary', () => {
     vi.clearAllMocks()
     aggregateWhereMocks.length = 0
     countQueryMock.mockResolvedValue(5)
-    selectQueryMock.mockImplementation(makeAggregateQuery)
+    selectQueryMock.mockImplementation(() => makeAggregateQuery())
   })
 
   it('requires organization update permission before starting any aggregate query', async () => {
@@ -87,5 +87,20 @@ describe('compliance summary authorization boundary', () => {
     aggregateWhereMocks.forEach((whereMock, index) => {
       expect(whereMock).toHaveBeenCalledWith(organizationPredicates[index + 1])
     })
+  })
+
+  it('returns the helper-protected total instead of a raw below-threshold count', async () => {
+    requirePermissionMock.mockResolvedValue({
+      session: { activeOrganizationId: 'org-private-cohort' },
+    })
+    countQueryMock.mockResolvedValue(4)
+    selectQueryMock.mockImplementation(() => makeAggregateQuery([
+      { value: null, count: 4 },
+    ]))
+
+    await expect(complianceSummaryHandler({})).resolves.toEqual(expect.objectContaining({
+      totalResponses: null,
+      suppressed: true,
+    }))
   })
 })

--- a/tests/unit/dashboard-stats-cache.test.ts
+++ b/tests/unit/dashboard-stats-cache.test.ts
@@ -7,10 +7,6 @@ describe('dashboard stats cache', () => {
     join(process.cwd(), 'server/api/dashboard/stats.get.ts'),
     'utf8',
   )
-  const httpCache = readFileSync(
-    join(process.cwd(), 'server/utils/httpCache.ts'),
-    'utf8',
-  )
 
   it('authorizes dashboard stats before calling the shared org-scoped data cache', () => {
     expect(stats).toContain('defineOrgScopedCachedFunction')
@@ -19,12 +15,5 @@ describe('dashboard stats cache', () => {
       stats.indexOf('return getCachedDashboardStats'),
     )
     expect(stats).not.toContain('defineCachedEventHandler')
-  })
-
-  it('keys cached data by authorized org, cache generation, and normalized input', () => {
-    expect(httpCache).toContain('defineCachedFunction')
-    expect(httpCache).toContain('getOrgDashboardCacheVersion(organizationId)')
-    expect(httpCache).toContain('hash(input)')
-    expect(httpCache).not.toContain("varies: ['cookie', 'authorization']")
   })
 })

--- a/tests/unit/dashboard-stats-cache.test.ts
+++ b/tests/unit/dashboard-stats-cache.test.ts
@@ -3,15 +3,28 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 describe('dashboard stats cache', () => {
-  const stats = readFileSync(join(process.cwd(), 'server/api/dashboard/stats.get.ts'), 'utf8')
-  const httpCache = readFileSync(join(process.cwd(), 'server/utils/httpCache.ts'), 'utf8')
+  const stats = readFileSync(
+    join(process.cwd(), 'server/api/dashboard/stats.get.ts'),
+    'utf8',
+  )
+  const httpCache = readFileSync(
+    join(process.cwd(), 'server/utils/httpCache.ts'),
+    'utf8',
+  )
 
-  it('routes dashboard stats through the shared org-scoped cache helper', () => {
-    expect(stats).toContain('defineCachedEventHandler')
-    expect(stats).toContain('orgScopedCacheOptions')
+  it('authorizes dashboard stats before calling the shared org-scoped data cache', () => {
+    expect(stats).toContain('defineOrgScopedCachedFunction')
+    expect(stats).toContain('defineEventHandler')
+    expect(stats.indexOf('requirePermission')).toBeLessThan(
+      stats.indexOf('return getCachedDashboardStats'),
+    )
+    expect(stats).not.toContain('defineCachedEventHandler')
   })
 
-  it('varies by cookie and bearer tokens so the cached handler preserves auth headers', () => {
-    expect(httpCache).toContain("varies: ['cookie', 'authorization']")
+  it('keys cached data by authorized org, cache generation, and normalized input', () => {
+    expect(httpCache).toContain('defineCachedFunction')
+    expect(httpCache).toContain('getOrgDashboardCacheVersion(organizationId)')
+    expect(httpCache).toContain('hash(input)')
+    expect(httpCache).not.toContain("varies: ['cookie', 'authorization']")
   })
 })

--- a/tests/unit/drizzle-config-secrets.test.ts
+++ b/tests/unit/drizzle-config-secrets.test.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = process.cwd()
+const databaseEnvKeys = [
+  'DATABASE_URL',
+  'PGHOST',
+  'PGPORT',
+  'PGUSER',
+  'PGPASSWORD',
+  'PGDATABASE',
+  'RAILWAY_TCP_PROXY_DOMAIN',
+  'RAILWAY_TCP_PROXY_PORT',
+] as const
+
+function runDrizzleConfig(overrides: Record<string, string | undefined>) {
+  const env: NodeJS.ProcessEnv = { ...process.env }
+  for (const key of databaseEnvKeys) delete env[key]
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete env[key]
+    else env[key] = value
+  }
+
+  return spawnSync(process.execPath, [
+    '--import',
+    'tsx',
+    '--input-type=module',
+    '-e',
+    "const config = (await import('./drizzle.config.ts')).default; console.log(config.dbCredentials.url)",
+  ], {
+    cwd: root,
+    env,
+    encoding: 'utf8',
+  })
+}
+
+function combinedOutput(result: ReturnType<typeof runDrizzleConfig>): string {
+  return `${result.stdout ?? ''}\n${result.stderr ?? ''}`
+}
+
+describe('drizzle database URL diagnostics', () => {
+  it('does not interpolate the raw DATABASE_URL in the thrown diagnostic', () => {
+    const source = readFileSync(resolve(root, 'drizzle.config.ts'), 'utf8')
+    const throwBlock = source.slice(source.indexOf('throw new Error'))
+
+    expect(source).not.toContain('Raw DATABASE_URL')
+    expect(throwBlock).not.toContain('${raw}')
+  })
+
+  it('never includes invalid direct URL secret material in errors', () => {
+    const rawUrl = 'postgresql://leak-user:leak-password@leak-host.example:bad-port/leak-db?token=leak-token'
+    const result = runDrizzleConfig({ DATABASE_URL: rawUrl })
+    const output = combinedOutput(result)
+
+    expect(result.status).not.toBe(0)
+    for (const secret of [
+      rawUrl,
+      'leak-user',
+      'leak-password',
+      'leak-host.example',
+      'leak-db',
+      'leak-token',
+    ]) {
+      expect(output).not.toContain(secret)
+    }
+    expect(output).toContain('DATABASE_URL hostname')
+    expect(output).toContain('PGHOST')
+    expect(output).toContain('RAILWAY_TCP_PROXY_DOMAIN')
+  })
+
+  it('names only missing variable categories when no usable host is configured', () => {
+    const sentinels = {
+      PGUSER: 'fallback-secret-user',
+      PGPASSWORD: 'fallback-secret-password',
+      PGDATABASE: 'fallback-secret-database',
+      PGPORT: 'fallback-secret-port',
+    }
+    const result = runDrizzleConfig(sentinels)
+    const output = combinedOutput(result)
+
+    expect(result.status).not.toBe(0)
+    for (const secret of Object.values(sentinels)) expect(output).not.toContain(secret)
+    expect(output).toContain('DATABASE_URL hostname')
+    expect(output).toContain('PGHOST')
+    expect(output).toContain('RAILWAY_TCP_PROXY_DOMAIN')
+  })
+
+  it('preserves a valid direct DATABASE_URL verbatim', () => {
+    const directUrl = 'postgresql://direct-user:direct-password@db.internal:5432/careers'
+    const result = runDrizzleConfig({ DATABASE_URL: directUrl })
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe('')
+    expect(result.stdout.trim()).toBe(directUrl)
+  })
+
+  it('preserves PG fallback URL reconstruction when DATABASE_URL has no hostname', () => {
+    const result = runDrizzleConfig({
+      DATABASE_URL: 'postgresql:///',
+      PGHOST: 'fallback.internal',
+      PGPORT: '6543',
+      PGUSER: 'fallback user',
+      PGPASSWORD: 'p@ss/word',
+      PGDATABASE: 'careers',
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe('')
+    expect(result.stdout.trim()).toBe(
+      'postgresql://fallback%20user:p%40ss%2Fword@fallback.internal:6543/careers',
+    )
+  })
+})

--- a/tests/unit/google-calendar-callback-scope.test.ts
+++ b/tests/unit/google-calendar-callback-scope.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const googleCalendarMocks = vi.hoisted(() => ({
+  exchangeCodeForTokens: vi.fn(),
+  saveCalendarIntegration: vi.fn(),
+  setupCalendarWebhook: vi.fn(),
+  getGoogleAuthUrl: vi.fn(),
+  isGoogleCalendarConfigured: vi.fn(),
+}))
+
+vi.mock('../../server/utils/google-calendar', () => googleCalendarMocks)
+
+const handleCalendarOAuthCallbackMock = vi.hoisted(() => vi.fn())
+const initiateCalendarOAuthMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../server/utils/calendarOAuth', () => ({
+  handleCalendarOAuthCallback: handleCalendarOAuthCallbackMock,
+  initiateCalendarOAuth: initiateCalendarOAuthMock,
+}))
+
+const requireAuthMock = vi.fn()
+const requirePermissionMock = vi.fn()
+
+vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
+vi.stubGlobal('requireAuth', requireAuthMock)
+vi.stubGlobal('requirePermission', requirePermissionMock)
+vi.stubGlobal('createError', (options: { statusCode: number, statusMessage?: string }) =>
+  Object.assign(new Error(options.statusMessage), options),
+)
+vi.stubGlobal('logWarn', vi.fn())
+
+const callbackHandler = (
+  await import('../../server/api/calendar/google/callback.get')
+).default as (event: unknown) => Promise<unknown>
+const connectHandler = (
+  await import('../../server/api/calendar/google/connect.get')
+).default as (event: unknown) => Promise<unknown>
+
+describe('Google Calendar OAuth callback organization scope', () => {
+  function mockAuthorizedSession(session: unknown) {
+    requireAuthMock.mockResolvedValue(session)
+    requirePermissionMock.mockResolvedValue(session)
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    googleCalendarMocks.exchangeCodeForTokens.mockResolvedValue({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      email: 'calendar@example.com',
+    })
+    googleCalendarMocks.saveCalendarIntegration.mockResolvedValue({
+      integrationId: 'integration-exact',
+      userId: 'user-1',
+      organizationId: 'org-active',
+    })
+    googleCalendarMocks.setupCalendarWebhook.mockResolvedValue(true)
+    googleCalendarMocks.isGoogleCalendarConfigured.mockReturnValue(true)
+    initiateCalendarOAuthMock.mockResolvedValue({ redirected: true })
+    handleCalendarOAuthCallbackMock.mockImplementation(async (_event, options) => {
+      await options.onSuccess({
+        code: 'authorization-code',
+        extraCookies: { gcal_oauth_org: 'org-active' },
+      })
+      return { redirected: true }
+    })
+  })
+
+  it('binds Google OAuth initiation to the exact active organization cookie', async () => {
+    mockAuthorizedSession({
+      user: { id: 'user-1' },
+      session: { activeOrganizationId: 'org-active' },
+    })
+
+    await connectHandler({})
+
+    expect(requirePermissionMock).toHaveBeenCalledWith({}, {
+      organization: ['update'],
+    })
+    expect(initiateCalendarOAuthMock).toHaveBeenCalledWith({}, expect.objectContaining({
+      stateCookieName: 'gcal_oauth_state',
+      extraCookies: [{ name: 'gcal_oauth_org', value: 'org-active' }],
+    }))
+  })
+
+  it('fails closed before OAuth initiation when no active organization is present', async () => {
+    mockAuthorizedSession({
+      user: { id: 'user-1' },
+      session: { activeOrganizationId: null },
+    })
+
+    await expect(connectHandler({})).rejects.toMatchObject({
+      statusCode: 403,
+      message: 'No active organization',
+    })
+
+    expect(initiateCalendarOAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed before provider work when the authenticated session has no active organization', async () => {
+    mockAuthorizedSession({
+      user: { id: 'user-1' },
+      session: { activeOrganizationId: null },
+    })
+
+    await expect(callbackHandler({})).rejects.toMatchObject({
+      statusCode: 403,
+      message: 'No active organization',
+    })
+
+    expect(handleCalendarOAuthCallbackMock).not.toHaveBeenCalled()
+    expect(googleCalendarMocks.exchangeCodeForTokens).not.toHaveBeenCalled()
+    expect(googleCalendarMocks.saveCalendarIntegration).not.toHaveBeenCalled()
+    expect(googleCalendarMocks.setupCalendarWebhook).not.toHaveBeenCalled()
+  })
+
+  it('persists the active organization and sets up the exact saved integration', async () => {
+    const tokens = {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      email: 'calendar@example.com',
+    }
+    mockAuthorizedSession({
+      user: { id: 'user-1' },
+      session: { activeOrganizationId: 'org-active' },
+    })
+    googleCalendarMocks.exchangeCodeForTokens.mockResolvedValue(tokens)
+
+    await callbackHandler({})
+
+    expect(requirePermissionMock).toHaveBeenCalledWith({}, {
+      organization: ['update'],
+    })
+    expect(handleCalendarOAuthCallbackMock).toHaveBeenCalledWith({}, expect.objectContaining({
+      extraCookieNames: ['gcal_oauth_org'],
+    }))
+    expect(googleCalendarMocks.saveCalendarIntegration).toHaveBeenCalledWith(
+      'user-1',
+      'org-active',
+      tokens,
+    )
+    expect(googleCalendarMocks.setupCalendarWebhook).toHaveBeenCalledWith({
+      integrationId: 'integration-exact',
+      userId: 'user-1',
+      organizationId: 'org-active',
+    })
+  })
+
+  it('rejects an OAuth callback when the active organization differs from the initiation cookie', async () => {
+    mockAuthorizedSession({
+      user: { id: 'user-1' },
+      session: { activeOrganizationId: 'org-current' },
+    })
+    handleCalendarOAuthCallbackMock.mockImplementation(async (_event, options) => {
+      await options.onSuccess({
+        code: 'authorization-code',
+        extraCookies: { gcal_oauth_org: 'org-initiated' },
+      })
+    })
+
+    await expect(callbackHandler({})).rejects.toThrow(
+      'Google Calendar organization changed during authorization',
+    )
+
+    expect(googleCalendarMocks.exchangeCodeForTokens).not.toHaveBeenCalled()
+    expect(googleCalendarMocks.saveCalendarIntegration).not.toHaveBeenCalled()
+    expect(googleCalendarMocks.setupCalendarWebhook).not.toHaveBeenCalled()
+  })
+
+  it('does no provider work when organization update permission is denied', async () => {
+    const forbidden = Object.assign(new Error('Forbidden'), { statusCode: 403 })
+    requirePermissionMock.mockRejectedValue(forbidden)
+    requireAuthMock.mockResolvedValue({
+      user: { id: 'user-1' },
+      session: { activeOrganizationId: 'org-active' },
+    })
+
+    await expect(callbackHandler({})).rejects.toBe(forbidden)
+
+    expect(handleCalendarOAuthCallbackMock).not.toHaveBeenCalled()
+    expect(googleCalendarMocks.exchangeCodeForTokens).not.toHaveBeenCalled()
+    expect(googleCalendarMocks.saveCalendarIntegration).not.toHaveBeenCalled()
+    expect(googleCalendarMocks.setupCalendarWebhook).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/google-calendar-integration-scope.test.ts
+++ b/tests/unit/google-calendar-integration-scope.test.ts
@@ -48,7 +48,8 @@ updateWhereMock.mockImplementation(() => ({ returning: updateReturningMock }))
 const updateSetMock = vi.fn(() => ({ where: updateWhereMock }))
 const insertReturningMock = vi.fn()
 const insertValuesMock = vi.fn(() => ({ returning: insertReturningMock }))
-const deleteWhereMock = vi.fn()
+const deleteReturningMock = vi.fn()
+const deleteWhereMock = vi.fn(() => ({ returning: deleteReturningMock }))
 const selectWhereMock = vi.fn(() => ({ query: 'credential-generation' }))
 const selectFromMock = vi.fn(() => ({ where: selectWhereMock }))
 const selectMock = vi.fn(() => ({ from: selectFromMock }))
@@ -108,6 +109,7 @@ type PerformIncrementalSync = (identity: {
 const saveCalendarIntegration = googleCalendar.saveCalendarIntegration as unknown as SaveCalendarIntegration
 const setupCalendarWebhook = googleCalendar.setupCalendarWebhook as unknown as SetupCalendarWebhook
 const performIncrementalSync = googleCalendar.performIncrementalSync as unknown as PerformIncrementalSync
+const removeCalendarIntegration = googleCalendar.removeCalendarIntegration
 const { interview } = await import('../../server/database/schema')
 
 function expectExactGoogleScope(
@@ -132,7 +134,7 @@ describe('Google Calendar integration identity scope', () => {
     vi.clearAllMocks()
     updateReturningMock.mockResolvedValue([{ id: 'integration-existing' }])
     insertReturningMock.mockResolvedValue([{ id: 'integration-inserted' }])
-    deleteWhereMock.mockResolvedValue([])
+    deleteReturningMock.mockResolvedValue([{ id: 'integration-deleted' }])
     calendarClient.channels.stop.mockResolvedValue({})
     calendarClient.events.watch.mockResolvedValue({
       data: { resourceId: 'resource-exact', expiration: '1780000000000' },
@@ -459,6 +461,82 @@ describe('Google Calendar integration identity scope', () => {
         },
       ]),
     }))
+  })
+
+  it('does not delete reconnected Google credentials after stale provider cleanup finishes', async () => {
+    const identity = {
+      integrationId: 'integration-disconnect-race',
+      userId: 'user-disconnect-race',
+      organizationId: 'org-disconnect-race',
+      connectionGeneration: 'connection-old',
+    }
+    deleteReturningMock.mockResolvedValueOnce([])
+
+    await expect(removeCalendarIntegration(identity)).resolves.toBe(false)
+
+    expect(calendarClient.channels.stop).not.toHaveBeenCalled()
+    expect(deleteWhereMock).toHaveBeenCalledWith(expect.objectContaining({
+      operator: 'and',
+      conditions: expect.arrayContaining([{
+        operator: 'eq',
+        column: calendarIntegration.connectionGeneration,
+        value: 'connection-old',
+      }]),
+    }))
+  })
+
+  it('allows a legacy null-token Google row to disconnect with a null-generation CAS', async () => {
+    const snapshot = {
+      integrationId: 'integration-null-token',
+      userId: 'user-null-token',
+      organizationId: 'org-null-token',
+      connectionGeneration: 'connection-null-token',
+    }
+    deleteReturningMock.mockResolvedValueOnce([{
+      id: snapshot.integrationId,
+      accessTokenEncrypted: null,
+      refreshTokenEncrypted: null,
+      webhookChannelId: null,
+      webhookResourceId: null,
+    }])
+
+    await removeCalendarIntegration(snapshot)
+
+    expect(deleteWhereMock).toHaveBeenCalledWith(expect.objectContaining({
+      operator: 'and',
+      conditions: expect.arrayContaining([{
+        operator: 'eq',
+        column: calendarIntegration.connectionGeneration,
+        value: 'connection-null-token',
+      }]),
+    }))
+    expect(calendarClient.channels.stop).not.toHaveBeenCalled()
+  })
+
+  it('claims the Google row before stopping its previous webhook channel', async () => {
+    const snapshot = {
+      integrationId: 'integration-claim-first',
+      userId: 'user-claim-first',
+      organizationId: 'org-claim-first',
+      connectionGeneration: 'connection-claim-first',
+    }
+    deleteReturningMock.mockResolvedValueOnce([{
+      id: snapshot.integrationId,
+      accessTokenEncrypted: 'stored-access',
+      refreshTokenEncrypted: 'stored-refresh',
+      webhookChannelId: 'channel-old',
+      webhookResourceId: 'resource-old',
+    }])
+    calendarClient.channels.stop.mockImplementationOnce(async () => {
+      expect(deleteReturningMock).toHaveBeenCalledTimes(1)
+      return {}
+    })
+
+    await expect(removeCalendarIntegration(snapshot)).resolves.toBe(true)
+
+    expect(calendarClient.channels.stop).toHaveBeenCalledWith({
+      requestBody: { id: 'channel-old', resourceId: 'resource-old' },
+    })
   })
 
   it('scopes attendee synchronization to the integration organization', async () => {

--- a/tests/unit/google-calendar-integration-scope.test.ts
+++ b/tests/unit/google-calendar-integration-scope.test.ts
@@ -20,6 +20,9 @@ const calendarClient = vi.hoisted(() => ({
   events: {
     watch: vi.fn(),
     list: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    insert: vi.fn(),
   },
 }))
 
@@ -130,6 +133,8 @@ describe('Google Calendar integration identity scope', () => {
       data: { resourceId: 'resource-exact', expiration: '1780000000000' },
     })
     calendarClient.events.list.mockResolvedValue({ data: { items: [] } })
+    calendarClient.events.patch.mockResolvedValue({ data: { htmlLink: 'https://calendar/event' } })
+    calendarClient.events.delete.mockResolvedValue({})
   })
 
   it('binds an existing Google integration to the active organization and returns its exact id', async () => {
@@ -337,6 +342,30 @@ describe('Google Calendar integration identity scope', () => {
     })
   })
 
+  it('uses exact integration identity for ordinary event operations', async () => {
+    const identity = {
+      integrationId: 'integration-event',
+      userId: 'user-event',
+      organizationId: 'org-event',
+    }
+    findFirstMock.mockResolvedValue({
+      id: identity.integrationId,
+      userId: identity.userId,
+      organizationId: identity.organizationId,
+      provider: 'google',
+      accessTokenEncrypted: 'stored-access',
+      refreshTokenEncrypted: 'stored-refresh',
+      calendarId: 'primary',
+    })
+
+    await expect(googleCalendar.updateCalendarEvent(identity, 'event-1', {}))
+      .resolves.toBe('https://calendar/event')
+
+    for (const [{ where }] of findFirstMock.mock.calls) {
+      expectExactGoogleScope(where, identity)
+    }
+  })
+
   it('scopes attendee synchronization to the integration organization', async () => {
     const identity = {
       integrationId: 'integration-sync',
@@ -354,9 +383,18 @@ describe('Google Calendar integration identity scope', () => {
       syncToken: null,
     })
     calendarClient.events.list.mockResolvedValue({
-      data: { items: [{ id: 'event-shared-provider-id' }] },
+      data: {
+        items: [{
+          id: 'event-shared-provider-id',
+          attendees: [{ email: 'candidate@example.com', responseStatus: 'accepted' }],
+        }],
+      },
     })
-    interviewFindFirstMock.mockResolvedValue(null)
+    interviewFindFirstMock.mockResolvedValue({
+      id: 'interview-exact',
+      candidateResponse: 'pending',
+      application: { candidate: { email: 'candidate@example.com' } },
+    })
 
     await performIncrementalSync(identity)
 
@@ -369,5 +407,37 @@ describe('Google Calendar integration identity scope', () => {
         ]),
       }),
     }))
+    expect(updateWhereMock).toHaveBeenCalledWith(expect.objectContaining({
+      operator: 'and',
+      conditions: expect.arrayContaining([
+        { operator: 'eq', column: interview.id, value: 'interview-exact' },
+        { operator: 'eq', column: interview.organizationId, value: 'org-sync' },
+      ]),
+    }))
+  })
+
+  it('does not mutate attendee state for an unowned legacy integration', async () => {
+    const identity = {
+      integrationId: 'integration-legacy-sync',
+      userId: 'user-legacy-sync',
+      organizationId: null,
+    }
+    findFirstMock.mockResolvedValue({
+      id: identity.integrationId,
+      userId: identity.userId,
+      organizationId: null,
+      provider: 'google',
+      accessTokenEncrypted: 'stored-access',
+      refreshTokenEncrypted: 'stored-refresh',
+      calendarId: 'primary',
+      syncToken: null,
+    })
+    calendarClient.events.list.mockResolvedValue({
+      data: { items: [{ id: 'event-unowned', attendees: [] }] },
+    })
+
+    await performIncrementalSync(identity)
+
+    expect(interviewFindFirstMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/google-calendar-integration-scope.test.ts
+++ b/tests/unit/google-calendar-integration-scope.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const drizzleMocks = vi.hoisted(() => ({
   and: vi.fn((...conditions: unknown[]) => ({ operator: 'and', conditions })),
   eq: vi.fn((column: unknown, value: unknown) => ({ operator: 'eq', column, value })),
+  exists: vi.fn((query: unknown) => ({ operator: 'exists', query })),
   isNull: vi.fn((column: unknown) => ({ operator: 'isNull', column })),
 }))
 
@@ -48,6 +49,9 @@ const updateSetMock = vi.fn(() => ({ where: updateWhereMock }))
 const insertReturningMock = vi.fn()
 const insertValuesMock = vi.fn(() => ({ returning: insertReturningMock }))
 const deleteWhereMock = vi.fn()
+const selectWhereMock = vi.fn(() => ({ query: 'credential-generation' }))
+const selectFromMock = vi.fn(() => ({ where: selectWhereMock }))
+const selectMock = vi.fn(() => ({ from: selectFromMock }))
 
 vi.stubGlobal('env', {
   BETTER_AUTH_SECRET: 'test-auth-secret',
@@ -63,6 +67,7 @@ const transactionClient = {
   update: vi.fn(() => ({ set: updateSetMock })),
   insert: vi.fn(() => ({ values: insertValuesMock })),
   delete: vi.fn(() => ({ where: deleteWhereMock })),
+  select: selectMock,
 }
 vi.stubGlobal('db', {
   ...transactionClient,
@@ -356,8 +361,44 @@ describe('Google Calendar integration identity scope', () => {
       operator: 'and',
       conditions: expect.arrayContaining([{
         operator: 'eq',
-        column: calendarIntegration.accessTokenEncrypted,
-        value: 'stored-access',
+        column: calendarIntegration.refreshTokenEncrypted,
+        value: 'stored-refresh',
+      }]),
+    }))
+  })
+
+  it('keeps webhook setup valid when its access token refreshes during watch creation', async () => {
+    const identity = {
+      integrationId: 'integration-token-refresh',
+      userId: 'user-token-refresh',
+      organizationId: 'org-token-refresh',
+    }
+    findFirstMock.mockResolvedValue({
+      id: identity.integrationId,
+      userId: identity.userId,
+      organizationId: identity.organizationId,
+      provider: 'google',
+      accessTokenEncrypted: 'stored-access',
+      refreshTokenEncrypted: 'stable-refresh-generation',
+      calendarId: 'primary',
+      webhookChannelId: null,
+      webhookResourceId: null,
+      syncToken: null,
+    })
+    calendarClient.events.watch.mockImplementationOnce(async () => {
+      const tokenListener = oauthClient.on.mock.calls.find(([event]) => event === 'tokens')?.[1]
+      await tokenListener({ access_token: 'rotated-access-token' })
+      return { data: { resourceId: 'resource-exact', expiration: '1780000000000' } }
+    })
+
+    await expect(setupCalendarWebhook(identity)).resolves.toBe(true)
+
+    expect(updateWhereMock).toHaveBeenCalledWith(expect.objectContaining({
+      operator: 'and',
+      conditions: expect.arrayContaining([{
+        operator: 'eq',
+        column: calendarIntegration.refreshTokenEncrypted,
+        value: 'stable-refresh-generation',
       }]),
     }))
   })
@@ -493,5 +534,43 @@ describe('Google Calendar integration identity scope', () => {
     await performIncrementalSync(identity)
 
     expect(interviewFindFirstMock).not.toHaveBeenCalled()
+  })
+
+  it('drops stale-account sync results when OAuth reconnect changes credential generation', async () => {
+    const identity = {
+      integrationId: 'integration-sync-race',
+      userId: 'user-sync-race',
+      organizationId: 'org-sync-race',
+    }
+    const oldGeneration = {
+      id: identity.integrationId,
+      userId: identity.userId,
+      organizationId: identity.organizationId,
+      provider: 'google',
+      accessTokenEncrypted: 'stored-access-old',
+      refreshTokenEncrypted: 'stored-refresh-old',
+      calendarId: 'primary',
+      syncToken: null,
+    }
+    findFirstMock
+      .mockResolvedValueOnce(oldGeneration)
+      .mockResolvedValueOnce(oldGeneration)
+      .mockResolvedValueOnce(null)
+    calendarClient.events.list.mockResolvedValue({
+      data: {
+        items: [{
+          id: 'event-from-old-account',
+          attendees: [{ email: 'candidate@example.com', responseStatus: 'accepted' }],
+        }],
+        nextSyncToken: 'old-account-sync-token',
+      },
+    })
+
+    await performIncrementalSync(identity)
+
+    expect(interviewFindFirstMock).not.toHaveBeenCalled()
+    expect(updateSetMock).not.toHaveBeenCalledWith(expect.objectContaining({
+      syncToken: 'old-account-sync-token',
+    }))
   })
 })

--- a/tests/unit/google-calendar-integration-scope.test.ts
+++ b/tests/unit/google-calendar-integration-scope.test.ts
@@ -150,6 +150,10 @@ describe('Google Calendar integration identity scope', () => {
 
     expect(updateSetMock).toHaveBeenCalledWith(expect.objectContaining({
       organizationId: 'org-active',
+      webhookChannelId: null,
+      webhookResourceId: null,
+      webhookExpiration: null,
+      syncToken: null,
     }))
     expect(updateWhereMock).toHaveBeenCalledWith(expect.objectContaining({
       operator: 'and',
@@ -312,7 +316,7 @@ describe('Google Calendar integration identity scope', () => {
     }
   })
 
-  it('stops a newly-created channel when the compare-and-set update loses a race', async () => {
+  it('stops a stale-generation channel when OAuth reconnect wins before metadata CAS', async () => {
     const identity = {
       integrationId: 'integration-raced',
       userId: 'user-raced',
@@ -330,7 +334,15 @@ describe('Google Calendar integration identity scope', () => {
       webhookResourceId: 'previous-resource',
       syncToken: null,
     })
-    updateReturningMock.mockResolvedValueOnce([])
+    let reconnectCompleted = false
+    calendarClient.events.watch.mockImplementationOnce(async () => {
+      reconnectCompleted = true
+      return { data: { resourceId: 'resource-exact', expiration: '1780000000000' } }
+    })
+    updateReturningMock.mockImplementationOnce(async () => {
+      expect(reconnectCompleted).toBe(true)
+      return []
+    })
 
     await expect(setupCalendarWebhook(identity)).resolves.toBe(false)
 
@@ -340,6 +352,14 @@ describe('Google Calendar integration identity scope', () => {
         resourceId: 'resource-exact',
       },
     })
+    expect(updateWhereMock).toHaveBeenCalledWith(expect.objectContaining({
+      operator: 'and',
+      conditions: expect.arrayContaining([{
+        operator: 'eq',
+        column: calendarIntegration.accessTokenEncrypted,
+        value: 'stored-access',
+      }]),
+    }))
   })
 
   it('uses exact integration identity for ordinary event operations', async () => {
@@ -364,6 +384,40 @@ describe('Google Calendar integration identity scope', () => {
     for (const [{ where }] of findFirstMock.mock.calls) {
       expectExactGoogleScope(where, identity)
     }
+  })
+
+  it('does not let an old OAuth client overwrite credentials after reconnect', async () => {
+    const identity = {
+      integrationId: 'integration-refresh',
+      userId: 'user-refresh',
+      organizationId: 'org-refresh',
+    }
+    findFirstMock.mockResolvedValue({
+      id: identity.integrationId,
+      userId: identity.userId,
+      organizationId: identity.organizationId,
+      provider: 'google',
+      accessTokenEncrypted: 'stored-access-version',
+      refreshTokenEncrypted: 'stored-refresh',
+    })
+
+    await googleCalendar.getCalendarClient(identity)
+    const tokenListener = oauthClient.on.mock.calls.find(([event]) => event === 'tokens')?.[1]
+    expect(tokenListener).toBeTypeOf('function')
+    await tokenListener({ access_token: 'refreshed-from-old-client' })
+
+    expect(updateWhereMock).toHaveBeenCalledWith(expect.objectContaining({
+      operator: 'and',
+      conditions: expect.arrayContaining([
+        { operator: 'eq', column: calendarIntegration.id, value: identity.integrationId },
+        { operator: 'eq', column: calendarIntegration.organizationId, value: identity.organizationId },
+        {
+          operator: 'eq',
+          column: calendarIntegration.accessTokenEncrypted,
+          value: 'stored-access-version',
+        },
+      ]),
+    }))
   })
 
   it('scopes attendee synchronization to the integration organization', async () => {

--- a/tests/unit/google-calendar-integration-scope.test.ts
+++ b/tests/unit/google-calendar-integration-scope.test.ts
@@ -1,0 +1,373 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const drizzleMocks = vi.hoisted(() => ({
+  and: vi.fn((...conditions: unknown[]) => ({ operator: 'and', conditions })),
+  eq: vi.fn((column: unknown, value: unknown) => ({ operator: 'eq', column, value })),
+  isNull: vi.fn((column: unknown) => ({ operator: 'isNull', column })),
+}))
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const original = await importOriginal<typeof import('drizzle-orm')>()
+  return { ...original, ...drizzleMocks }
+})
+
+const oauthClient = vi.hoisted(() => ({
+  setCredentials: vi.fn(),
+  on: vi.fn(),
+}))
+const calendarClient = vi.hoisted(() => ({
+  channels: { stop: vi.fn() },
+  events: {
+    watch: vi.fn(),
+    list: vi.fn(),
+  },
+}))
+
+vi.mock('googleapis', () => ({
+  google: {
+    auth: { OAuth2: vi.fn(function OAuth2Client() { return oauthClient }) },
+    calendar: vi.fn(() => calendarClient),
+    oauth2: vi.fn(),
+  },
+}))
+
+vi.mock('../../server/utils/encryption', () => ({
+  encrypt: vi.fn((value: string) => `encrypted:${value}`),
+  decrypt: vi.fn((value: string) => `decrypted:${value}`),
+}))
+
+const findFirstMock = vi.fn()
+const interviewFindFirstMock = vi.fn()
+const updateReturningMock = vi.fn()
+const updateWhereMock = vi.fn()
+updateWhereMock.mockImplementation(() => ({ returning: updateReturningMock }))
+const updateSetMock = vi.fn(() => ({ where: updateWhereMock }))
+const insertReturningMock = vi.fn()
+const insertValuesMock = vi.fn(() => ({ returning: insertReturningMock }))
+const deleteWhereMock = vi.fn()
+
+vi.stubGlobal('env', {
+  BETTER_AUTH_SECRET: 'test-auth-secret',
+  GOOGLE_CLIENT_ID: 'google-client-id',
+  GOOGLE_CLIENT_SECRET: 'google-client-secret',
+  BETTER_AUTH_URL: 'https://careers.example.com',
+})
+const transactionClient = {
+  query: {
+    calendarIntegration: { findFirst: findFirstMock },
+    interview: { findFirst: interviewFindFirstMock },
+  },
+  update: vi.fn(() => ({ set: updateSetMock })),
+  insert: vi.fn(() => ({ values: insertValuesMock })),
+  delete: vi.fn(() => ({ where: deleteWhereMock })),
+}
+vi.stubGlobal('db', {
+  ...transactionClient,
+  transaction: vi.fn(async (callback: (tx: typeof transactionClient) => Promise<unknown>) =>
+    await callback(transactionClient)),
+})
+vi.stubGlobal('logError', vi.fn())
+vi.stubGlobal('logWarn', vi.fn())
+vi.stubGlobal('createError', (options: { statusCode: number, statusMessage?: string }) =>
+  Object.assign(new Error(options.statusMessage), options),
+)
+
+const googleCalendar = await import('../../server/utils/google-calendar')
+const { calendarIntegration } = await import('../../server/database/schema')
+
+type SaveCalendarIntegration = (
+  userId: string,
+  organizationId: string,
+  params: { accessToken: string, refreshToken: string, email: string | null },
+) => Promise<{
+  integrationId: string
+  userId: string
+  organizationId: string | null
+}>
+
+type SetupCalendarWebhook = (identity: {
+  integrationId: string
+  userId: string
+  organizationId: string | null
+}) => Promise<boolean>
+
+type PerformIncrementalSync = (identity: {
+  integrationId: string
+  userId: string
+  organizationId: string | null
+}) => Promise<void>
+
+const saveCalendarIntegration = googleCalendar.saveCalendarIntegration as unknown as SaveCalendarIntegration
+const setupCalendarWebhook = googleCalendar.setupCalendarWebhook as unknown as SetupCalendarWebhook
+const performIncrementalSync = googleCalendar.performIncrementalSync as unknown as PerformIncrementalSync
+const { interview } = await import('../../server/database/schema')
+
+function expectExactGoogleScope(
+  expression: unknown,
+  identity: { integrationId: string, userId: string, organizationId: string | null },
+) {
+  expect(expression).toEqual(expect.objectContaining({
+    operator: 'and',
+    conditions: expect.arrayContaining([
+      { operator: 'eq', column: calendarIntegration.id, value: identity.integrationId },
+      { operator: 'eq', column: calendarIntegration.userId, value: identity.userId },
+      { operator: 'eq', column: calendarIntegration.provider, value: 'google' },
+      ...(identity.organizationId
+        ? [{ operator: 'eq', column: calendarIntegration.organizationId, value: identity.organizationId }]
+        : [{ operator: 'isNull', column: calendarIntegration.organizationId }]),
+    ]),
+  }))
+}
+
+describe('Google Calendar integration identity scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    updateReturningMock.mockResolvedValue([{ id: 'integration-existing' }])
+    insertReturningMock.mockResolvedValue([{ id: 'integration-inserted' }])
+    deleteWhereMock.mockResolvedValue([])
+    calendarClient.channels.stop.mockResolvedValue({})
+    calendarClient.events.watch.mockResolvedValue({
+      data: { resourceId: 'resource-exact', expiration: '1780000000000' },
+    })
+    calendarClient.events.list.mockResolvedValue({ data: { items: [] } })
+  })
+
+  it('binds an existing Google integration to the active organization and returns its exact id', async () => {
+    findFirstMock
+      .mockResolvedValueOnce({ id: 'integration-existing', organizationId: 'org-active' })
+      .mockResolvedValueOnce({ id: 'integration-existing', organizationId: 'org-active' })
+
+    const integrationId = await saveCalendarIntegration('user-1', 'org-active', {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      email: 'calendar@example.com',
+    })
+
+    expect(updateSetMock).toHaveBeenCalledWith(expect.objectContaining({
+      organizationId: 'org-active',
+    }))
+    expect(updateWhereMock).toHaveBeenCalledWith(expect.objectContaining({
+      operator: 'and',
+      conditions: expect.arrayContaining([
+        { operator: 'eq', column: calendarIntegration.id, value: 'integration-existing' },
+        { operator: 'eq', column: calendarIntegration.userId, value: 'user-1' },
+        { operator: 'eq', column: calendarIntegration.provider, value: 'google' },
+      ]),
+    }))
+    expect(integrationId).toEqual({
+      integrationId: 'integration-existing',
+      userId: 'user-1',
+      organizationId: 'org-active',
+    })
+  })
+
+  it('inserts a new Google integration with organization ownership and returns its exact id', async () => {
+    findFirstMock.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
+
+    const integrationId = await saveCalendarIntegration('user-1', 'org-active', {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      email: null,
+    })
+
+    expect(insertValuesMock).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user-1',
+      organizationId: 'org-active',
+      provider: 'google',
+    }))
+    expect(deleteWhereMock).not.toHaveBeenCalled()
+    expect(integrationId).toEqual({
+      integrationId: 'integration-inserted',
+      userId: 'user-1',
+      organizationId: 'org-active',
+    })
+  })
+
+  it('rejects moving an existing Google integration between organizations', async () => {
+    findFirstMock
+      .mockResolvedValueOnce({ id: 'integration-existing', organizationId: 'org-a' })
+      .mockResolvedValueOnce(null)
+
+    await expect(saveCalendarIntegration('user-1', 'org-b', {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      email: null,
+    })).rejects.toMatchObject({ statusCode: 409 })
+
+    expect(updateSetMock).not.toHaveBeenCalled()
+    expect(insertValuesMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects overwriting an organization integration owned by another row', async () => {
+    findFirstMock
+      .mockResolvedValueOnce({ id: 'integration-user', organizationId: null })
+      .mockResolvedValueOnce({ id: 'integration-org', organizationId: 'org-active' })
+
+    await expect(saveCalendarIntegration('user-1', 'org-active', {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      email: null,
+    })).rejects.toMatchObject({ statusCode: 409 })
+
+    expect(updateSetMock).not.toHaveBeenCalled()
+    expect(insertValuesMock).not.toHaveBeenCalled()
+  })
+
+  it('claims an unowned legacy row only through its exact null-owned identity', async () => {
+    findFirstMock
+      .mockResolvedValueOnce({ id: 'integration-legacy', organizationId: null })
+      .mockResolvedValueOnce(null)
+
+    await expect(saveCalendarIntegration('user-1', 'org-active', {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      email: null,
+    })).resolves.toEqual({
+      integrationId: 'integration-legacy',
+      userId: 'user-1',
+      organizationId: 'org-active',
+    })
+
+    expect(updateWhereMock).toHaveBeenCalledWith(expect.objectContaining({
+      operator: 'and',
+      conditions: expect.arrayContaining([
+        { operator: 'isNull', column: calendarIntegration.organizationId },
+      ]),
+    }))
+  })
+
+  it('translates a concurrent uniqueness race into a stable conflict', async () => {
+    findFirstMock.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
+    insertReturningMock.mockRejectedValueOnce(Object.assign(new Error('duplicate'), { code: '23505' }))
+
+    await expect(saveCalendarIntegration('user-1', 'org-active', {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      email: null,
+    })).rejects.toMatchObject({ statusCode: 409 })
+  })
+
+  it('reads and updates webhook metadata through the exact interactive integration scope', async () => {
+    const identity = {
+      integrationId: 'integration-exact',
+      userId: 'user-exact',
+      organizationId: 'org-exact',
+    }
+    findFirstMock.mockResolvedValue({
+      id: identity.integrationId,
+      userId: identity.userId,
+      organizationId: identity.organizationId,
+      provider: 'google',
+      accessTokenEncrypted: 'stored-access',
+      refreshTokenEncrypted: 'stored-refresh',
+      calendarId: 'primary',
+      webhookChannelId: null,
+      webhookResourceId: null,
+      syncToken: null,
+    })
+
+    await expect(setupCalendarWebhook(identity)).resolves.toBe(true)
+
+    expect(findFirstMock).toHaveBeenCalled()
+    for (const [{ where }] of findFirstMock.mock.calls) {
+      expectExactGoogleScope(where, identity)
+    }
+    expect(updateWhereMock).toHaveBeenCalled()
+    for (const [where] of updateWhereMock.mock.calls) {
+      expectExactGoogleScope(where, identity)
+    }
+  })
+
+  it('keeps a legacy null-owned cron integration constrained to null ownership', async () => {
+    const identity = {
+      integrationId: 'integration-legacy',
+      userId: 'user-legacy',
+      organizationId: null,
+    }
+    findFirstMock.mockResolvedValue({
+      id: identity.integrationId,
+      userId: identity.userId,
+      organizationId: null,
+      provider: 'google',
+      accessTokenEncrypted: 'stored-access',
+      refreshTokenEncrypted: 'stored-refresh',
+      calendarId: 'primary',
+      webhookChannelId: null,
+      webhookResourceId: null,
+      syncToken: null,
+    })
+
+    await expect(setupCalendarWebhook(identity)).resolves.toBe(true)
+
+    for (const [{ where }] of findFirstMock.mock.calls) {
+      expectExactGoogleScope(where, identity)
+    }
+    for (const [where] of updateWhereMock.mock.calls) {
+      expectExactGoogleScope(where, identity)
+    }
+  })
+
+  it('stops a newly-created channel when the compare-and-set update loses a race', async () => {
+    const identity = {
+      integrationId: 'integration-raced',
+      userId: 'user-raced',
+      organizationId: 'org-raced',
+    }
+    findFirstMock.mockResolvedValue({
+      id: identity.integrationId,
+      userId: identity.userId,
+      organizationId: identity.organizationId,
+      provider: 'google',
+      accessTokenEncrypted: 'stored-access',
+      refreshTokenEncrypted: 'stored-refresh',
+      calendarId: 'primary',
+      webhookChannelId: 'previous-channel',
+      webhookResourceId: 'previous-resource',
+      syncToken: null,
+    })
+    updateReturningMock.mockResolvedValueOnce([])
+
+    await expect(setupCalendarWebhook(identity)).resolves.toBe(false)
+
+    expect(calendarClient.channels.stop).toHaveBeenCalledWith({
+      requestBody: {
+        id: expect.any(String),
+        resourceId: 'resource-exact',
+      },
+    })
+  })
+
+  it('scopes attendee synchronization to the integration organization', async () => {
+    const identity = {
+      integrationId: 'integration-sync',
+      userId: 'user-sync',
+      organizationId: 'org-sync',
+    }
+    findFirstMock.mockResolvedValue({
+      id: identity.integrationId,
+      userId: identity.userId,
+      organizationId: identity.organizationId,
+      provider: 'google',
+      accessTokenEncrypted: 'stored-access',
+      refreshTokenEncrypted: 'stored-refresh',
+      calendarId: 'primary',
+      syncToken: null,
+    })
+    calendarClient.events.list.mockResolvedValue({
+      data: { items: [{ id: 'event-shared-provider-id' }] },
+    })
+    interviewFindFirstMock.mockResolvedValue(null)
+
+    await performIncrementalSync(identity)
+
+    expect(interviewFindFirstMock).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        operator: 'and',
+        conditions: expect.arrayContaining([
+          { operator: 'eq', column: interview.googleCalendarEventId, value: 'event-shared-provider-id' },
+          { operator: 'eq', column: interview.organizationId, value: 'org-sync' },
+        ]),
+      }),
+    }))
+  })
+})

--- a/tests/unit/list-api-cache.test.ts
+++ b/tests/unit/list-api-cache.test.ts
@@ -6,22 +6,59 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const readProjectFile = (path: string) =>
   readFileSync(join(process.cwd(), path), 'utf8')
 
-const CACHED_LIST_HANDLERS = [
-  'server/api/jobs/index.get.ts',
-  'server/api/candidates/index.get.ts',
-  'server/api/applications/index.get.ts',
-  'server/api/interviews/index.get.ts',
-  'server/api/dashboard/stats.get.ts',
+const CACHED_LIST_ROUTES = [
+  { file: 'server/api/jobs/index.get.ts', cacheName: 'jobs-list' },
+  { file: 'server/api/candidates/index.get.ts', cacheName: 'candidates-list' },
+  {
+    file: 'server/api/applications/index.get.ts',
+    cacheName: 'applications-list',
+  },
+  { file: 'server/api/interviews/index.get.ts', cacheName: 'interviews-list' },
+  { file: 'server/api/dashboard/stats.get.ts', cacheName: 'dashboard-stats' },
 ] as const
 
 const cachedResponse = { source: 'org-cache' }
 const requirePermissionMock = vi.fn()
+const getValidatedQueryMock = vi.fn()
+const storageItems = new Map<string, unknown>()
+let capturedCacheOptions: {
+  maxAge: number
+  swr: boolean
+  name: string
+  getKey: (organizationId: string, input: unknown) => Promise<string>
+}
+
+const createCachedFunctionMock = () =>
+  vi.fn(async (_organizationId: string, _input: unknown) => cachedResponse)
+const routeCachedFunctions = new Map<
+  string,
+  ReturnType<typeof createCachedFunctionMock>
+>()
 
 vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
-vi.stubGlobal('defineCachedEventHandler', () => async () => cachedResponse)
-vi.stubGlobal('orgScopedCacheOptions', {})
-vi.stubGlobal('defineOrgScopedCachedFunction', () => async () => cachedResponse)
+vi.stubGlobal(
+  'defineCachedFunction',
+  (loader: unknown, options: typeof capturedCacheOptions) => {
+    capturedCacheOptions = options
+    return loader
+  },
+)
+vi.stubGlobal('useStorage', () => ({
+  getItem: async (key: string) => storageItems.get(key),
+  setItem: async (key: string, value: unknown) => {
+    storageItems.set(key, value)
+  },
+}))
+vi.stubGlobal('defineOrgScopedCachedFunction', (name: string) => {
+  const cachedFunction = createCachedFunctionMock()
+  routeCachedFunctions.set(name, cachedFunction)
+  return cachedFunction
+})
 vi.stubGlobal('requirePermission', requirePermissionMock)
+vi.stubGlobal('getValidatedQuery', getValidatedQueryMock)
+
+const { bumpOrgDashboardCacheVersion, defineOrgScopedCachedFunction } =
+  await import('../../server/utils/httpCache')
 
 const cachedListHandlers = await Promise.all([
   import('../../server/api/jobs/index.get'),
@@ -30,7 +67,10 @@ const cachedListHandlers = await Promise.all([
   import('../../server/api/interviews/index.get'),
   import('../../server/api/dashboard/stats.get'),
 ]).then(modules =>
-  modules.map(module => module.default as (event: unknown) => Promise<unknown>),
+  modules.map((module, index) => ({
+    ...CACHED_LIST_ROUTES[index]!,
+    handler: module.default as (event: unknown) => Promise<unknown>,
+  })),
 )
 
 function findOuterHandlerCalls(source: string, file: string) {
@@ -91,46 +131,94 @@ function findOuterHandlerCalls(source: string, file: string) {
 }
 
 describe('defineOrgScopedCachedFunction', () => {
-  it('defines org-generation SWR cache keys without request events or auth headers', () => {
-    const source = readProjectFile('server/utils/httpCache.ts')
+  beforeEach(() => {
+    storageItems.clear()
+    defineOrgScopedCachedFunction('jobs-list', async () => cachedResponse)
+  })
 
-    expect(source).toContain('defineOrgScopedCachedFunction')
-    expect(source).toContain('defineCachedFunction')
-    expect(source).toContain('ORG_SCOPED_CACHE_MAX_AGE_SECONDS')
-    expect(source).toContain('swr: true')
-    expect(source).toMatch(
-      /getKey:\s*async \(organizationId[^)]*,\s*input[^)]*\)/,
-    )
-    expect(source).toContain('getOrgDashboardCacheVersion(organizationId)')
-    expect(source).toContain('hash(input)')
-    expect(source).not.toContain('defineCachedEventHandler')
-    expect(source).not.toContain("varies: ['cookie', 'authorization']")
+  it('uses route-specific Nitro SWR options', () => {
+    expect(capturedCacheOptions).toMatchObject({
+      maxAge: 30,
+      swr: true,
+      name: 'org-dashboard-jobslist',
+    })
+  })
+
+  it('does not collide organization IDs that differ only by punctuation', async () => {
+    const input = { page: 1, limit: 20 }
+
+    const dashedKey = await capturedCacheOptions.getKey('org-a', input)
+    const compactKey = await capturedCacheOptions.getKey('orga', input)
+
+    expect(dashedKey).not.toBe(compactKey)
+  })
+
+  it('changes keys for different normalized inputs', async () => {
+    const firstKey = await capturedCacheOptions.getKey('org-a', {
+      page: 1,
+      limit: 20,
+    })
+    const secondKey = await capturedCacheOptions.getKey('org-a', {
+      page: 2,
+      limit: 20,
+    })
+
+    expect(firstKey).not.toBe(secondKey)
+  })
+
+  it('changes keys after the organization cache generation is bumped', async () => {
+    const input = { page: 1, limit: 20 }
+    const initialKey = await capturedCacheOptions.getKey('org-a', input)
+
+    await bumpOrgDashboardCacheVersion('org-a')
+    const bumpedKey = await capturedCacheOptions.getKey('org-a', input)
+
+    expect(initialKey).not.toBe(bumpedKey)
   })
 })
 
 describe('dashboard list API authorization boundary', () => {
   beforeEach(() => {
     requirePermissionMock.mockReset()
+    getValidatedQueryMock.mockReset()
+    getValidatedQueryMock.mockResolvedValue({ page: 1, limit: 20 })
+    for (const cachedFunction of routeCachedFunctions.values()) {
+      cachedFunction.mockClear()
+    }
     requirePermissionMock.mockRejectedValue(
       Object.assign(new Error('Forbidden'), { statusCode: 403 }),
     )
   })
 
-  it.each(
-    cachedListHandlers.map(
-      (handler, index) => [CACHED_LIST_HANDLERS[index], handler] as const,
-    ),
-  )(
-    '%s rechecks permission before returning an available cache hit',
-    async (_file, handler) => {
+  it.each(cachedListHandlers)(
+    '$file rechecks permission before returning an available cache hit',
+    async ({ cacheName, handler }) => {
       await expect(handler({})).rejects.toMatchObject({ statusCode: 403 })
       expect(requirePermissionMock).toHaveBeenCalledTimes(1)
+      expect(routeCachedFunctions.get(cacheName)).not.toHaveBeenCalled()
     },
   )
 
-  it.each(CACHED_LIST_HANDLERS)(
-    '%s keeps authorization in the outer event handler before its org cache lookup',
-    file => {
+  it.each(cachedListHandlers)(
+    '$file passes the exact authorized organization ID to the cached function',
+    async ({ cacheName, handler }) => {
+      requirePermissionMock.mockResolvedValue({
+        session: { activeOrganizationId: 'org-a' },
+      })
+
+      await handler({})
+
+      expect(routeCachedFunctions.get(cacheName)).toHaveBeenCalledTimes(1)
+      expect(routeCachedFunctions.get(cacheName)).toHaveBeenCalledWith(
+        'org-a',
+        expect.anything(),
+      )
+    },
+  )
+
+  it.each(CACHED_LIST_ROUTES)(
+    '$file keeps authorization in the outer event handler before its org cache lookup',
+    ({ file }) => {
       const source = readProjectFile(file)
       const { cachedFunctionNames, calls } = findOuterHandlerCalls(source, file)
       const permissionCall = calls.find(

--- a/tests/unit/list-api-cache.test.ts
+++ b/tests/unit/list-api-cache.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import ts from 'typescript'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const readProjectFile = (path: string) =>
   readFileSync(join(process.cwd(), path), 'utf8')
@@ -11,33 +12,138 @@ const CACHED_LIST_HANDLERS = [
   'server/api/applications/index.get.ts',
   'server/api/interviews/index.get.ts',
   'server/api/dashboard/stats.get.ts',
-]
+] as const
 
-describe('orgScopedCacheOptions', () => {
-  const source = readProjectFile('server/utils/httpCache.ts')
+const cachedResponse = { source: 'org-cache' }
+const requirePermissionMock = vi.fn()
 
-  it('exports shared Nitro SWR defaults with session varies headers', () => {
-    expect(source).toContain('orgScopedCacheOptions')
-    expect(source).toContain('swr: true')
-    expect(source).toContain("varies: ['cookie', 'authorization']")
+vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
+vi.stubGlobal('defineCachedEventHandler', () => async () => cachedResponse)
+vi.stubGlobal('orgScopedCacheOptions', {})
+vi.stubGlobal('defineOrgScopedCachedFunction', () => async () => cachedResponse)
+vi.stubGlobal('requirePermission', requirePermissionMock)
+
+const cachedListHandlers = await Promise.all([
+  import('../../server/api/jobs/index.get'),
+  import('../../server/api/candidates/index.get'),
+  import('../../server/api/applications/index.get'),
+  import('../../server/api/interviews/index.get'),
+  import('../../server/api/dashboard/stats.get'),
+]).then(modules =>
+  modules.map(module => module.default as (event: unknown) => Promise<unknown>),
+)
+
+function findOuterHandlerCalls(source: string, file: string) {
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+  const cachedFunctionNames = new Set<string>()
+  let outerHandler: ts.CallExpression | undefined
+
+  function visit(node: ts.Node) {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isCallExpression(node.initializer) &&
+      ts.isIdentifier(node.initializer.expression) &&
+      node.initializer.expression.text === 'defineOrgScopedCachedFunction'
+    ) {
+      cachedFunctionNames.add(node.name.text)
+    }
+
+    if (
+      ts.isExportAssignment(node) &&
+      ts.isCallExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === 'defineEventHandler'
+    ) {
+      outerHandler = node.expression
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+
+  if (!outerHandler) return { cachedFunctionNames, calls: [] }
+  const calls: Array<{ name: string; position: number }> = []
+  const handlerArgument = outerHandler.arguments[0]
+
+  if (handlerArgument) {
+    function visitHandler(node: ts.Node) {
+      if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+        calls.push({
+          name: node.expression.text,
+          position: node.getStart(sourceFile),
+        })
+      }
+      ts.forEachChild(node, visitHandler)
+    }
+    visitHandler(handlerArgument)
+  }
+
+  return { cachedFunctionNames, calls }
+}
+
+describe('defineOrgScopedCachedFunction', () => {
+  it('defines org-generation SWR cache keys without request events or auth headers', () => {
+    const source = readProjectFile('server/utils/httpCache.ts')
+
+    expect(source).toContain('defineOrgScopedCachedFunction')
+    expect(source).toContain('defineCachedFunction')
     expect(source).toContain('ORG_SCOPED_CACHE_MAX_AGE_SECONDS')
-  })
-
-  it('scopes cache keys by organization and bumps generation on writes', () => {
-    expect(source).toContain('ORG_SCOPED_DASHBOARD_CACHE_NAME')
-    expect(source).toContain('async getKey(event: H3Event)')
-    expect(source).toContain('bumpOrgDashboardCacheVersion')
-    expect(source).toContain('invalidateOrgScopedDashboardCache')
-    expect(source).toContain('invalidateOrgScopedDashboardCacheForOrg')
+    expect(source).toContain('swr: true')
+    expect(source).toMatch(
+      /getKey:\s*async \(organizationId[^)]*,\s*input[^)]*\)/,
+    )
+    expect(source).toContain('getOrgDashboardCacheVersion(organizationId)')
+    expect(source).toContain('hash(input)')
+    expect(source).not.toContain('defineCachedEventHandler')
+    expect(source).not.toContain("varies: ['cookie', 'authorization']")
   })
 })
 
-describe('dashboard list API Nitro cache', () => {
-  it.each(CACHED_LIST_HANDLERS)('%s uses defineCachedEventHandler with orgScopedCacheOptions', (file) => {
-    const source = readProjectFile(file)
-    expect(source, file).toContain('defineCachedEventHandler')
-    expect(source, file).toContain('orgScopedCacheOptions')
-    expect(source, file).toContain('requirePermission')
-    expect(source, file).not.toMatch(/export default defineEventHandler\(/)
+describe('dashboard list API authorization boundary', () => {
+  beforeEach(() => {
+    requirePermissionMock.mockReset()
+    requirePermissionMock.mockRejectedValue(
+      Object.assign(new Error('Forbidden'), { statusCode: 403 }),
+    )
   })
+
+  it.each(
+    cachedListHandlers.map(
+      (handler, index) => [CACHED_LIST_HANDLERS[index], handler] as const,
+    ),
+  )(
+    '%s rechecks permission before returning an available cache hit',
+    async (_file, handler) => {
+      await expect(handler({})).rejects.toMatchObject({ statusCode: 403 })
+      expect(requirePermissionMock).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  it.each(CACHED_LIST_HANDLERS)(
+    '%s keeps authorization in the outer event handler before its org cache lookup',
+    file => {
+      const source = readProjectFile(file)
+      const { cachedFunctionNames, calls } = findOuterHandlerCalls(source, file)
+      const permissionCall = calls.find(
+        call => call.name === 'requirePermission',
+      )
+      const cachedCall = calls.find(call => cachedFunctionNames.has(call.name))
+
+      expect(source, file).not.toContain('defineCachedEventHandler')
+      expect(source, file).not.toContain('orgScopedCacheOptions')
+      expect(cachedFunctionNames.size, file).toBeGreaterThan(0)
+      expect(permissionCall, file).toBeDefined()
+      expect(cachedCall, file).toBeDefined()
+      expect(permissionCall!.position, file).toBeLessThan(cachedCall!.position)
+    },
+  )
 })

--- a/tests/unit/microsoft-calendar-credential-races.test.ts
+++ b/tests/unit/microsoft-calendar-credential-races.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const dbMocks = vi.hoisted(() => {
+  const findFirst = vi.fn()
+  const updateReturning = vi.fn()
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }))
+  const updateSet = vi.fn(() => ({ where: updateWhere }))
+  return {
+    findFirst,
+    updateReturning,
+    updateWhere,
+    updateSet,
+    db: {
+      query: {
+        calendarIntegration: { findFirst },
+        orgSettings: { findFirst: vi.fn() },
+      },
+      update: vi.fn(() => ({ set: updateSet })),
+    },
+  }
+})
+
+vi.mock('../../server/utils/db', () => ({ db: dbMocks.db }))
+vi.mock('../../server/utils/env', () => ({
+  env: {
+    BETTER_AUTH_SECRET: 'test-secret',
+    BETTER_AUTH_URL: 'https://careers.example.com',
+    FACTORY_CAREERS_CALENDAR_GROUP_ID: 'group-configured',
+    FACTORY_CAREERS_CALENDAR_EMAIL: 'calendar@example.com',
+    MICROSOFT_CALENDAR_AUTH_MODE: 'delegated',
+    MICROSOFT_CALENDAR_CLIENT_ID: 'client-id',
+    MICROSOFT_CALENDAR_CLIENT_SECRET: 'client-secret',
+    MICROSOFT_CALENDAR_TENANT_ID: 'tenant-id',
+  },
+}))
+vi.mock('../../server/utils/encryption', () => ({
+  encrypt: vi.fn((value: string) => `encrypted:${value}`),
+  decrypt: vi.fn((value: string) => `decrypted:${value}`),
+}))
+
+vi.stubGlobal('logError', vi.fn())
+vi.stubGlobal('logWarn', vi.fn())
+
+const fetchMock = vi.fn()
+vi.stubGlobal('$fetch', fetchMock)
+
+const { createMicrosoftCalendarEvent } = await import('../../server/utils/microsoft-calendar')
+
+const eventData = {
+  title: 'Interview',
+  description: 'Description',
+  startTime: new Date('2026-07-16T12:00:00.000Z'),
+  durationMinutes: 30,
+  timezone: 'UTC',
+  location: null,
+  candidateEmail: 'candidate@example.com',
+  candidateName: 'Candidate',
+  interviewerEmails: [],
+}
+
+function delegatedIntegration(calendarId = 'group-existing') {
+  return {
+    id: 'integration-1',
+    userId: 'user-1',
+    organizationId: 'org-1',
+    provider: 'microsoft',
+    connectionGeneration: 'connection-old',
+    accessTokenEncrypted: 'encrypted:old-access',
+    refreshTokenEncrypted: 'encrypted:old-refresh',
+    calendarId,
+  }
+}
+
+describe('Microsoft Calendar credential generation races', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fetchMock.mockImplementation(async (url: string, init?: { method?: string }) => {
+      if (url.includes('/oauth2/v2.0/token')) {
+        return { access_token: 'refreshed-access', refresh_token: 'rotated-refresh' }
+      }
+      if (url.includes('/groups/group-configured?')) {
+        return { id: 'group-configured', mail: 'calendar@example.com' }
+      }
+      if (url.includes('/calendar/events') && init?.method === 'POST') {
+        return { id: 'event-1', webLink: 'https://calendar.example/event-1' }
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+  })
+
+  it('does not let an in-flight refresh overwrite or use credentials after reconnect wins', async () => {
+    dbMocks.findFirst.mockResolvedValueOnce(delegatedIntegration())
+    dbMocks.updateReturning.mockResolvedValueOnce([])
+
+    await expect(createMicrosoftCalendarEvent('user-1', 'org-1', eventData)).resolves.toBeNull()
+
+    expect(dbMocks.updateReturning).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toContain('/oauth2/v2.0/token')
+  })
+
+  it('does not use a resolved group after reconnect wins the lazy calendar-id write', async () => {
+    dbMocks.findFirst.mockResolvedValueOnce(delegatedIntegration('primary'))
+    dbMocks.updateReturning
+      .mockResolvedValueOnce([{ id: 'integration-1' }])
+      .mockResolvedValueOnce([])
+
+    await expect(createMicrosoftCalendarEvent('user-1', 'org-1', eventData)).resolves.toBeNull()
+
+    expect(dbMocks.updateReturning).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/calendar/events'))).toBe(false)
+  })
+})

--- a/tests/unit/microsoft-calendar-integration-scope.test.ts
+++ b/tests/unit/microsoft-calendar-integration-scope.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const dbMocks = vi.hoisted(() => {
+  const findFirst = vi.fn()
+  const updateReturning = vi.fn()
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }))
+  const updateSet = vi.fn(() => ({ where: updateWhere }))
+  const insertValues = vi.fn()
+  const deleteFrom = vi.fn()
+  const tx = {
+    query: { calendarIntegration: { findFirst } },
+    update: vi.fn(() => ({ set: updateSet })),
+    insert: vi.fn(() => ({ values: insertValues })),
+  }
+  const db = {
+    ...tx,
+    query: {
+      calendarIntegration: { findFirst },
+      orgSettings: { findFirst: vi.fn() },
+    },
+    delete: deleteFrom,
+    transaction: vi.fn(async (callback: (client: typeof tx) => Promise<unknown>) =>
+      await callback(tx)),
+  }
+  return {
+    db,
+    findFirst,
+    updateReturning,
+    updateWhere,
+    updateSet,
+    insertValues,
+    deleteFrom,
+  }
+})
+
+vi.mock('../../server/utils/db', () => ({ db: dbMocks.db }))
+vi.mock('../../server/utils/env', () => ({
+  env: {
+    BETTER_AUTH_SECRET: 'test-secret',
+    FACTORY_CAREERS_CALENDAR_GROUP_ID: 'group-exact',
+    FACTORY_CAREERS_CALENDAR_EMAIL: 'calendar@example.com',
+    MICROSOFT_CALENDAR_AUTH_MODE: 'delegated',
+  },
+}))
+vi.mock('../../server/utils/encryption', () => ({
+  encrypt: vi.fn((value: string) => `encrypted:${value}`),
+  decrypt: vi.fn(),
+}))
+
+vi.stubGlobal('$fetch', vi.fn(async () => ({
+  id: 'group-exact',
+  mail: 'calendar@example.com',
+})))
+vi.stubGlobal('createError', (options: { statusCode: number, statusMessage?: string }) =>
+  Object.assign(new Error(options.statusMessage), options),
+)
+
+const { saveMicrosoftCalendarIntegration } = await import('../../server/utils/microsoft-calendar')
+
+const tokens = {
+  accessToken: 'access-token',
+  refreshToken: 'refresh-token',
+  email: 'calendar@example.com',
+}
+
+describe('Microsoft Calendar integration organization scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dbMocks.updateReturning.mockResolvedValue([{ id: 'integration-existing' }])
+    dbMocks.insertValues.mockResolvedValue(undefined)
+  })
+
+  it('rejects moving a delegated integration between organizations without deleting it', async () => {
+    dbMocks.findFirst
+      .mockResolvedValueOnce({ id: 'integration-existing', organizationId: 'org-a' })
+      .mockResolvedValueOnce(null)
+
+    await expect(saveMicrosoftCalendarIntegration('user-1', 'org-b', tokens))
+      .rejects.toMatchObject({ statusCode: 409 })
+
+    expect(dbMocks.deleteFrom).not.toHaveBeenCalled()
+    expect(dbMocks.updateSet).not.toHaveBeenCalled()
+    expect(dbMocks.insertValues).not.toHaveBeenCalled()
+  })
+
+  it('updates a same-organization delegated integration atomically', async () => {
+    dbMocks.findFirst
+      .mockResolvedValueOnce({ id: 'integration-existing', organizationId: 'org-a' })
+      .mockResolvedValueOnce({ id: 'integration-existing', organizationId: 'org-a' })
+
+    await saveMicrosoftCalendarIntegration('user-1', 'org-a', tokens)
+
+    expect(dbMocks.db.transaction).toHaveBeenCalledTimes(1)
+    expect(dbMocks.updateSet).toHaveBeenCalledWith(expect.objectContaining({
+      organizationId: 'org-a',
+      provider: 'microsoft',
+    }))
+    expect(dbMocks.deleteFrom).not.toHaveBeenCalled()
+  })
+
+  it('translates a concurrent uniqueness conflict without destroying the existing row', async () => {
+    dbMocks.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
+    dbMocks.insertValues.mockRejectedValueOnce(Object.assign(new Error('duplicate'), { code: '23505' }))
+
+    await expect(saveMicrosoftCalendarIntegration('user-1', 'org-a', tokens))
+      .rejects.toMatchObject({ statusCode: 409 })
+
+    expect(dbMocks.deleteFrom).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/public-application-compliance.test.ts
+++ b/tests/unit/public-application-compliance.test.ts
@@ -156,7 +156,8 @@ describe('public application compliance self-identification', () => {
   it('provides aggregate reporting without returning individual answers', () => {
     const source = readProjectFile('server/api/compliance/applications/summary.get.ts')
 
-    expect(source).toContain("requirePermission(event, { application: ['read'] })")
+    expect(source).toContain("requirePermission(event, { organization: ['update'] })")
+    expect(source).not.toContain("requirePermission(event, { application: ['read'] })")
     expect(source).toContain('totalResponses')
     expect(source).toContain('breakdowns')
     expect(source).not.toContain('candidateId')

--- a/tests/unit/public-application-compliance.test.ts
+++ b/tests/unit/public-application-compliance.test.ts
@@ -156,8 +156,6 @@ describe('public application compliance self-identification', () => {
   it('provides aggregate reporting without returning individual answers', () => {
     const source = readProjectFile('server/api/compliance/applications/summary.get.ts')
 
-    expect(source).toContain("requirePermission(event, { organization: ['update'] })")
-    expect(source).not.toContain("requirePermission(event, { application: ['read'] })")
     expect(source).toContain('totalResponses')
     expect(source).toContain('breakdowns')
     expect(source).not.toContain('candidateId')

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -88,6 +88,33 @@ describe('createRateLimiter', () => {
     await expect(b(ip)).resolves.toBeUndefined()
   })
 
+  it('supports an explicit bounded key resolver without weakening the secure default', async () => {
+    const limiter = createRateLimiter({
+      windowMs: 60_000,
+      maxRequests: 1,
+      keyResolver: event => (event as unknown as FakeEvent).__headers['x-client-key'],
+    })
+    const sharedSocketA = makeEvent('10.0.0.5', { 'x-client-key': 'client-a' })
+    const sharedSocketB = makeEvent('10.0.0.5', { 'x-client-key': 'client-b' })
+
+    await expect(limiter(sharedSocketA)).resolves.toBeUndefined()
+    await expect(limiter(sharedSocketB)).resolves.toBeUndefined()
+    await expect(limiter(sharedSocketA)).rejects.toMatchObject({ statusCode: 429 })
+  })
+
+  it('collapses excess custom keys into a bounded overflow bucket', async () => {
+    const limiter = createRateLimiter({
+      windowMs: 60_000,
+      maxRequests: 1,
+      maxTrackedKeys: 1,
+      keyResolver: event => (event as unknown as FakeEvent).__headers['x-client-key'],
+    })
+
+    await expect(limiter(makeEvent('10.0.0.5', { 'x-client-key': 'client-a' }))).resolves.toBeUndefined()
+    await expect(limiter(makeEvent('10.0.0.5', { 'x-client-key': 'client-b' }))).resolves.toBeUndefined()
+    await expect(limiter(makeEvent('10.0.0.5', { 'x-client-key': 'client-c' }))).rejects.toMatchObject({ statusCode: 429 })
+  })
+
   it('emits standard rate-limit headers on every response', async () => {
     // Note: `remaining` is computed BEFORE recording the current request, so
     // the first call sees `maxRequests` remaining (the response describes the

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -115,6 +115,33 @@ describe('createRateLimiter', () => {
     await expect(limiter(makeEvent('10.0.0.5', { 'x-client-key': 'client-c' }))).rejects.toMatchObject({ statusCode: 429 })
   })
 
+  it('reclaims expired dedicated keys before assigning new clients to overflow', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-07-16T12:00:00.000Z'))
+      const limiter = createRateLimiter({
+        windowMs: 1_000,
+        maxRequests: 1,
+        maxTrackedKeys: 1,
+        keyResolver: event => (event as unknown as FakeEvent).__headers['x-client-key'],
+      })
+
+      await limiter(makeEvent('10.0.0.5', { 'x-client-key': 'client-a' }))
+      await limiter(makeEvent('10.0.0.5', { 'x-client-key': 'client-b' }))
+      await expect(limiter(makeEvent('10.0.0.5', { 'x-client-key': 'client-c' })))
+        .rejects.toMatchObject({ statusCode: 429 })
+
+      vi.setSystemTime(new Date('2026-07-16T12:00:01.001Z'))
+      await expect(limiter(makeEvent('10.0.0.5', { 'x-client-key': 'client-c' }))).resolves.toBeUndefined()
+      await expect(limiter(makeEvent('10.0.0.5', { 'x-client-key': 'client-d' }))).resolves.toBeUndefined()
+      await expect(limiter(makeEvent('10.0.0.5', { 'x-client-key': 'client-e' })))
+        .rejects.toMatchObject({ statusCode: 429 })
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('emits standard rate-limit headers on every response', async () => {
     // Note: `remaining` is computed BEFORE recording the current request, so
     // the first call sees `maxRequests` remaining (the response describes the


### PR DESCRIPTION
## Summary

- authorize organization-scoped dashboard reads before caching and make cache keys collision-safe
- prevent small-cohort inference and protect compliance summary access
- bind Google and Microsoft calendar credentials, OAuth state, renewals, webhooks, and disconnects to stable organization connection generations
- harden the PostHog proxy with an explicit allowlist, bounded streaming, shared deadlines, layered transactional rate limits, concurrency caps, and safe forwarded headers
- redact database URLs from surfaced initialization errors

## Validation run

- `npm run preflight:pr` (210 test files, 1,263 tests; typecheck; CLI smoke; production env contract; production build; resume-parser bundle smoke)
- `npm run check:conventions` (7 files, 62 tests)
- focused security suite (11 files, 112 tests)
- analytics Node-stream stress loop (10/10 runs)
- disposable local PostgreSQL migration rehearsal through 0050; verified `connection_generation` is `NOT NULL` with no null residue
- authenticated local browser QA for calendar connect, connected, disconnect, and reconnect states with no console warnings/errors

## CLI parity

No CLI/API contract surface changes. The existing parity guard passes.

## Known risks or skipped checks

- rate and concurrency limits are process-local, matching the current single-instance deployment model
- provider concurrency paths are covered with mocked database/provider races; no destructive live provider calls were made

## Release/version notes

No changeset is needed. User-visible fixes are recorded in `CHANGELOG.md` and the repository release flow will version them.

## DCO

All commits include a `Signed-off-by` trailer.

<!-- openclaw-review-loop:
channel=codex
agent=codex
sessionKey=
providerThreadId=
origin=external-ui
-->
