### PR TITLE
fix: enforce audited migration baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ self-hosters.
 
 - Kept the job sub-navigation to one Add, status, and actions control set while moving between Pipeline, Table, Application, AI, and Settings.
 - Updated the pinned Nano ID, DOMPurify, and tar transitive dependencies to resolve current security advisories.
-- Made production startup apply every bundled database migration with a dedicated DDL role, verify the audited migration-ledger lineage and modeled schema, and fail readiness before serving traffic when either check drifts.
+- Established migration 0059 as the audited production-ledger baseline while retaining full modeled-schema verification for inherited migrations that predate complete ledger tracking.
+- Made production startup apply every bundled database migration with a dedicated DDL role, verify the migration ledger and modeled schema, and fail readiness before serving traffic when either check drifts.
 - Routed provider-ID Microsoft sign-in through the server-owned SSO entry point so operator-configured provider changes cannot leave the admin login button on a stale hardcoded slug, and preserved invitation or redirect context when SSO startup fails.
 - Added rollback-safe SSO client-secret storage across mixed application versions and proactive Microsoft credential monitoring with expiry and incident alerts.
 - Encrypted organization OIDC client secrets at rest, backfilled existing providers safely, and kept SSO registration, discovery, and callbacks transparent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ self-hosters.
 
 - Kept the job sub-navigation to one Add, status, and actions control set while moving between Pipeline, Table, Application, AI, and Settings.
 - Updated the pinned Nano ID, DOMPurify, and tar transitive dependencies to resolve current security advisories.
-- Made production startup apply every bundled database migration with a dedicated DDL role, verify the migration ledger and modeled schema, and fail readiness before serving traffic when either check drifts.
+- Made production startup apply every bundled database migration with a dedicated DDL role, verify the audited migration-ledger lineage and modeled schema, and fail readiness before serving traffic when either check drifts.
 - Routed provider-ID Microsoft sign-in through the server-owned SSO entry point so operator-configured provider changes cannot leave the admin login button on a stale hardcoded slug, and preserved invitation or redirect context when SSO startup fails.
 - Added rollback-safe SSO client-secret storage across mixed application versions and proactive Microsoft credential monitoring with expiry and incident alerts.
 - Encrypted organization OIDC client secrets at rest, backfilled existing providers safely, and kept SSO registration, discovery, and callbacks transparent.

--- a/docs/operations/PRODUCTION-RUNBOOK.md
+++ b/docs/operations/PRODUCTION-RUNBOOK.md
@@ -45,8 +45,8 @@ keep `SKIP_RUNTIME_MIGRATIONS=false`; startup rejects a skipped migration gate.
 Before readiness succeeds, one reserved database session takes the advisory
 lock, applies every bundled migration, and verifies both of these conditions:
 
-- Every bundled migration timestamp and hash exists in
-  `drizzle.__drizzle_migrations`.
+- Every bundled migration timestamp and hash from the audited migration 0059
+  reconciliation baseline forward exists in `drizzle.__drizzle_migrations`.
 - Every table and column in the Drizzle runtime model exists in the live
   `public` schema.
 
@@ -54,6 +54,13 @@ Any migration, ledger, permission, or schema mismatch fails the new deploy.
 Render must keep the last healthy deploy serving until the database gate passes.
 Do not bypass readiness or point `DATABASE_MIGRATION_URL` at the application
 role.
+
+The inherited database predates complete Drizzle ledger tracking and contains
+edited historical migration hashes. Migration 0059 establishes the audited
+ledger baseline after those legacy entries. The modeled-schema inventory covers
+the inherited tables and columns; the bidirectional timestamp-and-hash gate
+covers every migration from 0059 forward. Do not move the baseline or add a
+manual ledger entry without verifying the exact committed SQL outcome first.
 
 For an incident, preserve the failed deploy logs and run the repository
 migrator with the concealed migration-role URL:

--- a/docs/operations/incidents/2026-08-14-public-application-migration-drift.md
+++ b/docs/operations/incidents/2026-08-14-public-application-migration-drift.md
@@ -39,8 +39,9 @@ or file body. Affected applicants must submit the form again.
 - Production requires a distinct `DATABASE_MIGRATION_URL` and rejects skipped
   runtime migrations.
 - Startup serializes migration work with an advisory lock.
-- Startup compares every bundled migration timestamp and hash with the Drizzle
-  migration ledger.
+- Startup compares every bundled migration timestamp and hash from the audited
+  migration 0059 reconciliation baseline forward with the Drizzle migration
+  ledger in both directions.
 - Startup compares every modeled table and column with the live public schema.
 - Readiness remains failed until migration, ledger, schema, and SSO storage
   checks all pass.

--- a/server/plugins/migrations.ts
+++ b/server/plugins/migrations.ts
@@ -19,6 +19,11 @@ import {
 } from '../utils/ssoReadiness'
 
 const MIGRATION_LOCK_ID = 123456789
+// Production's historical ledger begins partway through the inherited migration
+// journal and includes edited legacy hashes. Migration 0059 is the audited
+// reconciliation baseline; every migration from this timestamp forward must
+// match the deployed bundle in both directions.
+const MIGRATION_LEDGER_ENFORCEMENT_TIMESTAMP = 1784228400000
 
 interface MigrationExecutionInput {
   nodeEnv: string
@@ -90,11 +95,14 @@ interface AppliedMigration {
 export function findMigrationLedgerDrift(
   expected: ExpectedMigration[],
   actual: AppliedMigration[],
+  enforcementTimestamp = 0,
 ): string[] {
-  const appliedByTimestamp = new Map(actual.map(migration => [migration.createdAt, migration.hash]))
+  const enforcedExpected = expected.filter(migration => migration.folderMillis >= enforcementTimestamp)
+  const enforcedActual = actual.filter(migration => Number(migration.createdAt) >= enforcementTimestamp)
+  const appliedByTimestamp = new Map(enforcedActual.map(migration => [migration.createdAt, migration.hash]))
   const drift: string[] = []
 
-  for (const migration of expected) {
+  for (const migration of enforcedExpected) {
     const timestamp = String(migration.folderMillis)
     const appliedHash = appliedByTimestamp.get(timestamp)
     if (appliedHash === undefined) {
@@ -105,8 +113,8 @@ export function findMigrationLedgerDrift(
     }
   }
 
-  const expectedTimestamps = new Set(expected.map(migration => String(migration.folderMillis)))
-  for (const migration of actual) {
+  const expectedTimestamps = new Set(enforcedExpected.map(migration => String(migration.folderMillis)))
+  for (const migration of enforcedActual) {
     if (!expectedTimestamps.has(migration.createdAt)) {
       drift.push(`${migration.createdAt}:unexpected`)
     }
@@ -175,6 +183,7 @@ async function assertMigrationLedgerMatchesBundle(client: postgres.Sql): Promise
   const drift = findMigrationLedgerDrift(
     expected,
     rows.map(row => ({ createdAt: row.created_at, hash: row.hash })),
+    MIGRATION_LEDGER_ENFORCEMENT_TIMESTAMP,
   )
 
   if (drift.length > 0) {

--- a/tests/unit/migration-locking.test.ts
+++ b/tests/unit/migration-locking.test.ts
@@ -116,6 +116,27 @@ describe('runtime migration locking', () => {
     ])
   })
 
+  it('enforces the audited ledger baseline without rejecting legacy untracked migrations', async () => {
+    const migrationModule = await import('../../server/plugins/migrations') as Record<string, unknown>
+    const findMigrationLedgerDrift = migrationModule.findMigrationLedgerDrift as undefined | ((
+      expected: Array<{ folderMillis: number, hash: string }>,
+      actual: Array<{ createdAt: string, hash: string }>,
+      enforcementTimestamp: number,
+    ) => string[])
+
+    expect(findMigrationLedgerDrift?.(
+      [
+        { folderMillis: 100, hash: 'legacy-bundle-hash' },
+        { folderMillis: 200, hash: 'audited-hash' },
+      ],
+      [
+        { createdAt: '150', hash: 'legacy-ledger-hash' },
+        { createdAt: '200', hash: 'audited-hash' },
+      ],
+      200,
+    )).toEqual([])
+  })
+
   it('reports migration completion accurately when a non-production bootstrap skips SQL', async () => {
     const migrationModule = await import('../../server/plugins/migrations') as Record<string, unknown>
     const migrationCompletionSummary = migrationModule.migrationCompletionSummary as undefined | ((


### PR DESCRIPTION
## Summary
- enforce bidirectional migration-ledger hashes from the audited 0059 reconciliation baseline forward
- preserve modeled table and column verification across the full inherited schema
- document the legacy ledger boundary and the exact verification rule

## Validation run
- `nvm exec 22.22.0 npm run test:unit` (1,880 passed; 7 skipped)
- `nvm exec 22.22.0 npm run lint`
- `nvm exec 22.22.0 npm run build`
- production migrations 0059-0063 applied or structurally verified in one transaction and their exact committed hashes reconciled

## Known risks or skipped checks
- Historical migrations before 0059 predate complete ledger tracking and include edited hashes; full modeled-schema verification remains active for that inherited range.

## Release/version notes
- No changeset is required; the operator-visible behavior is recorded under Changelog Unreleased.

<!-- openclaw-review-loop:
channel=codex
agent=codex
sessionKey=
providerThreadId=
origin=external-ui
-->