### PR TITLE
fix: improve AI usage chart defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ self-hosters.
 ### Fixed
 
 - Removed the verbose search-scope helper from the job pipeline.
+- Made AI usage charts render a true rolling 30-day window with readable scales, quiet-day gaps, compact bars, period totals, and accessible daily details.
 - Pinned recruiter-search database functions to trusted schemas, protected device authorization with row-level security, and indexed durable-processing relationships used during cleanup.
 - Protected internal recruiter-search and durable-processing tables with the same server-role-only row-level security boundary used by existing production data.
 - Kept large job pipelines stable with bounded server pagination, accurate filtered stage counts, identity-safe selection, and application-scoped interview history.

--- a/app/pages/dashboard/ai-analysis.vue
+++ b/app/pages/dashboard/ai-analysis.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {
-  Brain, Sparkles, TrendingUp, AlertTriangle, CheckCircle2,
+  Brain, Sparkles, TrendingUp, CheckCircle2,
   XCircle, Zap, Clock, BarChart3, Activity, AlertCircle, DollarSign,
 } from 'lucide-vue-next'
 import {
@@ -8,6 +8,13 @@ import {
   getAnalysisRunStatusDotClass,
   getScoreBadgeClass,
 } from '~/utils/status-display'
+import type { AiUsageDay } from '~/utils/ai-usage-chart'
+import {
+  buildAiUsageSeries,
+  formatUsageDate,
+  getNiceUsageAxisMax,
+  getUsageBarHeight,
+} from '~/utils/ai-usage-chart'
 
 definePageMeta({
   layout: 'dashboard',
@@ -59,23 +66,54 @@ function calcCost(promptTokens: number, completionTokens: number): number | null
 
 const totalCost = computed(() => calcCost(summary.value.totalPromptTokens, summary.value.totalCompletionTokens))
 
-// Chart bar heights (simple bar chart)
-const maxDailyCount = computed(() => Math.max(...dailyRuns.value.map((d: any) => d.count), 1))
-const maxDailyTokens = computed(() => Math.max(...dailyRuns.value.map((d: any) => d.promptTokens + d.completionTokens), 1))
+// Keep sparse API rows sparse at the contract boundary, then normalize the
+// presentation to a real rolling calendar window for predictable chart sizing.
+const usageWindowEnd = new Date()
+usageWindowEnd.setHours(12, 0, 0, 0)
 
-const chartStartDate = computed(() => {
-  const first = dailyRuns.value[0]
-  return first ? formatDate(first.date) : ''
-})
-const chartEndDate = computed(() => {
-  const last = dailyRuns.value.at(-1)
-  return last ? formatDate(last.date) : ''
+const usageDays = computed(() => buildAiUsageSeries(
+  dailyRuns.value as AiUsageDay[],
+  { endDate: usageWindowEnd },
+))
+
+const usageTotals = computed(() => usageDays.value.reduce((totals, day) => ({
+  runs: totals.runs + day.count,
+  promptTokens: totals.promptTokens + day.promptTokens,
+  completionTokens: totals.completionTokens + day.completionTokens,
+  tokens: totals.tokens + day.promptTokens + day.completionTokens,
+}), {
+  runs: 0,
+  promptTokens: 0,
+  completionTokens: 0,
+  tokens: 0,
+}))
+
+const peakDailyRuns = computed(() => Math.max(...usageDays.value.map(day => day.count), 0))
+const peakDailyTokens = computed(() => Math.max(
+  ...usageDays.value.map(day => day.promptTokens + day.completionTokens),
+  0,
+))
+const runsAxisMax = computed(() => getNiceUsageAxisMax(peakDailyRuns.value))
+const tokensAxisMax = computed(() => getNiceUsageAxisMax(peakDailyTokens.value))
+const chartStartDate = computed(() => formatUsageDate(usageDays.value[0]?.date ?? ''))
+const chartMiddleDate = computed(() => formatUsageDate(
+  usageDays.value[Math.floor((usageDays.value.length - 1) / 2)]?.date ?? '',
+))
+const chartEndDate = computed(() => formatUsageDate(usageDays.value.at(-1)?.date ?? ''))
+const promptTokenShare = computed(() => {
+  if (usageTotals.value.tokens === 0) return 0
+  return Math.round((usageTotals.value.promptTokens / usageTotals.value.tokens) * 100)
 })
 
 function formatNumber(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
   return n.toString()
+}
+
+function formatAxisNumber(n: number): string {
+  if (Number.isInteger(n)) return formatNumber(n)
+  return n.toFixed(1).replace(/\.0$/, '')
 }
 
 function formatCost(cost: number | null): string {
@@ -91,9 +129,27 @@ function formatCostPrecise(cost: number | null): string {
   return `$${cost.toFixed(2)}`
 }
 
-function formatDate(dateStr: string): string {
-  const d = new Date(dateStr)
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+function getDayTokenTotal(day: AiUsageDay): number {
+  return day.promptTokens + day.completionTokens
+}
+
+function getPromptTokenPercentage(day: AiUsageDay): number {
+  const total = getDayTokenTotal(day)
+  return total === 0 ? 0 : (day.promptTokens / total) * 100
+}
+
+function getUsageDayLabel(day: AiUsageDay): string {
+  const tokens = getDayTokenTotal(day)
+  if (day.count === 0 && tokens === 0) {
+    return `${formatUsageDate(day.date)}: no usage`
+  }
+  return `${formatUsageDate(day.date)}: ${day.count} run${day.count === 1 ? '' : 's'}, ${formatNumber(tokens)} tokens`
+}
+
+function getUsageTooltipPosition(index: number): string {
+  if (index < 3) return 'left-0'
+  if (index >= usageDays.value.length - 3) return 'right-0'
+  return 'left-1/2 -translate-x-1/2'
 }
 
 function formatDateTime(dateStr: string | Date): string {
@@ -233,92 +289,166 @@ function formatDateTime(dateStr: string | Date): string {
         </DashboardStatCard>
       </div>
 
-      <!-- ─── Usage chart (last 30 days) ─── -->
-      <div v-if="dailyRuns.length > 0" class="ui-panel ui-dashboard-panel overflow-hidden mb-6">
-        <div class="px-6 py-5 border-b border-surface-200 dark:border-surface-800">
+      <!-- ─── Usage chart (rolling 30 days) ─── -->
+      <div class="ui-panel ui-dashboard-panel mb-6">
+        <div class="flex flex-col gap-4 border-b border-surface-200 px-5 py-5 dark:border-surface-800 sm:flex-row sm:items-center sm:justify-between sm:px-6">
           <div class="flex items-center gap-3">
-            <div class="flex items-center justify-center size-10 rounded-lg bg-brand-50 dark:bg-brand-950 text-brand-600 dark:text-brand-400">
+            <div class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-brand-50 text-brand-600 dark:bg-brand-950 dark:text-brand-400">
               <BarChart3 class="size-5" />
             </div>
             <div>
-              <h2 class="text-base font-semibold text-surface-900 dark:text-surface-100">Usage — Last 30 Days</h2>
-              <p class="text-sm text-surface-500 dark:text-surface-400">Daily run counts and token consumption</p>
+              <h2 class="text-base font-semibold text-surface-900 dark:text-surface-100">Usage</h2>
+              <p class="text-sm text-surface-500 dark:text-surface-400">
+                Rolling 30 days · {{ chartStartDate }}–{{ chartEndDate }}
+              </p>
             </div>
           </div>
+
+          <dl class="grid grid-cols-2 gap-x-6 rounded-lg border border-surface-200 bg-surface-50 px-4 py-2.5 dark:border-surface-800 dark:bg-surface-900/60 sm:min-w-64">
+            <div>
+              <dt class="text-[10px] font-semibold uppercase tracking-wider text-surface-400 dark:text-surface-500">Runs</dt>
+              <dd class="mt-0.5 text-sm font-semibold tabular-nums text-surface-900 dark:text-surface-100">{{ formatNumber(usageTotals.runs) }}</dd>
+            </div>
+            <div>
+              <dt class="text-[10px] font-semibold uppercase tracking-wider text-surface-400 dark:text-surface-500">Tokens</dt>
+              <dd class="mt-0.5 text-sm font-semibold tabular-nums text-surface-900 dark:text-surface-100">{{ formatNumber(usageTotals.tokens) }}</dd>
+            </div>
+          </dl>
         </div>
 
-        <div class="px-6 py-5 space-y-6">
-          <!-- Runs per day bar chart -->
-          <div>
-            <h3 class="text-xs font-semibold uppercase tracking-wider text-surface-400 dark:text-surface-500 mb-3">Runs per Day</h3>
-            <div class="flex items-end gap-1 h-24">
-              <div
-                v-for="day in dailyRuns"
-                :key="day.date"
-                class="group relative flex-1 min-w-0 h-full flex items-end"
-              >
-                <div
-                  class="w-full rounded-t bg-brand-500 dark:bg-brand-400 transition-all duration-200 hover:bg-brand-600 dark:hover:bg-brand-300"
-                  :style="{ height: `${Math.max((day.count / maxDailyCount) * 100, 4)}%` }"
-                />
-                <!-- Tooltip -->
-                <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 hidden group-hover:block z-10">
-                  <div class="rounded-lg border border-surface-200 bg-white px-2.5 py-1.5 shadow-lg dark:border-surface-700 dark:bg-surface-800 whitespace-nowrap text-[11px]">
-                    <p class="font-semibold text-surface-800 dark:text-surface-200">{{ formatDate(day.date) }}</p>
-                    <p class="text-surface-500">{{ day.count }} run{{ day.count !== 1 ? 's' : '' }}</p>
-                    <p class="text-surface-400">{{ formatNumber(day.promptTokens + day.completionTokens) }} tokens</p>
-                    <p v-if="pricing.configured" class="text-emerald-600 dark:text-emerald-400 font-medium">{{ formatCostPrecise(calcCost(day.promptTokens, day.completionTokens)) }}</p>
-                  </div>
-                </div>
+        <div class="grid divide-y divide-surface-200 dark:divide-surface-800 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+          <section class="p-5 sm:p-6" aria-labelledby="usage-runs-title">
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <h3 id="usage-runs-title" class="text-sm font-semibold text-surface-800 dark:text-surface-200">Runs per day</h3>
+                <p class="mt-0.5 text-xs text-surface-500 dark:text-surface-400">Completed and failed scoring runs</p>
               </div>
+              <span class="shrink-0 rounded-full bg-brand-50 px-2.5 py-1 text-[11px] font-medium tabular-nums text-brand-700 dark:bg-brand-950 dark:text-brand-300">
+                Peak {{ formatNumber(peakDailyRuns) }}
+              </span>
             </div>
-            <div class="flex justify-between mt-1.5 text-[10px] text-surface-400">
-              <span>{{ chartStartDate }}</span>
-              <span>{{ chartEndDate }}</span>
-            </div>
-          </div>
 
-          <!-- Tokens per day bar chart -->
-          <div>
-            <h3 class="text-xs font-semibold uppercase tracking-wider text-surface-400 dark:text-surface-500 mb-3">Tokens per Day</h3>
-            <div class="flex items-end gap-1 h-24">
-              <div
-                v-for="day in dailyRuns"
-                :key="`tokens-${day.date}`"
-                class="group relative flex-1 min-w-0 h-full flex items-end"
-              >
-                <div class="w-full flex flex-col-reverse rounded-t overflow-hidden" :style="{ height: `${Math.max(((day.promptTokens + day.completionTokens) / maxDailyTokens) * 100, 4)}%` }">
-                  <div
-                    class="w-full bg-violet-500 dark:bg-violet-400"
-                    :style="{ height: `${(day.promptTokens / (day.promptTokens + day.completionTokens || 1)) * 100}%` }"
-                  />
-                  <div
-                    class="w-full bg-amber-400 dark:bg-amber-300"
-                    :style="{ height: `${(day.completionTokens / (day.promptTokens + day.completionTokens || 1)) * 100}%` }"
-                  />
+            <div class="mt-5">
+              <div class="flex h-36 gap-3">
+                <div class="flex w-9 shrink-0 flex-col justify-between py-0.5 text-right text-[10px] tabular-nums text-surface-400 dark:text-surface-500" aria-hidden="true">
+                  <span>{{ formatAxisNumber(runsAxisMax) }}</span>
+                  <span>{{ formatAxisNumber(runsAxisMax / 2) }}</span>
+                  <span>0</span>
                 </div>
-                <!-- Tooltip -->
-                <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 hidden group-hover:block z-10">
-                  <div class="rounded-lg border border-surface-200 bg-white px-2.5 py-1.5 shadow-lg dark:border-surface-700 dark:bg-surface-800 whitespace-nowrap text-[11px]">
-                    <p class="font-semibold text-surface-800 dark:text-surface-200">{{ formatDate(day.date) }}</p>
-                    <p class="text-violet-600 dark:text-violet-400">Prompt: {{ formatNumber(day.promptTokens) }}</p>
-                    <p class="text-amber-600 dark:text-amber-400">Completion: {{ formatNumber(day.completionTokens) }}</p>
-                    <p v-if="pricing.configured" class="text-emerald-600 dark:text-emerald-400 font-medium mt-0.5 pt-0.5 border-t border-surface-100 dark:border-surface-700">{{ formatCostPrecise(calcCost(day.promptTokens, day.completionTokens)) }}</p>
+                <div class="relative min-w-0 flex-1">
+                  <div class="pointer-events-none absolute inset-0 flex flex-col justify-between py-1" aria-hidden="true">
+                    <span v-for="line in 3" :key="`runs-grid-${line}`" class="border-t border-dashed border-surface-200 dark:border-surface-800" />
+                  </div>
+                  <p v-if="usageTotals.runs === 0" class="absolute inset-0 flex items-center justify-center text-xs text-surface-400 dark:text-surface-500">
+                    No runs in this window
+                  </p>
+                  <div class="absolute inset-0 flex items-end gap-px pt-1 sm:gap-0.5" role="list" aria-label="Daily AI scoring runs over the last 30 days">
+                    <div
+                      v-for="(day, index) in usageDays"
+                      :key="day.date"
+                      class="group relative flex h-full min-w-0 flex-1 items-end justify-center focus:outline-none"
+                      role="listitem"
+                      :aria-label="getUsageDayLabel(day)"
+                      :tabindex="day.count > 0 ? 0 : undefined"
+                      :title="getUsageDayLabel(day)"
+                    >
+                      <div
+                        v-if="day.count > 0"
+                        class="w-full max-w-3 rounded-t-[3px] bg-brand-500 transition-colors group-hover:bg-brand-600 group-focus-visible:ring-2 group-focus-visible:ring-brand-500 group-focus-visible:ring-offset-2 dark:bg-brand-400 dark:group-hover:bg-brand-300 dark:group-focus-visible:ring-offset-surface-900"
+                        :style="{ height: `${getUsageBarHeight(day.count, runsAxisMax)}%` }"
+                      />
+                      <div
+                        v-if="day.count > 0"
+                        class="pointer-events-none absolute top-2 z-20 opacity-0 transition-opacity group-hover:opacity-100 group-focus:opacity-100"
+                        :class="getUsageTooltipPosition(index)"
+                      >
+                        <div class="whitespace-nowrap rounded-lg border border-surface-200 bg-white px-2.5 py-2 text-[11px] shadow-lg dark:border-surface-700 dark:bg-surface-800">
+                          <p class="font-semibold text-surface-800 dark:text-surface-200">{{ formatUsageDate(day.date) }}</p>
+                          <p class="mt-0.5 text-surface-500 dark:text-surface-400">{{ day.count }} run{{ day.count === 1 ? '' : 's' }}</p>
+                          <p class="text-surface-400 dark:text-surface-500">{{ formatNumber(getDayTokenTotal(day)) }} tokens</p>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div class="flex items-center justify-between mt-1.5">
-              <div class="flex items-center gap-3 text-[10px] text-surface-400">
-                <span class="flex items-center gap-1"><span class="inline-block size-2 rounded-sm bg-violet-500 dark:bg-violet-400" /> Prompt</span>
-                <span class="flex items-center gap-1"><span class="inline-block size-2 rounded-sm bg-amber-400 dark:bg-amber-300" /> Completion</span>
-              </div>
-              <div class="flex gap-4 text-[10px] text-surface-400">
+              <div class="ml-12 mt-2 flex justify-between text-[10px] text-surface-400 dark:text-surface-500" aria-hidden="true">
                 <span>{{ chartStartDate }}</span>
+                <span>{{ chartMiddleDate }}</span>
                 <span>{{ chartEndDate }}</span>
               </div>
             </div>
-          </div>
+          </section>
+
+          <section class="p-5 sm:p-6" aria-labelledby="usage-tokens-title">
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <h3 id="usage-tokens-title" class="text-sm font-semibold text-surface-800 dark:text-surface-200">Tokens per day</h3>
+                <div class="mt-1 flex items-center gap-3 text-[10px] text-surface-400 dark:text-surface-500">
+                  <span class="flex items-center gap-1"><span class="size-2 rounded-sm bg-violet-500 dark:bg-violet-400" /> Prompt</span>
+                  <span class="flex items-center gap-1"><span class="size-2 rounded-sm bg-amber-400 dark:bg-amber-300" /> Completion</span>
+                </div>
+              </div>
+              <span class="shrink-0 rounded-full bg-violet-50 px-2.5 py-1 text-[11px] font-medium tabular-nums text-violet-700 dark:bg-violet-950 dark:text-violet-300">
+                {{ promptTokenShare }}% prompt
+              </span>
+            </div>
+
+            <div class="mt-5">
+              <div class="flex h-36 gap-3">
+                <div class="flex w-9 shrink-0 flex-col justify-between py-0.5 text-right text-[10px] tabular-nums text-surface-400 dark:text-surface-500" aria-hidden="true">
+                  <span>{{ formatAxisNumber(tokensAxisMax) }}</span>
+                  <span>{{ formatAxisNumber(tokensAxisMax / 2) }}</span>
+                  <span>0</span>
+                </div>
+                <div class="relative min-w-0 flex-1">
+                  <div class="pointer-events-none absolute inset-0 flex flex-col justify-between py-1" aria-hidden="true">
+                    <span v-for="line in 3" :key="`tokens-grid-${line}`" class="border-t border-dashed border-surface-200 dark:border-surface-800" />
+                  </div>
+                  <p v-if="usageTotals.tokens === 0" class="absolute inset-0 flex items-center justify-center text-xs text-surface-400 dark:text-surface-500">
+                    No tokens used in this window
+                  </p>
+                  <div class="absolute inset-0 flex items-end gap-px pt-1 sm:gap-0.5" role="list" aria-label="Daily AI token usage over the last 30 days">
+                    <div
+                      v-for="(day, index) in usageDays"
+                      :key="`tokens-${day.date}`"
+                      class="group relative flex h-full min-w-0 flex-1 items-end justify-center focus:outline-none"
+                      role="listitem"
+                      :aria-label="getUsageDayLabel(day)"
+                      :tabindex="getDayTokenTotal(day) > 0 ? 0 : undefined"
+                      :title="getUsageDayLabel(day)"
+                    >
+                      <div
+                        v-if="getDayTokenTotal(day) > 0"
+                        class="flex w-full max-w-3 flex-col-reverse overflow-hidden rounded-t-[3px] group-focus-visible:ring-2 group-focus-visible:ring-violet-500 group-focus-visible:ring-offset-2 dark:group-focus-visible:ring-offset-surface-900"
+                        :style="{ height: `${getUsageBarHeight(getDayTokenTotal(day), tokensAxisMax)}%` }"
+                      >
+                        <div class="w-full bg-violet-500 transition-colors group-hover:bg-violet-600 dark:bg-violet-400 dark:group-hover:bg-violet-300" :style="{ height: `${getPromptTokenPercentage(day)}%` }" />
+                        <div class="w-full bg-amber-400 transition-colors group-hover:bg-amber-500 dark:bg-amber-300 dark:group-hover:bg-amber-200" :style="{ height: `${100 - getPromptTokenPercentage(day)}%` }" />
+                      </div>
+                      <div
+                        v-if="getDayTokenTotal(day) > 0"
+                        class="pointer-events-none absolute top-2 z-20 opacity-0 transition-opacity group-hover:opacity-100 group-focus:opacity-100"
+                        :class="getUsageTooltipPosition(index)"
+                      >
+                        <div class="whitespace-nowrap rounded-lg border border-surface-200 bg-white px-2.5 py-2 text-[11px] shadow-lg dark:border-surface-700 dark:bg-surface-800">
+                          <p class="font-semibold text-surface-800 dark:text-surface-200">{{ formatUsageDate(day.date) }}</p>
+                          <p class="mt-0.5 text-violet-600 dark:text-violet-400">Prompt: {{ formatNumber(day.promptTokens) }}</p>
+                          <p class="text-amber-600 dark:text-amber-400">Completion: {{ formatNumber(day.completionTokens) }}</p>
+                          <p v-if="pricing.configured" class="mt-1 border-t border-surface-100 pt-1 font-medium text-emerald-600 dark:border-surface-700 dark:text-emerald-400">{{ formatCostPrecise(calcCost(day.promptTokens, day.completionTokens)) }}</p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="ml-12 mt-2 flex justify-between text-[10px] text-surface-400 dark:text-surface-500" aria-hidden="true">
+                <span>{{ chartStartDate }}</span>
+                <span>{{ chartMiddleDate }}</span>
+                <span>{{ chartEndDate }}</span>
+              </div>
+            </div>
+          </section>
         </div>
       </div>
 

--- a/app/pages/dashboard/ai-analysis.vue
+++ b/app/pages/dashboard/ai-analysis.vue
@@ -26,6 +26,8 @@ useSeoMeta({
   robots: 'noindex, nofollow',
 })
 
+const { locale } = useI18n()
+
 const { data: stats, status: fetchStatus, error, refresh } = useFetch('/api/ai-analysis/stats', {
   key: 'ai-analysis-stats',
   headers: useRequestHeaders(['cookie']),
@@ -100,11 +102,11 @@ const peakDailyTokens = computed(() => Math.max(
 ))
 const runsAxisMax = computed(() => getNiceUsageAxisMax(peakDailyRuns.value))
 const tokensAxisMax = computed(() => getNiceUsageAxisMax(peakDailyTokens.value))
-const chartStartDate = computed(() => formatUsageDate(usageDays.value[0]?.date ?? ''))
-const chartMiddleDate = computed(() => formatUsageDate(
+const chartStartDate = computed(() => formatChartDate(usageDays.value[0]?.date ?? ''))
+const chartMiddleDate = computed(() => formatChartDate(
   usageDays.value[Math.floor((usageDays.value.length - 1) / 2)]?.date ?? '',
 ))
-const chartEndDate = computed(() => formatUsageDate(usageDays.value.at(-1)?.date ?? ''))
+const chartEndDate = computed(() => formatChartDate(usageDays.value.at(-1)?.date ?? ''))
 const promptTokenShare = computed(() => {
   if (usageTotals.value.tokens === 0) return 0
   return Math.round((usageTotals.value.promptTokens / usageTotals.value.tokens) * 100)
@@ -119,6 +121,10 @@ function formatNumber(n: number): string {
 function formatAxisNumber(n: number): string {
   if (Number.isInteger(n)) return formatNumber(n)
   return n.toFixed(1).replace(/\.0$/, '')
+}
+
+function formatChartDate(dateKey: string): string {
+  return formatUsageDate(dateKey, locale.value)
 }
 
 function formatCost(cost: number | null): string {
@@ -146,9 +152,9 @@ function getPromptTokenPercentage(day: AiUsageDay): number {
 function getUsageDayLabel(day: AiUsageDay): string {
   const tokens = getDayTokenTotal(day)
   if (day.count === 0 && tokens === 0) {
-    return `${formatUsageDate(day.date)}: no usage`
+    return `${formatChartDate(day.date)}: no usage`
   }
-  return `${formatUsageDate(day.date)}: ${day.count} run${day.count === 1 ? '' : 's'}, ${formatNumber(tokens)} tokens`
+  return `${formatChartDate(day.date)}: ${day.count} run${day.count === 1 ? '' : 's'}, ${formatNumber(tokens)} tokens`
 }
 
 function getUsageTooltipPosition(index: number): string {
@@ -368,7 +374,7 @@ function formatDateTime(dateStr: string | Date): string {
                         :class="getUsageTooltipPosition(index)"
                       >
                         <div class="whitespace-nowrap rounded-lg border border-surface-200 bg-white px-2.5 py-2 text-[11px] shadow-lg dark:border-surface-700 dark:bg-surface-800">
-                          <p class="font-semibold text-surface-800 dark:text-surface-200">{{ formatUsageDate(day.date) }}</p>
+                          <p class="font-semibold text-surface-800 dark:text-surface-200">{{ formatChartDate(day.date) }}</p>
                           <p class="mt-0.5 text-surface-500 dark:text-surface-400">{{ day.count }} run{{ day.count === 1 ? '' : 's' }}</p>
                           <p class="text-surface-400 dark:text-surface-500">{{ formatNumber(getDayTokenTotal(day)) }} tokens</p>
                         </div>
@@ -437,7 +443,7 @@ function formatDateTime(dateStr: string | Date): string {
                         :class="getUsageTooltipPosition(index)"
                       >
                         <div class="whitespace-nowrap rounded-lg border border-surface-200 bg-white px-2.5 py-2 text-[11px] shadow-lg dark:border-surface-700 dark:bg-surface-800">
-                          <p class="font-semibold text-surface-800 dark:text-surface-200">{{ formatUsageDate(day.date) }}</p>
+                          <p class="font-semibold text-surface-800 dark:text-surface-200">{{ formatChartDate(day.date) }}</p>
                           <p class="mt-0.5 text-violet-600 dark:text-violet-400">Prompt: {{ formatNumber(day.promptTokens) }}</p>
                           <p class="text-amber-600 dark:text-amber-400">Completion: {{ formatNumber(day.completionTokens) }}</p>
                           <p v-if="pricing.configured" class="mt-1 border-t border-surface-100 pt-1 font-medium text-emerald-600 dark:border-surface-700 dark:text-emerald-400">{{ formatCostPrecise(calcCost(day.promptTokens, day.completionTokens)) }}</p>

--- a/app/pages/dashboard/ai-analysis.vue
+++ b/app/pages/dashboard/ai-analysis.vue
@@ -68,12 +68,17 @@ const totalCost = computed(() => calcCost(summary.value.totalPromptTokens, summa
 
 // Keep sparse API rows sparse at the contract boundary, then normalize the
 // presentation to a real rolling calendar window for predictable chart sizing.
-const usageWindowEnd = new Date()
-usageWindowEnd.setHours(12, 0, 0, 0)
+const fallbackUsageWindowEndDate = useState(
+  'ai-usage-window-end-date',
+  () => new Date().toISOString().slice(0, 10),
+)
+const usageWindowEndDate = computed(() =>
+  stats.value?.usagePeriod.endDate ?? fallbackUsageWindowEndDate.value,
+)
 
 const usageDays = computed(() => buildAiUsageSeries(
   dailyRuns.value as AiUsageDay[],
-  { endDate: usageWindowEnd },
+  { endDateKey: usageWindowEndDate.value },
 ))
 
 const usageTotals = computed(() => usageDays.value.reduce((totals, day) => ({
@@ -321,7 +326,7 @@ function formatDateTime(dateStr: string | Date): string {
             <div class="flex items-start justify-between gap-4">
               <div>
                 <h3 id="usage-runs-title" class="text-sm font-semibold text-surface-800 dark:text-surface-200">Runs per day</h3>
-                <p class="mt-0.5 text-xs text-surface-500 dark:text-surface-400">Completed and failed scoring runs</p>
+                <p class="mt-0.5 text-xs text-surface-500 dark:text-surface-400">Completed, failed, and partial scoring runs</p>
               </div>
               <span class="shrink-0 rounded-full bg-brand-50 px-2.5 py-1 text-[11px] font-medium tabular-nums text-brand-700 dark:bg-brand-950 dark:text-brand-300">
                 Peak {{ formatNumber(peakDailyRuns) }}

--- a/app/utils/ai-usage-chart.ts
+++ b/app/utils/ai-usage-chart.ts
@@ -1,0 +1,95 @@
+export const AI_USAGE_WINDOW_DAYS = 30
+
+export interface AiUsageDay {
+  date: string
+  count: number
+  promptTokens: number
+  completionTokens: number
+}
+
+interface BuildAiUsageSeriesOptions {
+  endDate?: Date
+  days?: number
+}
+
+function toLocalDateKey(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function parseDateKey(dateKey: string): Date {
+  const year = Number(dateKey.slice(0, 4))
+  const month = Number(dateKey.slice(5, 7))
+  const day = Number(dateKey.slice(8, 10))
+  return new Date(year, month - 1, day, 12)
+}
+
+export function buildAiUsageSeries(
+  source: AiUsageDay[],
+  options: BuildAiUsageSeriesOptions = {},
+): AiUsageDay[] {
+  const requestedDays = options.days ?? AI_USAGE_WINDOW_DAYS
+  const days = Number.isInteger(requestedDays) && requestedDays > 0
+    ? requestedDays
+    : AI_USAGE_WINDOW_DAYS
+  const endDate = new Date(options.endDate ?? Date.now())
+  endDate.setHours(12, 0, 0, 0)
+
+  const valuesByDate = new Map<string, AiUsageDay>()
+  for (const row of source) {
+    const date = row.date.slice(0, 10)
+    const existing = valuesByDate.get(date)
+    valuesByDate.set(date, {
+      date,
+      count: (existing?.count ?? 0) + row.count,
+      promptTokens: (existing?.promptTokens ?? 0) + row.promptTokens,
+      completionTokens: (existing?.completionTokens ?? 0) + row.completionTokens,
+    })
+  }
+
+  const startDate = new Date(endDate)
+  startDate.setDate(startDate.getDate() - (days - 1))
+
+  return Array.from({ length: days }, (_, index) => {
+    const date = new Date(startDate)
+    date.setDate(startDate.getDate() + index)
+    const dateKey = toLocalDateKey(date)
+    return valuesByDate.get(dateKey) ?? {
+      date: dateKey,
+      count: 0,
+      promptTokens: 0,
+      completionTokens: 0,
+    }
+  })
+}
+
+export function formatUsageDate(dateKey: string, locale?: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    month: 'short',
+    day: 'numeric',
+  }).format(parseDateKey(dateKey))
+}
+
+export function getNiceUsageAxisMax(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 1
+  if (value <= 1) return 2
+
+  const magnitude = 10 ** Math.floor(Math.log10(value))
+  const normalized = value / magnitude
+  const niceNormalized = normalized <= 1
+    ? 1
+    : normalized <= 2
+      ? 2
+      : normalized <= 5
+        ? 5
+        : 10
+
+  return niceNormalized * magnitude
+}
+
+export function getUsageBarHeight(value: number, axisMax: number): number {
+  if (!Number.isFinite(value) || value <= 0 || axisMax <= 0) return 0
+  return Math.min(100, Math.max(4, (value / axisMax) * 100))
+}

--- a/app/utils/ai-usage-chart.ts
+++ b/app/utils/ai-usage-chart.ts
@@ -9,6 +9,7 @@ export interface AiUsageDay {
 
 interface BuildAiUsageSeriesOptions {
   endDate?: Date
+  endDateKey?: string
   days?: number
 }
 
@@ -34,7 +35,9 @@ export function buildAiUsageSeries(
   const days = Number.isInteger(requestedDays) && requestedDays > 0
     ? requestedDays
     : AI_USAGE_WINDOW_DAYS
-  const endDate = new Date(options.endDate ?? Date.now())
+  const endDate = options.endDateKey
+    ? parseDateKey(options.endDateKey.slice(0, 10))
+    : new Date(options.endDate ?? Date.now())
   endDate.setHours(12, 0, 0, 0)
 
   const valuesByDate = new Map<string, AiUsageDay>()

--- a/server/api/ai-analysis/stats.get.ts
+++ b/server/api/ai-analysis/stats.get.ts
@@ -14,10 +14,6 @@ export default defineEventHandler(async (event) => {
   const session = await requirePermission(event, { scoring: ['read'] })
   const orgId = session.session.activeOrganizationId
 
-  const thirtyDaysAgo = new Date()
-  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
-  const thirtyDaysAgoISO = thirtyDaysAgo.toISOString()
-
   // Fetch pricing from ALL configs in the org so historical model breakdown
   // can be priced correctly even if the user has multiple configurations.
   const pricingConfigs = await db.query.aiConfig.findMany({
@@ -48,6 +44,7 @@ export default defineEventHandler(async (event) => {
     dailyRuns,
     recentRuns,
     modelBreakdown,
+    usagePeriodRows,
   ] = await Promise.all([
     // 1. Total runs
     db.$count(analysisRun, eq(analysisRun.organizationId, orgId)),
@@ -78,7 +75,7 @@ export default defineEventHandler(async (event) => {
       .from(analysisRun)
       .where(and(
         eq(analysisRun.organizationId, orgId),
-        sql`${analysisRun.createdAt} >= ${thirtyDaysAgoISO}`,
+        sql`${analysisRun.createdAt} >= CURRENT_DATE - INTERVAL '29 days'`,
       ))
       .groupBy(sql`DATE(${analysisRun.createdAt})`)
       .orderBy(sql`DATE(${analysisRun.createdAt})`),
@@ -118,14 +115,34 @@ export default defineEventHandler(async (event) => {
       .from(analysisRun)
       .where(eq(analysisRun.organizationId, orgId))
       .groupBy(analysisRun.provider, analysisRun.model),
+
+    // 8. Database-aligned calendar period used by the chart. Returning date
+    // keys avoids SSR/browser timezone drift during hydration.
+    db.execute<{ start_date: string, end_date: string }>(sql`
+      SELECT
+        TO_CHAR(CURRENT_DATE - INTERVAL '29 days', 'YYYY-MM-DD') AS start_date,
+        TO_CHAR(CURRENT_DATE, 'YYYY-MM-DD') AS end_date
+    `),
   ])
 
   const usage = tokenUsage[0]
+  const usagePeriod = usagePeriodRows[0]
+
+  if (!usagePeriod) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Unable to determine AI usage period',
+    })
+  }
 
   const inputPrice = defaultAnalysisConfig?.inputPricePer1m != null ? Number(defaultAnalysisConfig.inputPricePer1m) : null
   const outputPrice = defaultAnalysisConfig?.outputPricePer1m != null ? Number(defaultAnalysisConfig.outputPricePer1m) : null
 
   return {
+    usagePeriod: {
+      startDate: usagePeriod.start_date,
+      endDate: usagePeriod.end_date,
+    },
     pricing: {
       inputPricePer1m: inputPrice,
       outputPricePer1m: outputPrice,

--- a/tests/unit/ai-analysis-stats.test.ts
+++ b/tests/unit/ai-analysis-stats.test.ts
@@ -1,24 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, it, expect } from 'vitest'
 
-/**
- * Regression test for the ai-analysis stats endpoint.
- * The postgres.js driver cannot serialise a raw Date object
- * inside Drizzle's `sql` template literals – it must receive
- * an ISO-8601 string instead.
- *
- * This test validates the serialisation logic that is used in
- * server/api/ai-analysis/stats.get.ts to build the 30-day filter.
- */
-describe('ai-analysis stats date parameter', () => {
-  it('toISOString() produces a string the postgres driver can accept', () => {
-    const thirtyDaysAgo = new Date()
-    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
-    const iso = thirtyDaysAgo.toISOString()
+describe('ai-analysis stats usage period', () => {
+  it('returns a database-aligned calendar window for hydration-stable charts', () => {
+    const route = readFileSync(
+      join(process.cwd(), 'server/api/ai-analysis/stats.get.ts'),
+      'utf8',
+    )
 
-    expect(typeof iso).toBe('string')
-    // Must be a valid ISO-8601 timestamp
-    expect(iso).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
-    // Re-parsing should yield the same instant
-    expect(new Date(iso).getTime()).toBe(thirtyDaysAgo.getTime())
+    expect(route).toContain('usagePeriod')
+    expect(route).toContain('CURRENT_DATE')
+    expect(route).toContain("INTERVAL '29 days'")
   })
 })

--- a/tests/unit/ai-usage-chart.test.ts
+++ b/tests/unit/ai-usage-chart.test.ts
@@ -62,7 +62,12 @@ describe('AI usage chart defaults', () => {
       expect(serverSeries.at(-1)?.date).toBe('2031-01-02')
     }
     finally {
-      process.env.TZ = previousTimeZone
+      if (previousTimeZone === undefined) {
+        delete process.env.TZ
+      }
+      else {
+        process.env.TZ = previousTimeZone
+      }
     }
   })
 
@@ -89,6 +94,8 @@ describe('AI usage chart defaults', () => {
     expect(page).toContain('usageDays')
     expect(page).toContain('stats.value?.usagePeriod.endDate')
     expect(page).not.toContain('const usageWindowEnd = new Date()')
+    expect(page).toContain('const { locale } = useI18n()')
+    expect(page).toContain('return formatUsageDate(dateKey, locale.value)')
     expect(page).not.toContain('v-for="day in dailyRuns"')
   })
 

--- a/tests/unit/ai-usage-chart.test.ts
+++ b/tests/unit/ai-usage-chart.test.ts
@@ -48,6 +48,24 @@ describe('AI usage chart defaults', () => {
     expect(formatUsageDate('2026-07-01', 'en-US')).toBe('Jul 1')
   })
 
+  it('keeps an API-provided window end stable across server and browser time zones', () => {
+    const previousTimeZone = process.env.TZ
+
+    try {
+      process.env.TZ = 'UTC'
+      const serverSeries = buildAiUsageSeries([], { endDateKey: '2031-01-02' })
+
+      process.env.TZ = 'America/New_York'
+      const browserSeries = buildAiUsageSeries([], { endDateKey: '2031-01-02' })
+
+      expect(serverSeries).toEqual(browserSeries)
+      expect(serverSeries.at(-1)?.date).toBe('2031-01-02')
+    }
+    finally {
+      process.env.TZ = previousTimeZone
+    }
+  })
+
   it('uses readable axis ceilings and keeps zero-value bars at zero height', () => {
     expect(getNiceUsageAxisMax(0)).toBe(1)
     expect(getNiceUsageAxisMax(1)).toBe(2)
@@ -69,6 +87,18 @@ describe('AI usage chart defaults', () => {
 
     expect(page).toContain('buildAiUsageSeries')
     expect(page).toContain('usageDays')
+    expect(page).toContain('stats.value?.usagePeriod.endDate')
+    expect(page).not.toContain('const usageWindowEnd = new Date()')
     expect(page).not.toContain('v-for="day in dailyRuns"')
+  })
+
+  it('describes every scoring status included in daily run counts', () => {
+    const page = readFileSync(
+      join(process.cwd(), 'app/pages/dashboard/ai-analysis.vue'),
+      'utf8',
+    )
+
+    expect(page).toContain('Completed, failed, and partial scoring runs')
+    expect(page).not.toContain('Completed and failed scoring runs')
   })
 })

--- a/tests/unit/ai-usage-chart.test.ts
+++ b/tests/unit/ai-usage-chart.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  AI_USAGE_WINDOW_DAYS,
+  buildAiUsageSeries,
+  formatUsageDate,
+  getNiceUsageAxisMax,
+  getUsageBarHeight,
+} from '../../app/utils/ai-usage-chart'
+
+describe('AI usage chart defaults', () => {
+  it('builds a rolling 30-day series and fills quiet days with zero values', () => {
+    const source = [
+      { date: '2026-06-16', count: 9, promptTokens: 900, completionTokens: 90 },
+      { date: '2026-07-14', count: 1, promptTokens: 120, completionTokens: 30 },
+      { date: '2026-07-16', count: 3, promptTokens: 450, completionTokens: 100 },
+    ]
+
+    const series = buildAiUsageSeries(source, {
+      endDate: new Date(2026, 6, 16, 12),
+    })
+
+    expect(AI_USAGE_WINDOW_DAYS).toBe(30)
+    expect(series).toHaveLength(30)
+    expect(series[0]).toEqual({
+      date: '2026-06-17',
+      count: 0,
+      promptTokens: 0,
+      completionTokens: 0,
+    })
+    expect(series.at(-1)?.date).toBe('2026-07-16')
+    expect(series.find(day => day.date === '2026-07-14')).toMatchObject({
+      count: 1,
+      promptTokens: 120,
+      completionTokens: 30,
+    })
+    expect(series.find(day => day.date === '2026-07-15')).toMatchObject({
+      count: 0,
+      promptTokens: 0,
+      completionTokens: 0,
+    })
+    expect(series.some(day => day.date === '2026-06-16')).toBe(false)
+    expect(source).toHaveLength(3)
+  })
+
+  it('formats date-only values without shifting them across time zones', () => {
+    expect(formatUsageDate('2026-07-01', 'en-US')).toBe('Jul 1')
+  })
+
+  it('uses readable axis ceilings and keeps zero-value bars at zero height', () => {
+    expect(getNiceUsageAxisMax(0)).toBe(1)
+    expect(getNiceUsageAxisMax(1)).toBe(2)
+    expect(getNiceUsageAxisMax(3)).toBe(5)
+    expect(getNiceUsageAxisMax(1260)).toBe(2000)
+
+    expect(getUsageBarHeight(0, 5)).toBe(0)
+    expect(getUsageBarHeight(-1, 5)).toBe(0)
+    expect(getUsageBarHeight(0.01, 5)).toBe(4)
+    expect(getUsageBarHeight(2.5, 5)).toBe(50)
+    expect(getUsageBarHeight(9, 5)).toBe(100)
+  })
+
+  it('renders the normalized series instead of stretching sparse API rows', () => {
+    const page = readFileSync(
+      join(process.cwd(), 'app/pages/dashboard/ai-analysis.vue'),
+      'utf8',
+    )
+
+    expect(page).toContain('buildAiUsageSeries')
+    expect(page).toContain('usageDays')
+    expect(page).not.toContain('v-for="day in dailyRuns"')
+  })
+})

--- a/tests/unit/cli-dashboard-commands.test.ts
+++ b/tests/unit/cli-dashboard-commands.test.ts
@@ -120,7 +120,11 @@ describe('CLI dashboard commands', () => {
       }
       if (url === 'https://careers.example.com/api/ai-analysis/stats') {
         expect(init?.method).toBe('GET')
-        return Response.json({ summary: { totalRuns: 4 }, dailyRuns: [] })
+        return Response.json({
+          usagePeriod: { startDate: '2026-06-17', endDate: '2026-07-16' },
+          summary: { totalRuns: 4 },
+          dailyRuns: [],
+        })
       }
       throw new Error(`Unexpected URL ${url}`)
     })
@@ -139,6 +143,10 @@ describe('CLI dashboard commands', () => {
     expect(candidateExit).toBe(0)
     expect(aiExit).toBe(0)
     expect(JSON.parse(candidateOut[0])).toEqual({ items: [], candidateId: 'cand_1', candidateName: 'Ada Lovelace' })
-    expect(JSON.parse(aiOut[0])).toEqual({ summary: { totalRuns: 4 }, dailyRuns: [] })
+    expect(JSON.parse(aiOut[0])).toEqual({
+      usagePeriod: { startDate: '2026-06-17', endDate: '2026-07-16' },
+      summary: { totalRuns: 4 },
+      dailyRuns: [],
+    })
   })
 })


### PR DESCRIPTION
## Summary

- render AI usage as a true rolling 30-day series, including zero-usage days
- add readable axes, period totals, peaks, token mix, and responsive side-by-side charts
- add keyboard-focusable daily details and regression coverage for chart defaults

## Validation run

- `npm run preflight:pr`
- authenticated Safari desktop QA on the AI Analysis dashboard
- Safari responsive QA at 390 x 844
- `git diff --check`

## Known risks or skipped checks

- No known risks. The existing Nuxt/Volar warnings remain unchanged.

## Release/version notes

- Added an Unreleased changelog entry.
- No changeset is needed for this application-only fix.

<!-- openclaw-review-loop:
channel=codex
agent=codex
sessionKey=
providerThreadId=
origin=external-ui
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI usage charts now accurately display a rolling 30-day window.
  * Days without activity are shown clearly, with improved scales and more readable bars.
  * Charts now include total runs and token usage for the selected period.
  * Daily usage details are available through improved tooltips and accessible interactions.
  * Token breakdowns and available daily cost information are displayed more clearly.
  * Empty periods now provide clearer messaging when no runs or tokens are recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->