### PR TITLE
docs: add development knowledge writeback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,16 @@ parity guard wiring, merge-conflict hygiene, theme rules, and agent-facing docs.
 This is a focused rules bundle, not a replacement for typecheck, build, e2e, or
 runtime browser checks when behavior changes.
 
+## Factory development knowledge
+
+After a durable change to architecture, deployment, CI, infrastructure,
+repository relationships, lifecycle, or operating procedures, update the
+repository changelog and capture the operating meaning with
+`work --org factory knowledge capture`. Link
+`[[sources/topics/development-hub|Factory development]]` and current evidence.
+Skip ordinary patches. Keep credentials, private data, and detailed threat
+information out of general development pages.
+
 ## Changelog Maintenance
 
 Treat the in-product changelog as part of the product.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ self-hosters.
 
 ### Added
 
+- Added the Factory development-knowledge writeback contract for durable
+  architecture, deployment, CI, infrastructure, lifecycle, and operations work.
 - Added append-only migration enforcement, base-to-branch PostgreSQL upgrade rehearsal, and an exact-commit production deployment gate.
 - Added five-minute public-path monitoring, exact-deploy and daily full application canaries, sanitized incident lifecycle automation, and rate-limited operational alerts.
 - Added AES-256-GCM application intake recovery with seven-day retention, delayed-submission receipts, idempotent owner replay, metadata-only CLI operations, key rotation, and scheduled expiry cleanup.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,16 @@ parity guard wiring, merge-conflict hygiene, theme rules, and agent-facing docs.
 This is a focused rules bundle, not a replacement for typecheck, build, e2e, or
 runtime browser checks when behavior changes.
 
+## Factory development knowledge
+
+After a durable change to architecture, deployment, CI, infrastructure,
+repository relationships, lifecycle, or operating procedures, update the
+repository changelog and capture the operating meaning with
+`work --org factory knowledge capture`. Link
+`[[sources/topics/development-hub|Factory development]]` and current evidence.
+Skip ordinary patches. Keep credentials, private data, and detailed threat
+information out of general development pages.
+
 ## Changelog Maintenance
 
 Treat the in-product changelog as part of the product.


### PR DESCRIPTION
## Summary
- add the durable organization development-knowledge writeback rule
- keep AGENTS.md and CLAUDE.md synchronized
- establish or update the repository changelog source

## Validation run
- Full pre-push validation passed: 1,941 unit tests, lint, typecheck, CLI smoke tests, production environment contract, and production build.

## Known risks or skipped checks
- Docs and changelog only. No runtime behavior changed.

## Release/version notes
- Changelog entry added; no version release required.

<!-- openclaw-review-loop:
channel=codex
agent=codex
sessionKey=
providerThreadId=
origin=external-ui
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Requires agents to write back durable architecture, deployment, CI, infrastructure, lifecycle, and operations changes via `work --org factory knowledge capture`, in addition to the repository changelog.
> 
> The same section is added to both `AGENTS.md` and `CLAUDE.md`. Ordinary patches are skipped, and credentials, private data, and detailed threat information stay out of general development pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f430a510d5b7493b19c4771f6ed876683504b00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->