### PR TITLE
fix: protect processing tables with RLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ self-hosters.
 
 ### Fixed
 
+- Protected internal recruiter-search and durable-processing tables with the same server-role-only row-level security boundary used by existing production data.
 - Kept large job pipelines stable with bounded server pagination, accurate filtered stage counts, identity-safe selection, and application-scoped interview history.
 - Kept ordinary application and job-pipeline lists available while the optional application search index is being migrated during a deployment.
 - Bound score details and reviewer feedback to the exact persisted analysis run, kept the last successful result visible after a failed re-score, and isolated candidate and scoring state when switching applications.

--- a/server/database/migrations/0057_processing_search_rls.sql
+++ b/server/database/migrations/0057_processing_search_rls.sql
@@ -1,0 +1,41 @@
+-- Keep internal recruiter-search and durable-processing data unavailable to
+-- Supabase client roles while preserving direct server-role access.
+ALTER TABLE "application_search_document" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "factory_careers_server_roles_full_access"
+  ON "application_search_document"
+  FOR ALL
+  TO PUBLIC
+  USING (CURRENT_USER <> ALL (ARRAY['anon', 'authenticated']))
+  WITH CHECK (CURRENT_USER <> ALL (ARRAY['anon', 'authenticated']));--> statement-breakpoint
+
+ALTER TABLE "application_search_refresh_queue" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "factory_careers_server_roles_full_access"
+  ON "application_search_refresh_queue"
+  FOR ALL
+  TO PUBLIC
+  USING (CURRENT_USER <> ALL (ARRAY['anon', 'authenticated']))
+  WITH CHECK (CURRENT_USER <> ALL (ARRAY['anon', 'authenticated']));--> statement-breakpoint
+
+ALTER TABLE "processing_batch" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "factory_careers_server_roles_full_access"
+  ON "processing_batch"
+  FOR ALL
+  TO PUBLIC
+  USING (CURRENT_USER <> ALL (ARRAY['anon', 'authenticated']))
+  WITH CHECK (CURRENT_USER <> ALL (ARRAY['anon', 'authenticated']));--> statement-breakpoint
+
+ALTER TABLE "processing_task" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "factory_careers_server_roles_full_access"
+  ON "processing_task"
+  FOR ALL
+  TO PUBLIC
+  USING (CURRENT_USER <> ALL (ARRAY['anon', 'authenticated']))
+  WITH CHECK (CURRENT_USER <> ALL (ARRAY['anon', 'authenticated']));--> statement-breakpoint
+
+ALTER TABLE "processing_batch_item" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "factory_careers_server_roles_full_access"
+  ON "processing_batch_item"
+  FOR ALL
+  TO PUBLIC
+  USING (CURRENT_USER <> ALL (ARRAY['anon', 'authenticated']))
+  WITH CHECK (CURRENT_USER <> ALL (ARRAY['anon', 'authenticated']));

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1784217600000,
       "tag": "0056_application_current_analysis_run",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1784221200000,
+      "tag": "0057_processing_search_rls",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/unit/processing-rls-migration.test.ts
+++ b/tests/unit/processing-rls-migration.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('processing data RLS migration', () => {
+  it('protects every internal search and processing table from Supabase client roles', () => {
+    const migration = read('server/database/migrations/0057_processing_search_rls.sql')
+
+    for (const table of [
+      'application_search_document',
+      'application_search_refresh_queue',
+      'processing_batch',
+      'processing_task',
+      'processing_batch_item',
+    ]) {
+      expect(migration).toContain(`ALTER TABLE "${table}" ENABLE ROW LEVEL SECURITY`)
+      expect(migration).toContain(`ON "${table}"`)
+    }
+
+    expect(migration).toContain("CURRENT_USER <> ALL (ARRAY['anon', 'authenticated'])")
+    expect(migration).toContain('WITH CHECK')
+  })
+})


### PR DESCRIPTION
## Summary
- add row-level security to internal recruiter-search and durable-processing tables
- preserve direct server-role access while blocking Supabase client roles
- record the operator-visible security boundary in the changelog

## Validation run
- `npm run preflight:pr`
- fresh PostgreSQL 17 migration replay through 0057
- verified all five new internal tables report RLS enabled

## Known risks or skipped checks
- No browser behavior changes in this follow-up.
- Production migration and backfill will run after merge.

## Release/version notes
- Changelog updated under Unreleased.
- No changeset is needed for this application repository.

<!-- openclaw-review-loop:
channel=codex
agent=codex
sessionKey=
providerThreadId=
origin=external-ui
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for internal search and processing data by restricting database access to server roles.

* **Tests**
  * Added coverage to verify row-level security is enabled and correctly configured for the protected data tables.

* **Documentation**
  * Updated the changelog with details about the enhanced data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->