### PR TITLE
fix: restore Factory logo in alert emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ self-hosters.
 
 ### Fixed
 
+- Loaded the Factory logo in operational alert emails from the first-party careers site instead of the retired external asset host.
 - Kept production storage readiness and encrypted intake buffering compatible with the private applicant-document bucket MIME policy.
 - Suppressed all candidate and internal notifications for authenticated synthetic applications and removed their database, queue, and storage artifacts after each probe.
 - Kept public job listings current within 60 seconds, disabled application-page caching, and made posted dates identical during server rendering and hydration.

--- a/server/lib/email/theme.ts
+++ b/server/lib/email/theme.ts
@@ -12,8 +12,7 @@ export const careersEmailConfig = {
   address: "5431 W 104th St, Los Angeles, CA 90045",
   accentColor: "#FF4426",
   siteUrl: "https://careers.thefactoryhq.com",
-  logoUrl:
-    "https://nypetlcjkgntmkebnxbx.supabase.co/storage/v1/object/public/public-assets/factory-logo.png",
+  logoUrl: "https://careers.thefactoryhq.com/factory-logo.png",
   logoMode: "full" as const,
   logoAlign: "left" as const,
   unsubscribeSecret: env.UNSUBSCRIBE_SECRET || "factory-careers-unsub-secret",

--- a/tests/unit/application-email-branding.test.ts
+++ b/tests/unit/application-email-branding.test.ts
@@ -95,5 +95,9 @@ describe("application receipt email branding", () => {
 		const html = await render(payload.react);
 		expect(html).toContain("invalid_client");
 		expect(html).toContain("2026-08-10T12:00:00.000Z");
+		expect(html).toContain(
+			'src="https://careers.thefactoryhq.com/factory-logo.png"',
+		);
+		expect(html).toContain('alt="Factory Careers"');
 	});
 });


### PR DESCRIPTION
## Summary
- serve the shared Factory email logo from the first-party careers domain
- verify operational-alert HTML includes the accessible Factory logo
- record the operator-visible fix in the changelog

## Validation run
- `npm run test:unit` (1,940 passed; 7 skipped)
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- full pre-push PR preflight
- live logo asset returns HTTP 200 as `image/png`

## Known risks or skipped checks
- Existing Nuxt/Volar and optional canvas warnings remain unchanged.
- No live alert was intentionally generated.

## Release/version notes
- Changelog entry added. No changeset is used by this repository.

<!-- openclaw-review-loop:
channel=codex
agent=codex
sessionKey=
providerThreadId=
origin=external-ui
-->