### PR TITLE
fix: address processing schema advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ self-hosters.
 
 ### Fixed
 
+- Pinned recruiter-search database functions to trusted schemas, protected device authorization with row-level security, and indexed durable-processing relationships used during cleanup.
 - Protected internal recruiter-search and durable-processing tables with the same server-role-only row-level security boundary used by existing production data.
 - Kept large job pipelines stable with bounded server pagination, accurate filtered stage counts, identity-safe selection, and application-scoped interview history.
 - Kept ordinary application and job-pipeline lists available while the optional application search index is being migrated during a deployment.

--- a/server/database/migrations/0058_processing_schema_advisories.sql
+++ b/server/database/migrations/0058_processing_schema_advisories.sql
@@ -1,0 +1,25 @@
+-- Keep unqualified names inside the recruiter-search trigger functions bound to
+-- trusted schemas rather than inheriting a caller-controlled search path.
+ALTER FUNCTION public.refresh_application_search_document(text) SET search_path = pg_catalog, public;
+ALTER FUNCTION public.queue_application_search_document(text) SET search_path = pg_catalog, public;
+ALTER FUNCTION public.flush_application_search_document_queue() SET search_path = pg_catalog, public;
+ALTER FUNCTION public.queue_application_search_for_candidate(text) SET search_path = pg_catalog, public;
+ALTER FUNCTION public.queue_application_search_for_job(text) SET search_path = pg_catalog, public;
+ALTER FUNCTION public.queue_application_search_for_entity(text, text) SET search_path = pg_catalog, public;
+ALTER FUNCTION public.queue_application_search_for_property_definition(text) SET search_path = pg_catalog, public;
+ALTER FUNCTION public.queue_application_search_for_tracking_link(text) SET search_path = pg_catalog, public;
+ALTER FUNCTION public.application_search_refresh_trigger() SET search_path = pg_catalog, public;
+--> statement-breakpoint
+ALTER TABLE "device_code" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE POLICY "factory_careers_server_roles_full_access"
+ON "device_code"
+FOR ALL
+USING (CURRENT_USER <> ALL (ARRAY['anon', 'authenticated']))
+WITH CHECK (CURRENT_USER <> ALL (ARRAY['anon', 'authenticated']));
+--> statement-breakpoint
+CREATE INDEX "processing_batch_item_batch_org_fk_idx"
+ON "processing_batch_item" USING btree ("batch_id", "organization_id");
+--> statement-breakpoint
+CREATE INDEX "processing_batch_item_task_org_fk_idx"
+ON "processing_batch_item" USING btree ("task_id", "organization_id");

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1784221200000,
       "tag": "0057_processing_search_rls",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1784224800000,
+      "tag": "0058_processing_schema_advisories",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/unit/processing-schema-advisories-migration.test.ts
+++ b/tests/unit/processing-schema-advisories-migration.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('processing schema advisory migration', () => {
+  it('pins recruiter-search function resolution to trusted schemas', () => {
+    const migration = read('server/database/migrations/0058_processing_schema_advisories.sql')
+
+    for (const signature of [
+      'refresh_application_search_document(text)',
+      'queue_application_search_document(text)',
+      'flush_application_search_document_queue()',
+      'queue_application_search_for_candidate(text)',
+      'queue_application_search_for_job(text)',
+      'queue_application_search_for_entity(text, text)',
+      'queue_application_search_for_property_definition(text)',
+      'queue_application_search_for_tracking_link(text)',
+      'application_search_refresh_trigger()',
+    ]) {
+      expect(migration).toContain(`ALTER FUNCTION public.${signature} SET search_path = pg_catalog, public`)
+    }
+  })
+
+  it('protects device authorization and covers composite processing foreign keys', () => {
+    const migration = read('server/database/migrations/0058_processing_schema_advisories.sql')
+
+    expect(migration).toContain('ALTER TABLE "device_code" ENABLE ROW LEVEL SECURITY')
+    expect(migration).toContain('ON "device_code"')
+    expect(migration).toContain("CURRENT_USER <> ALL (ARRAY['anon', 'authenticated'])")
+    expect(migration).toContain('("batch_id", "organization_id")')
+    expect(migration).toContain('("task_id", "organization_id")')
+  })
+})


### PR DESCRIPTION
## Summary

- pin recruiter-search functions to trusted database schemas
- protect device authorization with the existing server-role-only RLS boundary
- add covering indexes for durable-processing composite foreign keys

## Validation run

- `npx vitest run tests/unit/processing-schema-advisories-migration.test.ts`
- `npm run check:conventions`
- fresh PostgreSQL 17 migration replay through 0058
- `npm run preflight:pr`

## Known risks or skipped checks

- Supabase still reports the pre-existing `pg_trgm` extension in `public`; relocating an installed extension is intentionally outside this focused migration.
- Existing informational unused-index advisories were not acted on because the new processing indexes have not yet accumulated production usage.

## Release/version notes

- Changelog updated under Unreleased.
- No changeset is required.

<!-- openclaw-review-loop:
channel=codex
agent=codex
sessionKey=
providerThreadId=
origin=external-ui
-->