### PR TITLE
fix: remove verbose pipeline search helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ self-hosters.
 
 ### Fixed
 
+- Removed the verbose search-scope helper from the job pipeline.
 - Pinned recruiter-search database functions to trusted schemas, protected device authorization with row-level security, and indexed durable-processing relationships used during cleanup.
 - Protected internal recruiter-search and durable-processing tables with the same server-role-only row-level security boundary used by existing production data.
 - Kept large job pipelines stable with bounded server pagination, accurate filtered stage counts, identity-safe selection, and application-scoped interview history.

--- a/app/pages/dashboard/jobs/[id]/index.vue
+++ b/app/pages/dashboard/jobs/[id]/index.vue
@@ -1056,9 +1056,6 @@ function closeDocPreview() {
           >
             {{ applicationTotal }} match{{ applicationTotal === 1 ? '' : 'es' }}
           </span>
-          <span class="hidden shrink-0 text-[10px] text-surface-400 dark:text-surface-500 xl:inline">
-            Searches profiles, resumes, answers, properties, interviews, comments, sources, and AI evidence
-          </span>
         </div>
       </div>
 

--- a/tests/unit/application-content-search.test.ts
+++ b/tests/unit/application-content-search.test.ts
@@ -84,6 +84,7 @@ describe('application content search', () => {
     expect(page).toContain('search: debouncedApplicationSearch')
     expect(page).toContain('placeholder="Filter by name or email…"')
     expect(page).toContain('Type 3+ characters')
+    expect(page).not.toContain('Searches profiles, resumes, answers, properties, interviews, comments, sources, and AI evidence')
     expect(page).not.toContain('v-model="searchTerm"')
   })
 })


### PR DESCRIPTION
## Summary

- Removes the verbose search-scope helper beside the job pipeline search field.
- Adds a regression assertion preventing the helper copy from returning.
- Records the user-visible cleanup in the Unreleased changelog.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Validation

- [x] `npm run preflight:pr`
- [x] 1,565 unit tests passed; 4 skipped
- [x] Lint, typecheck, CLI smoke tests, production environment contract, and production build passed
- [x] `git diff --check`

## Known risks or skipped checks

- Browser QA was not run because this removes static helper copy without changing controls, layout behavior, data flow, auth, or tenant scoping.
- Existing Nuxt/Vue warnings remain unchanged.

## Release/version notes

- [x] This is not a release PR.
- [x] `CHANGELOG.md` was updated under Unreleased.
- No changeset is required.

## CLI parity

- No API, shared contract, authentication, or CLI coverage changes.

## Keyboard / accessibility acceptance

- No interactive controls or keyboard behavior changed.

## DCO

- Agent-generated commit created with the repository-required `--no-verify` workflow; no human-authored commit was added.

<!-- openclaw-review-loop:
channel=codex
agent=codex
sessionKey=
providerThreadId=
origin=external-ui
-->
